### PR TITLE
Add oAuthToken to parameters in serialization and unserialization

### DIFF
--- a/Security/Core/Authentication/Token/OAuthToken.php
+++ b/Security/Core/Authentication/Token/OAuthToken.php
@@ -77,4 +77,19 @@ class OAuthToken extends AbstractToken
     {
         $this->resourceOwnerName = $resourceOwnerName;
     }
+
+    public function serialize()
+    {
+        $this->setAttribute('accessToken', $this->accessToken);
+        return parent::serialize();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        parent::unserialize($serialized);
+        $this->accessToken = $this->getAttribute('accessToken');
+    }
 }


### PR DESCRIPTION
Session keeps oAuthToken by serializing and unserializing, but accessToken is not kept. In order to keep it in security context (useful for more api's call on services), it can be useful to keep it, like the user, in the security context.

To do so, adding accessToken to the token parameters (serialized) is a useful trick avoiding to redeclare all token class.
