### PR TITLE
Fixed the composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
 
     "require-dev": {
         "doctrine/orm": "*",
+        "symfony/validator": ">=2.0,<2.2-dev",
         "friendsofsymfony/user-bundle": "*",
         "symfony/twig-bundle": "*"
     },


### PR DESCRIPTION
The best practice for bundle is to require framework-bundle instead of the full-stack framework so that users can have the choice to use only the subtree splits instead of the full repo.
and the name of the DoctrineBundle changed when it was moved to Doctrine.
