### PR TITLE
Force user to set `firewall_name` setting as it's required.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,7 +34,9 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->fixXmlConfig('resource_owner')
             ->children()
-            ->scalarNode('firewall_name')->defaultValue(false)->end()
+            ->scalarNode('firewall_name')
+                ->cannotBeEmpty()
+            ->end()
             ->arrayNode('http_client')
                 ->addDefaultsIfNotSet()
                 ->children()

--- a/Resources/doc/2-configuring_resource_owners.md
+++ b/Resources/doc/2-configuring_resource_owners.md
@@ -5,6 +5,19 @@ use in your application. These resource owners will be used in the oauth
 firewall. The bundle ships several pre-configured resource owners that only
 need little configuration.
 
+To make this bundle working you need to add this setting:
+
+``` yaml
+# app/config/config.yml
+
+hwi_oauth:
+    # name of the firewall in which this bundle is active, this setting MUST be set
+    firewall_name: secured_area
+
+    # here you will add one (or more) of configurations for resource owners
+    # and other setting you want to adjust in this bundle, just checkout list below!
+```
+
 - [Facebook](2x-facebook.md)
 - [Google](2x-google.md)
 - [GitHub](2x-github.md)


### PR DESCRIPTION
Closes #59.
