### PR TITLE
set resource owner name for oauthtoken

### DIFF
--- a/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -73,6 +73,7 @@ class OAuthProvider implements AuthenticationProviderInterface
         }
 
         $token = new OAuthToken($token->getAccessToken(), $user->getRoles());
+        $token->setResourceOwnerName($resourceOwner->getName());
         $token->setUser($user);
         $token->setAuthenticated(true);
 


### PR DESCRIPTION
i have had the same problem as described in #31.

https://github.com/hwi/HWIOAuthBundle/issues/31#issuecomment-6420163 
"but there is still the issue that the token stored in session has a blank $resourceOwnerName and that causes OAuthProvider::authenticate to execute ->getUserInformation on a non-object. What i did is return the exiting token in this case instead of executing the rest of the method to the end, which generates a fresh token.

The token already has a user anyway, so the question then is, is this safe? and is it a bug?"

i think this is a bug. so simple set the resource owner name for the newly created token. and all works fine ;)
