### PR TITLE
Fixed case when user have defined more than one resource owner.

### DIFF
--- a/Security/Http/Firewall/OAuthListener.php
+++ b/Security/Http/Firewall/OAuthListener.php
@@ -75,8 +75,18 @@ class OAuthListener extends AbstractAuthenticationListener
     {
         list($resourceOwner, $checkPath) = $this->resourceOwnerMap->getResourceOwnerByRequest($request);
 
+        $code = $request->query->get('code');
+        // We have more than one resource registered probably, let's try to get code instead dying in loop
+        if (null === $code) {
+            $authorizationUrl = $resourceOwner->getAuthorizationUrl(
+                $this->httpUtils->createRequest($request, $checkPath)->getUri()
+            );
+
+            return $this->httpUtils->createRedirectResponse($request, $authorizationUrl);
+        }
+
         $accessToken = $resourceOwner->getAccessToken(
-            $request->query->get('code'),
+            $code,
             $this->httpUtils->createRequest($request, $checkPath)->getUri()
         );
 


### PR DESCRIPTION
Example configs:

``` yaml
# config.yml
hwi_oauth:
    resource_owners:
        github:
            type:           github
            client_id:      %github.client_id%
            client_secret:  %github.client_secret%

        google:
            type:           google
            client_id:      %google.client_id%
            client_secret:  %google.client_secret%

    firewall_name: secured_area
```

``` yaml
# security.yml
security:
    firewalls:
        secured_area:
            pattern:   ^/
            anonymous: true
            logout:    true
            oauth:
                resource_owners:
                    github:        /login/check-github
                    google:        /login/check-google
                login_path:        /login
                failure_path:      /login

                oauth_user_provider:
                    service: hwi_oauth.user.provider
```
