### PR TITLE
[WiP] Add Flickr support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+### (2012-xx-xx)
+
+* Flickr support
+
 ### (2012-06-28)
 
 * OAuth 1.0a support (linkedin/twitter/generic)

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -136,7 +136,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('type')
                             ->validate()
-                                ->ifNotInArray(array('facebook', 'oauth2', 'github', 'google', 'sensio_connect', 'windows_live', 'vkontakte', 'oauth1', 'twitter', 'linkedin'))
+                                ->ifNotInArray(array('facebook', 'oauth2', 'github', 'google', 'sensio_connect', 'windows_live', 'vkontakte', 'oauth1', 'twitter', 'linkedin', 'flickr'))
                                 ->thenInvalid('Unknown resource owner type %s.')
                             ->end()
                             ->validate()

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -138,7 +138,7 @@ class HWIOAuthExtension extends Extension
             }
 
             // todo: come up with a nicer way to do check this
-            if (in_array($type, array('linkedin', 'oauth1', 'twitter'))) {
+            if (in_array($type, array('flickr', 'linkedin', 'oauth1', 'twitter'))) {
                 $definition->addArgument(new Reference('hwi_oauth.storage.session'));
             }
         }

--- a/OAuth/ResourceOwner/FlickrResourceOwner.php
+++ b/OAuth/ResourceOwner/FlickrResourceOwner.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
+
+/**
+ * FlickrResourceOwner
+ *
+ * @author Karel <karel@hardware.info>
+ */
+class FlickrResourceOwner extends GenericOAuth1ResourceOwner
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $options = array(
+        'authorization_url'   => 'http://www.flickr.com/services/oauth/authorize',
+        'request_token_url'   => 'http://www.flickr.com/services/oauth/request_token',
+        'access_token_url'    => 'http://www.flickr.com/services/oauth/access_token',
+        'infos_url'           => 'http://api.flickr.com/services/rest/?format=json&method=flickr.test.echo&nojsoncallback=1',
+        'user_response_class' => '\HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse',
+        'realm'               => null,
+    );
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $paths = array(
+        'username'     => 'user_nsid',
+        'displayname'  => 'username',
+    );
+}

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -16,6 +16,7 @@
         <parameter key="hwi_oauth.resource_owner.oauth1.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth1ResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.oauth2.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner</parameter>
 
+        <parameter key="hwi_oauth.resource_owner.flickr.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\FlickrResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.facebook.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\FacebookResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.github.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GitHubResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.google.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GoogleResourceOwner</parameter>


### PR DESCRIPTION
Now we have support for OAuth 1.0a I'm trying to add a Flickr ResourceOwner. Everything seems to be working well except the user information retrieval fails. I'm always getting an "Invalid API Key (Key has invalid format)" error. I couldn't figure out if the error is caused by my App or the OAuth bundle. Maybe someone else is willing to try? See the section below for more information.

Create a Flickr App:
http://www.flickr.com/services/apps/create/apply/

Api overview:
http://www.flickr.com/services/api/

User Authentication:
http://www.flickr.com/services/api/auth.oauth.html
