### PR TITLE
Fixing bad doc-block reference to old class.

### DIFF
--- a/Security/Http/ResourceOwnerMap.php
+++ b/Security/Http/ResourceOwnerMap.php
@@ -62,7 +62,7 @@ class ResourceOwnerMap
      *
      * @param string $id
      *
-     * @return null|HWI\Bundle\OAuthBundle\OAuthResourceOwnerInterface
+     * @return null|\HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface
      */
     public function getResourceOwnerByName($name)
     {


### PR DESCRIPTION
Linking to proper `\HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface`
