### PR TITLE
Added TokenGenerator to FOSUBRegistrationFormHandler.php

### DIFF
--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -13,7 +13,8 @@ namespace HWI\Bundle\OAuthBundle\Form;
 
 use FOS\UserBundle\Form\Handler\RegistrationFormHandler,
     FOS\UserBundle\Model\UserManagerInterface,
-    FOS\UserBundle\Mailer\MailerInterface;
+    FOS\UserBundle\Mailer\MailerInterface,
+    FOS\UserBundle\Util\TokenGenerator;
 
 use HWI\Bundle\OAuthBundle\OAuth\Response\AdvancedUserResponseInterface,
     HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
@@ -33,6 +34,7 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
     protected $userManager;
     protected $mailer;
     protected $registrationFormHandler;
+    protected $tokenGenerator;
     protected $iterations;
 
     /**
@@ -43,11 +45,12 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
      * @param MailerInterface         $mailer                  FOSUB mailer
      * @param integer                 $iterations              Amount of attempts that should be made to 'guess' a unique username
      */
-    public function __construct(RegistrationFormHandler $registrationFormHandler, UserManagerInterface $userManager, MailerInterface $mailer, $iterations = 5)
+    public function __construct(RegistrationFormHandler $registrationFormHandler, UserManagerInterface $userManager, MailerInterface $mailer, TokenGenerator $tokenGenerator, $iterations = 5)
     {
         $this->registrationFormHandler = $registrationFormHandler;
         $this->userManager = $userManager;
         $this->mailer = $mailer;
+        $this->tokenGenerator = $tokenGenerator;
         $this->iterations = $iterations;
     }
 
@@ -114,7 +117,7 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
     {
         $handlerClass = get_class($this->registrationFormHandler);
 
-        return new $handlerClass($form, $request, $this->userManager, $this->mailer);
+        return new $handlerClass($form, $request, $this->userManager, $this->mailer, $this->tokenGenerator);
     }
 
 }

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -60,6 +60,7 @@
             <argument type="service" id="fos_user.registration.form.handler" />
             <argument type="service" id="fos_user.user_manager" />
             <argument type="service" id="fos_user.mailer" />
+            <argument type="service" id="fos_user.util.token_generator" />
         </service>
 
         <!-- Session storage -->


### PR DESCRIPTION
I my research to connect FOSUB with Twitter I got Errors.

After more research I found out that @stof changed sth in FriendsOfSymfony/FOSUserBundle@3cec0a7e166751fb35b7b3caacfe06a60b88ac33 .

So I added the TokenGenerator and everything works fine.

Let me know what you think... 
