### PR TITLE
Added OAuthHelper + Twig extension to allow setting login urls in templates

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -61,8 +61,8 @@ class ConnectController extends ContainerAware
         }
 
         return $this->container->get('templating')->renderResponse('HWIOAuthBundle:Connect:login.html.twig', array(
-            'error'           => $error,
-            'resource_owners' => $this->getResourceOwners($request, $connect && $hasUser),
+            'error'   => $error,
+            'connect' => $connect && $hasUser,
         ));
     }
 
@@ -179,55 +179,6 @@ class ConnectController extends ContainerAware
             'form' => $form->createView(),
             'userInformation' => $userInformation,
         ));
-    }
-
-    /**
-     * Gets all the resource owners for a given request.
-     *
-     * @param Request $request A request.
-     * @param boolean $connect Whether it should be connect, or just 'regular' redirect urls.
-     *
-     * @return array Resource owner information.
-     */
-    protected function getResourceOwners(Request $request, $connect)
-    {
-        $ownerMap = $this->container->get('hwi_oauth.resource_ownermap.'.$this->container->getParameter('hwi_oauth.firewall_name'));
-
-        $resourceOwners = array();
-        foreach ($ownerMap->getResourceOwners() as $name => $checkPath) {
-            $resourceOwner = $ownerMap->getResourceOwnerByName($name);
-            $resourceOwners[$name] = array(
-                'url' => $resourceOwner->getAuthorizationUrl(
-                    $connect
-                    ? $this->generate('hwi_oauth_connect_service', array('service' => $name), true)
-                    : $this->getUriForCheckPath($request, $checkPath)
-                ),
-                'name' => $name,
-            );
-        }
-
-        return $resourceOwners;
-    }
-
-    /**
-     * Get the uri for a given path.
-     *
-     * @param Request $request A request instance
-     * @param string  $path    Path or route
-     *
-     * @return string
-     */
-    protected function getUriForCheckPath(Request $request, $path)
-    {
-        if ($path && '/' !== $path[0] && 0 !== strpos($path, 'http')) {
-            $path = $this->generate($path, array(), true);
-        }
-
-        if (0 !== strpos($path, 'http')) {
-            $path = $request->getUriForPath($path);
-        }
-
-        return $path;
     }
 
     /**

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -35,6 +35,8 @@ class HWIOAuthExtension extends Extension
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config/'));
         $loader->load('oauth.xml');
+        $loader->load('templating.xml');
+        $loader->load('twig.xml');
 
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), $configs);

--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="hwi_oauth.templating.helper.oauth.class">HWI\Bundle\OAuthBundle\Templating\Helper\OAuthHelper</parameter>
+    </parameters>
+
+    <services>
+        <service id="hwi_oauth.templating.helper.oauth" class="%hwi_oauth.templating.helper.oauth.class%">
+            <argument type="service" id="service_container" />
+            <tag name="templating.helper" alias="oauth" />
+        </service>
+    </services>
+</container>

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="hwi_oauth.twig.extension.oauth.class">HWI\Bundle\OAuthBundle\Twig\Extension\OAuthExtension</parameter>
+    </parameters>
+
+    <services>
+        <service id="hwi_oauth.twig.extension.oauth" class="%hwi_oauth.twig.extension.oauth.class%" public="false">
+            <argument type="service" id="hwi_oauth.templating.helper.oauth" />
+            <tag name="twig.extension" />
+        </service>
+    </services>
+</container>

--- a/Resources/views/Connect/login.html.twig
+++ b/Resources/views/Connect/login.html.twig
@@ -4,7 +4,7 @@
     {% if error %}
         <span>{{ error }}</span>
     {% endif %}
-    {% for owner in resource_owners %}
-    <a href="{{ owner.url }}">{{ owner.name | trans({}, 'HWIOAuthBundle') }}</a> <br />
+    {% for owner in hwi_oauth_resource_owners() %}
+    <a href="{{ hwi_oauth_login_url(owner) }}">{{ owner | trans({}, 'HWIOAuthBundle') }}</a> <br />
     {% endfor %}
 {% endblock hwi_oauth_content %}

--- a/Security/Http/ResourceOwnerMap.php
+++ b/Security/Http/ResourceOwnerMap.php
@@ -92,6 +92,24 @@ class ResourceOwnerMap
                 return array($this->getResourceOwnerByName($name), $checkPath);
             }
         }
+
+        return null;
+    }
+
+    /**
+     * Gets the check path for given resource name.
+     *
+     * @param string $name
+     *
+     * @return null|string
+     */
+    public function getResourceOwnerCheckPath($name)
+    {
+        if (isset($this->resourceOwners[$name])) {
+            return $this->resourceOwners[$name];
+        }
+
+        return null;
     }
 
     /**

--- a/Templating/Helper/OAuthHelper.php
+++ b/Templating/Helper/OAuthHelper.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Templating\Helper;
+
+use Symfony\Component\DependencyInjection\ContainerInterface,
+    Symfony\Component\HttpFoundation\Request,
+    Symfony\Component\Templating\Helper\Helper;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+
+/**
+ * OAuthHelper
+ *
+ * @author Joseph Bielawski <stloyd@gmail.com>
+ */
+class OAuthHelper extends Helper
+{
+    private $container;
+    private $ownerMap;
+
+    /**
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        $this->ownerMap  = $this->container->get('hwi_oauth.resource_ownermap.'.$this->container->getParameter('hwi_oauth.firewall_name'));
+    }
+
+    /**
+     * @return array
+     */
+    public function getResourceOwners()
+    {
+        $resourceOwners = $this->ownerMap->getResourceOwners();
+
+        return array_keys($resourceOwners);
+    }
+
+    /**
+     * @param string  $name
+     * @param boolean $connect
+     *
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function getLoginUrl($name, $connect = false)
+    {
+        $resourceOwner = $this->ownerMap->getResourceOwnerByName($name);
+        if (!$resourceOwner instanceof ResourceOwnerInterface) {
+            throw new \RuntimeException(sprintf("No resource owner with name '%s'.", $name));
+        }
+
+        $checkPath = $this->ownerMap->getResourceOwnerCheckPath($name);
+
+        return $this->getAuthorizationUrl($resourceOwner, $name, $checkPath, $connect);
+    }
+
+    /**
+     * @param ResourceOwnerInterface $resourceOwner
+     * @param string                 $name
+     * @param string                 $checkPath
+     * @param boolean                $connect
+     *
+     * @return mixed
+     */
+    private function getAuthorizationUrl(ResourceOwnerInterface $resourceOwner, $name, $checkPath, $connect)
+    {
+        return $resourceOwner->getAuthorizationUrl(
+            $connect
+                ? $this->generateUrl('hwi_oauth_connect_service', array('service' => $name), true)
+                : $this->generateUri($checkPath)
+        );
+    }
+
+    /**
+     * Get the uri for a given path.
+     *
+     * @param string $path Path or route
+     *
+     * @return string
+     */
+    private function generateUri($path)
+    {
+        if (0 === strpos($path, 'http') || !$path) {
+            return $path;
+        }
+
+        if ($path && '/' === $path[0]) {
+            return $this->container->get('request')->getUriForPath($path);
+        }
+
+        return $this->generateUrl($path, true);
+    }
+
+    /**
+     * @param string  $route
+     * @param array   $params
+     * @param boolean $absolute
+     *
+     * @return string
+     */
+    private function generateUrl($route, array $params = array(), $absolute = false)
+    {
+        return $this->container->get('router')->generate($route, $params, $absolute);
+    }
+
+    /**
+     * Returns the name of the helper.
+     *
+     * @return string The helper name
+     */
+    public function getName()
+    {
+        return 'hwi_oauth';
+    }
+}

--- a/Twig/Extension/OAuthExtension.php
+++ b/Twig/Extension/OAuthExtension.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Twig\Extension;
+
+use HWI\Bundle\OAuthBundle\Templating\Helper\OAuthHelper;
+
+/**
+ * OAuthExtension
+ *
+ * @author Joseph Bielawski <stloyd@gmail.com>
+ */
+class OAuthExtension extends \Twig_Extension
+{
+    /**
+     * @var OAuthHelper
+     */
+    protected $helper;
+
+    /**
+     * @param OAuthHelper $helper
+     */
+    public function __construct(OAuthHelper $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFunctions()
+    {
+        return array(
+            'hwi_oauth_login_url'       => new \Twig_Function_Method($this, 'getLoginUrl'),
+            'hwi_oauth_resource_owners' => new \Twig_Function_Method($this, 'getResourceOwners')
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function getResourceOwners()
+    {
+        return $this->helper->getResourceOwners();
+    }
+
+    /**
+     * @param string  $name
+     * @param boolean $connect
+     *
+     * @return string
+     */
+    public function getLoginUrl($name, $connect = false)
+    {
+        return $this->helper->getLoginUrl($name, $connect);
+    }
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string The extension name
+     */
+    public function getName()
+    {
+        return 'hwi_oauth';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,18 +23,20 @@
 
     "require": {
         "php":                ">=5.3.2",
-        "symfony/symfony":    "2.*",
+        "symfony/symfony":    ">=2.0,<2.2-dev",
         "sensio/buzz-bundle": "*"
     },
 
     "require-dev": {
         "doctrine/orm": "*",
-        "friendsofsymfony/user-bundle": "*"
+        "friendsofsymfony/user-bundle": "*",
+        "symfony/twig-bundle": "*"
     },
 
     "suggest": {
-        "symfony/doctrine-bundle": "*",
-        "friendsofsymfony/user-bundle": "*"
+        "symfony/doctrine-bundle": "to use Doctrine user provider",
+        "friendsofsymfony/user-bundle": "to connect FOSUB with this bundle",
+        "symfony/twig-bundle": "to use the Twig hwi_oauth_* functions"
     },
 
     "autoload": {


### PR DESCRIPTION
With those changes you can call this in any place, i.e.

``` html+jinja
{% if is_granted('IS_AUTHENTICATED_FULLY') %}
    <span>{{ app.user }}</span><br>
    <a href="{{ path('_logout') }}">Log out</a>
{% else %}
    Sign In using: <a href="{{ hwi_oauth_login_url('github') }}">GitHub</a> or <a href="{{ hwi_oauth_login_url('google') }}">Google</a>
{% endif %}
```
