### PR TITLE
Missing abstract flag on the security listener

### DIFF
--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -41,7 +41,7 @@
 
         Cheers!
         -->
-        <service id="hwi_oauth.authentication.listener.oauth" class="%hwi_oauth.authentication.listener.oauth.class%" parent="security.authentication.listener.abstract" />
+        <service id="hwi_oauth.authentication.listener.oauth" class="%hwi_oauth.authentication.listener.oauth.class%" parent="security.authentication.listener.abstract" abstract="true"/>
         <service id="hwi_oauth.authentication.provider.oauth" class="%hwi_oauth.authentication.provider.oauth.class%" />
         <service id="hwi_oauth.authentication.entry_point.oauth" class="%hwi_oauth.authentication.entry_point.oauth.class%" />
         <service id="hwi_oauth.user.provider" class="%hwi_oauth.user.provider.class%" />


### PR DESCRIPTION
As specified [here](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php#L114)

This issue is a fix for this [issues](https://github.com/symfony/symfony/issues/4837):

```
[Symfony\Component\DependencyInjection\Exception\RuntimeException]                                                                                                                                      
 The definition "hwi_oauth.authentication.listener.oauth" has a reference to an abstract definition "security.authentication.success_handler". Abstract definitions cannot be the target of references.  
```
