### PR TITLE
Move extending points to allow simpler overriding "get access token", "get user info"

### DIFF
--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -171,7 +171,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
     /**
      * Get the 'parsed' content based on the response headers.
      *
-     * @param HttpResponse $response
+     * @param HttpResponse $rawResponse
      *
      * @return mixed
      */
@@ -185,4 +185,20 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
 
         return $response;
     }
+
+    /**
+     * @param string $url
+     * @param array  $parameters
+     *
+     * @return mixed
+     */
+    abstract protected function doGetAccessTokenRequest($url, array $parameters = array());
+
+    /**
+     * @param string $url
+     * @param array  $parameters
+     *
+     * @return mixed
+     */
+    abstract protected function doGetUserInformationRequest($url, array $parameters = array());
 }

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -40,7 +40,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
             'access_token' => $accessToken
         ));
 
-        $content = $this->doGetUserInformationRequest($url);
+        $content = $this->doGetUserInformationRequest($url)->getContent();
 
         $response = $this->getUserResponse();
         $response->setResponse($content);
@@ -77,7 +77,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
             'redirect_uri'  => $redirectUri,
         ));
 
-        $response = $this->doGetAccessTokenRequest($parameters);
+        $response = $this->doGetAccessTokenRequest($this->getOption('access_token_url'), $parameters);
         $response = $this->getResponseContent($response);
 
         if (isset($response['error'])) {
@@ -100,24 +100,18 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
     }
 
     /**
-     * @param string $url
-     *
-     * @return mixed
+     * {@inheritDoc}
      */
-    protected function doGetUserInformationRequest($url)
+    protected function doGetAccessTokenRequest($url, array $parameters = array())
     {
-        return $this->httpRequest($url)->getContent();
+        return $this->httpRequest($url, http_build_query($parameters));
     }
 
     /**
-     * @param array $parameters
-     *
-     * @return mixed
+     * {@inheritDoc}
      */
-    protected function doGetAccessTokenRequest(array $parameters)
+    protected function doGetUserInformationRequest($url, array $parameters = array())
     {
-        $content = http_build_query($parameters);
-
-        return $this->httpRequest($this->getOption('access_token_url'), $content);
+        return $this->httpRequest($url);
     }
 }

--- a/OAuth/ResourceOwner/SensioConnectResourceOwner.php
+++ b/OAuth/ResourceOwner/SensioConnectResourceOwner.php
@@ -36,7 +36,7 @@ class SensioConnectResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function doGetAccessTokenRequest(array $parameters)
+    protected function doGetAccessTokenRequest($url, array $parameters = array())
     {
         return $this->httpRequest($this->getOption('access_token_url'), $parameters, array(), 'POST');
     }
@@ -44,8 +44,8 @@ class SensioConnectResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function doGetUserInformationRequest($url)
+    protected function doGetUserInformationRequest($url, array $parameters = array())
     {
-        return $this->httpRequest($url, null, array('Accept: application/vnd.com.sensiolabs.connect+xml'))->getContent();
+        return $this->httpRequest($url, null, array('Accept: application/vnd.com.sensiolabs.connect+xml'));
     }
 }


### PR DESCRIPTION
With this change #55 would no need to overriding full function, and duplicated code just something like:

``` php
<?php

class FlickrResourceOwner extends GenericOAuth1ResourceOwner
{
    // (...)

    protected function doGetUserInformationRequest($url, array $parameters = array())
    {
        $url .= http_build_query($parameters);

        return $this->httpRequest($url, null, array(), array(), 'GET');
    }
}
```
