### PR TITLE
Refactoring of resource owners and responses to handle unique data properly for all resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+### 2012-08-13
+* Added `UserResponseInterface#getRealName()` method, also new default path `realname`
+  was added, this path holds real name of user
+* Added new path `uuid` that now hold an unique user identifier
+* [BC break] Method `UserResponseInterface#getUsername()` now always returns an real
+  unique user identifier, an uses path `uuid`
+* [BC break] Path `username` no longer holds an unique user identifier
+* [BC break] `OAuth1RequestTokenStorageInterface#save()` second param `$token` now
+  must be an array
+
 ### 2012-07-15
 
 * Added `UserResponseInterface#getAccessToken()` and `UserResponseInterface#setAccessToken`

--- a/Connect/AccountConnectorInterface.php
+++ b/Connect/AccountConnectorInterface.php
@@ -27,5 +27,5 @@ interface AccountConnectorInterface
      * @param mixed                 $user     The user object
      * @param UserResponseInterface $response The oauth response
      */
-    function connect($user, UserResponseInterface $response);
+    public function connect($user, UserResponseInterface $response);
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,6 +22,27 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
+     * Array of supported resource owners, indentation is intentional to easily notice
+     * which resource is of which type.
+     *
+     * @var array
+     */
+    private $resourceOwners = array(
+        'oauth2',
+            'facebook',
+            'github',
+            'google',
+            'sensio_connect',
+            'stack_exchange',
+            'vkontakte',
+            'windows_live',
+
+        'oauth1',
+            'linkedin',
+            'twitter',
+    );
+
+    /**
      * Generates the configuration tree builder.
      *
      * @return TreeBuilder $builder The tree builder
@@ -138,7 +159,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('type')
                             ->validate()
-                                ->ifNotInArray(array('facebook', 'oauth2', 'github', 'google', 'sensio_connect', 'windows_live', 'vkontakte', 'oauth1', 'twitter', 'linkedin'))
+                                ->ifNotInArray($this->resourceOwners)
                                 ->thenInvalid('Unknown resource owner type %s.')
                             ->end()
                             ->validate()

--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -43,6 +43,7 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
      * @param RegistrationFormHandler $registrationFormHandler FOSUB registration form handler
      * @param UserManagerInterface    $userManager             FOSUB user manager
      * @param MailerInterface         $mailer                  FOSUB mailer
+     * @param TokenGenerator          $tokenGenerator          FOSUB token generator
      * @param integer                 $iterations              Amount of attempts that should be made to 'guess' a unique username
      */
     public function __construct(RegistrationFormHandler $registrationFormHandler, UserManagerInterface $userManager, MailerInterface $mailer, TokenGenerator $tokenGenerator = null, $iterations = 5)
@@ -55,13 +56,7 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
     }
 
     /**
-     * Processes the form for a given request.
-     *
-     * @param Request               $request         Active request
-     * @param Form                  $form            Form to process
-     * @param UserResponseInterface $userInformation OAuth response
-     *
-     * @return boolean True if the processing was successful
+     * {@inheritDoc}
      */
     public function process(Request $request, Form $form, UserResponseInterface $userInformation)
     {
@@ -76,7 +71,7 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
 
             $user->setUsername($this->getUniqueUsername($userInformation->getDisplayName()));
 
-            if ($userInformation instanceof AdvancedUserResponseInterface) {
+            if ($userInformation instanceof AdvancedUserResponseInterface && method_exists($user, 'setEmail')) {
                 $user->setEmail($userInformation->getEmail());
             }
 

--- a/Form/RegistrationFormHandlerInterface.php
+++ b/Form/RegistrationFormHandlerInterface.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\Form,
     Symfony\Component\HttpFoundation\Request;
 
 /**
- * FormHandlerInterface
+ * RegistrationFormHandlerInterface
  *
  * Interface for objects that are able to handle a form.
  *
@@ -28,10 +28,11 @@ interface RegistrationFormHandlerInterface
     /**
      * Processes the form for a given request.
      *
-     * @param Request $request Active request
-     * @param Form    $form    Form to process
+     * @param Request               $request         Active request
+     * @param Form                  $form            Form to process
+     * @param UserResponseInterface $userInformation OAuth response
      *
      * @return boolean True if the processing was successful
      */
-    function process(Request $request, Form $form, UserResponseInterface $userInformation);
+    public function process(Request $request, Form $form, UserResponseInterface $userInformation);
 }

--- a/OAuth/OAuth1RequestTokenStorage/SessionStorage.php
+++ b/OAuth/OAuth1RequestTokenStorage/SessionStorage.php
@@ -51,7 +51,7 @@ class SessionStorage implements OAuth1RequestTokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function save(ResourceOwnerInterface $resourceOwner, $token)
+    public function save(ResourceOwnerInterface $resourceOwner, array $token)
     {
         if (!isset($token['oauth_token'])) {
             throw new \RuntimeException('Invalid request token.');

--- a/OAuth/OAuth1RequestTokenStorageInterface.php
+++ b/OAuth/OAuth1RequestTokenStorageInterface.php
@@ -30,7 +30,7 @@ interface OAuth1RequestTokenStorageInterface
      *
      * @return array
      */
-    function fetch(ResourceOwnerInterface $resourceOwner, $tokenId);
+    public function fetch(ResourceOwnerInterface $resourceOwner, $tokenId);
 
     /**
      * Save a request token to the storage.
@@ -38,5 +38,5 @@ interface OAuth1RequestTokenStorageInterface
      * @param ResourceOwnerInterface $resourceOwner
      * @param array                  $token
      */
-    function save(ResourceOwnerInterface $resourceOwner, $token);
+    public function save(ResourceOwnerInterface $resourceOwner, array $token);
 }

--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -33,8 +33,9 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
      * {@inheritDoc}
      */
     protected $paths = array(
-        'username'     => 'id',
-        'displayname'  => 'name',
+        'identifier' => 'id',
+        'nickname'   => 'username',
+        'realname'   => 'name',
     );
 
     /**

--- a/OAuth/ResourceOwner/GitHubResourceOwner.php
+++ b/OAuth/ResourceOwner/GitHubResourceOwner.php
@@ -34,8 +34,9 @@ class GitHubResourceOwner extends GenericOAuth2ResourceOwner
      * {@inheritDoc}
      */
     protected $paths = array(
-        'username'       => 'login',
-        'displayname'    => 'name',
+        'identifier'     => 'id',
+        'nickname'       => 'login',
+        'realname'       => 'name',
         'email'          => 'email',
         'profilepicture' => 'avatar_url',
     );

--- a/OAuth/ResourceOwner/GoogleResourceOwner.php
+++ b/OAuth/ResourceOwner/GoogleResourceOwner.php
@@ -30,14 +30,17 @@ class GoogleResourceOwner extends GenericOAuth2ResourceOwner
         'access_token_url'    => 'https://accounts.google.com/o/oauth2/token',
         'infos_url'           => 'https://www.googleapis.com/oauth2/v1/userinfo',
         'scope'               => 'userinfo.profile',
-        'user_response_class' => '\HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse',
+        'user_response_class' => '\HWI\Bundle\OAuthBundle\OAuth\Response\AdvancedPathUserResponse',
     );
 
     /**
      * {@inheritDoc}
      */
     protected $paths = array(
-        'username'     => 'id',
-        'displayname'  => 'name',
+        'identifier'     => 'id',
+        'nickname'       => 'name',
+        'realname'       => 'name',
+        'email'          => 'email',
+        'profilepicture' => 'picture',
     );
 }

--- a/OAuth/ResourceOwner/LinkedinResourceOwner.php
+++ b/OAuth/ResourceOwner/LinkedinResourceOwner.php
@@ -34,8 +34,9 @@ class LinkedinResourceOwner extends GenericOAuth1ResourceOwner
      * {@inheritDoc}
      */
     protected $paths = array(
-        'username'     => 'id',
-        'displayname'  => 'formattedName',
+        'identifier' => 'id',
+        'nickname'   => 'formattedName',
+        'realname'   => 'formattedName',
     );
 
     /**

--- a/OAuth/ResourceOwner/TwitterResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitterResourceOwner.php
@@ -34,7 +34,8 @@ class TwitterResourceOwner extends GenericOAuth1ResourceOwner
      * {@inheritDoc}
      */
     protected $paths = array(
-        'username'     => 'id',
-        'displayname'  => 'screen_name',
+        'identifier' => 'id',
+        'nickname'   => 'screen_name',
+        'realname'   => 'name',
     );
 }

--- a/OAuth/ResourceOwner/VkontakteResourceOwner.php
+++ b/OAuth/ResourceOwner/VkontakteResourceOwner.php
@@ -33,8 +33,9 @@ class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
      * {@inheritDoc}
      */
     protected $paths = array(
-        'username'     => 'response.user_id',
-        'displayname'  => 'response.user_name',
+        'identifier' => 'response.user_id',
+        'nickname'   => 'response.user_name',
+        'realname'   => 'response.user_name',
     );
 
     /**

--- a/OAuth/ResourceOwner/WindowsLiveResourceOwner.php
+++ b/OAuth/ResourceOwner/WindowsLiveResourceOwner.php
@@ -33,7 +33,8 @@ class WindowsLiveResourceOwner extends GenericOAuth2ResourceOwner
      * {@inheritDoc}
      */
     protected $paths = array(
-        'username'     => 'id',
-        'displayname'  => 'name',
+        'identifier' => 'id',
+        'nickname'   => 'name',
+        'realname'   => 'name',
     );
 }

--- a/OAuth/ResourceOwnerInterface.php
+++ b/OAuth/ResourceOwnerInterface.php
@@ -28,7 +28,7 @@ interface ResourceOwnerInterface
      *
      * @return UserResponseInterface The wrapped response interface.
      */
-    function getUserInformation($accessToken);
+    public function getUserInformation($accessToken);
 
     /**
      * Returns the provider's authorization url
@@ -38,7 +38,7 @@ interface ResourceOwnerInterface
      *
      * @return string The authorization url
      */
-    function getAuthorizationUrl($redirectUri, array $extraParameters = array());
+    public function getAuthorizationUrl($redirectUri, array $extraParameters = array());
 
     /**
      * Retrieve an access token for a given code
@@ -49,14 +49,14 @@ interface ResourceOwnerInterface
      *
      * @return string The access token
      */
-    function getAccessToken(Request $request, $redirectUri, array $extraParameters = array());
+    public function getAccessToken(Request $request, $redirectUri, array $extraParameters = array());
 
     /**
      * Return a name for the resource owner.
      *
      * @return string
      */
-    function getName();
+    public function getName();
 
     /**
      * Checks whether the class can handle the request.
@@ -65,10 +65,10 @@ interface ResourceOwnerInterface
      *
      * @return boolean
      */
-    function handles(Request $request);
+    public function handles(Request $request);
 
     /**
      * Sets a name for the resource owner.
      */
-    function setName($name);
+    public function setName($name);
 }

--- a/OAuth/Response/AbstractUserResponse.php
+++ b/OAuth/Response/AbstractUserResponse.php
@@ -68,7 +68,7 @@ abstract class AbstractUserResponse implements UserResponseInterface
     {
         $this->response = json_decode($response, true);
 
-        if (json_last_error() != \JSON_ERROR_NONE) {
+        if (JSON_ERROR_NONE !== json_last_error()) {
             throw new AuthenticationException(sprintf('Not a valid JSON response.'));
         }
     }

--- a/OAuth/Response/PathUserResponse.php
+++ b/OAuth/Response/PathUserResponse.php
@@ -21,22 +21,33 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  */
 class PathUserResponse extends AbstractUserResponse
 {
-    protected $paths;
+    /**
+     * @var array
+     */
+    protected $paths = array();
 
     /**
      * {@inheritdoc}
      */
     public function getUsername()
     {
-        return $this->getValueForPath('username');
+        return $this->getValueForPath('identifier');
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getDisplayName()
+    public function getNickname()
     {
-        return $this->getValueForPath('displayname');
+        return $this->getValueForPath('nickname');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRealName()
+    {
+        return $this->getValueForPath('realname');
     }
 
     /**
@@ -64,7 +75,7 @@ class PathUserResponse extends AbstractUserResponse
      *
      * @return mixed
      *
-     * @throws \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @throws AuthenticationException
      */
     protected function getPath($name)
     {
@@ -81,7 +92,7 @@ class PathUserResponse extends AbstractUserResponse
      * @param string  $path           Name of the path to get the value for
      * @param boolean $catchException Whether to throw an exception or return null
      *
-     * @return null|String
+     * @return null|string
      *
      * @throws AuthenticationException
      */

--- a/OAuth/Response/SensioConnectUserResponse.php
+++ b/OAuth/Response/SensioConnectUserResponse.php
@@ -31,6 +31,14 @@ class SensioConnectUserResponse extends AbstractUserResponse implements Advanced
      */
     public function getUsername()
     {
+        return $this->getNodeValue('./foaf:uuid', $this->response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNickname()
+    {
         $username = null;
         $accounts = $this->xpath->query('./foaf:account/foaf:OnlineAccount', $this->response);
         for ($i = 0; $i < $accounts->length; $i++) {
@@ -47,7 +55,7 @@ class SensioConnectUserResponse extends AbstractUserResponse implements Advanced
     /**
      * {@inheritdoc}
      */
-    public function getDisplayName()
+    public function getRealName()
     {
         return $this->getNodeValue('./foaf:name', $this->response);
     }

--- a/OAuth/Response/UserResponseInterface.php
+++ b/OAuth/Response/UserResponseInterface.php
@@ -17,22 +17,30 @@ use HWI\Bundle\OAuthBundle\OAuth\ResponseInterface;
  * UserResponseInterface
  *
  * @author Alexander <iam.asm89@gmail.com>
+ * @author Joseph Bielawski <stloyd@gmail.com>
  */
 interface UserResponseInterface extends ResponseInterface
 {
     /**
-     * Get the username.
+     * Get the unique user identifier.
      *
      * @return string
      */
     public function getUsername();
 
     /**
-     * Get the name to display.
+     * Get the username to display.
      *
      * @return string
      */
-    public function getDisplayName();
+    public function getNickname();
+
+    /**
+     * Get the real name of user.
+     *
+     * @return string
+     */
+    public function getRealName();
 
     /**
      * Get the access token used for the request.

--- a/Resources/doc/2x-others.md
+++ b/Resources/doc/2x-others.md
@@ -19,8 +19,8 @@ hwi_oauth:
             scope:               ""
             user_response_class: HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse
             paths:
-                username: id
-                displayname: username
+                identifier: id
+                nickname:   username
 ```
 
 or an oauth1:
@@ -41,8 +41,8 @@ hwi_oauth:
             realm:               ""
             user_response_class: HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse
             paths:
-                username: id
-                displayname: username
+                identifier: id
+                nickname:   username
 ```
 
 When you're done. Continue by configuring the security layer or go back to

--- a/Resources/doc/reference_configuration.md
+++ b/Resources/doc/reference_configuration.md
@@ -20,7 +20,7 @@ hwi_oauth:
             scope:               ""
             user_response_class: \Our\Custom\Response\Class
             paths:
-                email: email
+                email:          email
                 profilepicture: picture
 
         facebook:
@@ -39,9 +39,9 @@ hwi_oauth:
             scope:               ""
             user_response_class: HWI\Bundle\OAuthBundle\OAuth\Response\AdvancedPathUserResponse
             paths:
-                username: id
-                displayname: username
-                email: email
+                identifier: id
+                nickname:   username
+                email:      email
 
         my_custom_oauth1:
             type:                oauth1
@@ -54,8 +54,8 @@ hwi_oauth:
             realm:               ""
             user_response_class: HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse
             paths:
-                username: id
-                displayname: username
+                identifier: id
+                nickname:   username
 
     # name of the firewall the oauth bundle is active in
     firewall_name: secured_area

--- a/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -33,17 +33,17 @@ class OAuthProvider implements AuthenticationProviderInterface
     private $resourceOwnerMap;
 
     /**
-     * @var Symfony\Component\Security\Core\User\UserProviderInterface
+     * @var OAuthAwareUserProviderInterface
      */
     private $userProvider;
 
     /**
-     * @param UserProviderInterface $userProvider     User provider
-     * @param ResourceOwnerMap      $resourceOwnerMap Resource owner map
+     * @param OAuthAwareUserProviderInterface $userProvider     User provider
+     * @param ResourceOwnerMap                $resourceOwnerMap Resource owner map
      */
     public function __construct(OAuthAwareUserProviderInterface $userProvider, ResourceOwnerMap $resourceOwnerMap)
     {
-        $this->userProvider  = $userProvider;
+        $this->userProvider     = $userProvider;
         $this->resourceOwnerMap = $resourceOwnerMap;
     }
 

--- a/Security/Core/Exception/OAuthAwareExceptionInterface.php
+++ b/Security/Core/Exception/OAuthAwareExceptionInterface.php
@@ -20,26 +20,26 @@ namespace HWI\Bundle\OAuthBundle\Security\Core\Exception;
 interface OAuthAwareExceptionInterface
 {
     /**
-    * Set the access token of the failed authentication request.
-    *
-    * @param string $accessToken
-    */
+     * Set the access token of the failed authentication request.
+     *
+     * @param string $accessToken
+     */
     public function setAccessToken($accessToken);
 
     /**
-    * @return string
-    */
+     * @return string
+     */
     public function getAccessToken();
 
     /**
-    * Set the name of the resource owner responsible for the oauth authentication.
-    *
-    * @param string $resourceOwnerName
-    */
+     * Set the name of the resource owner responsible for the oauth authentication.
+     *
+     * @param string $resourceOwnerName
+     */
     public function setResourceOwnerName($resourceOwnerName);
 
     /**
-    * @return string
-    */
+     * @return string
+     */
     public function getResourceOwnerName();
 }

--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -95,6 +95,8 @@ class FOSUBUserProvider implements OAuthAwareUserProviderInterface
      * @param UserResponseInterface $response
      *
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function getProperty(UserResponseInterface $response)
     {

--- a/Security/Core/User/OAuthAwareUserProviderInterface.php
+++ b/Security/Core/User/OAuthAwareUserProviderInterface.php
@@ -29,5 +29,5 @@ interface OAuthAwareUserProviderInterface
      *
      * @throws UsernameNotFoundException if the user is not found
      */
-    function loadUserByOAuthUserResponse(UserResponseInterface $response);
+    public function loadUserByOAuthUserResponse(UserResponseInterface $response);
 }

--- a/Security/Core/User/OAuthUser.php
+++ b/Security/Core/User/OAuthUser.php
@@ -21,6 +21,11 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class OAuthUser implements UserInterface
 {
     /**
+     * @var string
+     */
+    protected $username;
+
+    /**
      * @param string $username
      */
     public function __construct($username)
@@ -73,6 +78,6 @@ class OAuthUser implements UserInterface
      */
     public function equals(UserInterface $user)
     {
-        return $user->getUsername() == $this->getUsername();
+        return $user->getUsername() === $this->username;
     }
 }

--- a/Security/Core/User/OAuthUserProvider.php
+++ b/Security/Core/User/OAuthUserProvider.php
@@ -35,6 +35,14 @@ class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProvider
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function loadUserByOAuthUserResponse(UserResponseInterface $response)
+    {
+        return $this->loadUserByUsername($response->getUsername());
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function refreshUser(UserInterface $user)
@@ -52,13 +60,5 @@ class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProvider
     public function supportsClass($class)
     {
         return $class === 'HWI\\Bundle\\OAuthBundle\\Security\\Core\\User\\OAuthUser';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function loadUserByOAuthUserResponse(UserResponseInterface $response)
-    {
-        return $this->loadUserByUsername($response->getUsername());
     }
 }

--- a/Security/Http/EntryPoint/OAuthEntryPoint.php
+++ b/Security/Http/EntryPoint/OAuthEntryPoint.php
@@ -34,16 +34,6 @@ class OAuthEntryPoint implements AuthenticationEntryPointInterface
     private $httpUtils;
 
     /**
-     * @var HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface
-     */
-    private $resourceOwner;
-
-    /**
-     * @var string
-     */
-    private $checkPath;
-
-    /**
      * @var string
      */
     private $loginPath;
@@ -53,13 +43,11 @@ class OAuthEntryPoint implements AuthenticationEntryPointInterface
      *
      * @param HttpUtils              $httpUtils
      * @param string                 $loginPath
-     * @param ResourceOwnerInterface $resourceOwner
-     * @param string                 $checkPath
      */
     public function __construct(HttpUtils $httpUtils, $loginPath)
     {
-        $this->httpUtils     = $httpUtils;
-        $this->loginPath     = $loginPath;
+        $this->httpUtils = $httpUtils;
+        $this->loginPath = $loginPath;
     }
 
     /**

--- a/Security/Http/ResourceOwnerMap.php
+++ b/Security/Http/ResourceOwnerMap.php
@@ -60,7 +60,7 @@ class ResourceOwnerMap
     /**
      * Gets the appropriate resource owner given the name.
      *
-     * @param string $id
+     * @param string $name
      *
      * @return null|\HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface
      */

--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -24,7 +24,13 @@ use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
  */
 class OAuthUtils
 {
+    /**
+     * @var ContainerInterface
+     */
     private $container;
+    /**
+     * @var \HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap
+     */
     private $ownerMap;
 
     /**

--- a/Tests/Fixtures/CustomUserResponse.php
+++ b/Tests/Fixtures/CustomUserResponse.php
@@ -22,10 +22,15 @@ class CustomUserResponse extends AbstractUserResponse
 {
     public function getUsername()
     {
+        return 'foo666';
+    }
+
+    public function getNickname()
+    {
         return 'foo';
     }
 
-    public function getDisplayName()
+    public function getRealName()
     {
         return 'foo';
     }

--- a/Tests/Fixtures/OAuthAwareException.php
+++ b/Tests/Fixtures/OAuthAwareException.php
@@ -14,7 +14,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\Fixtures;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAwareExceptionInterface;
 
 /**
- * AbstractUserResponse
+ * OAuthAwareException
  *
  * @author Alexander <iam.asm89@gmail.com>
  */
@@ -43,5 +43,4 @@ class OAuthAwareException extends \Exception
     {
         $this->resourceOwnerName = $resourceOwnerName;
     }
-
 }

--- a/Tests/Fixtures/User.php
+++ b/Tests/Fixtures/User.php
@@ -45,6 +45,7 @@ class User extends BaseUser
     public function eraseCredentials()
     {
     }
+
     public function getGitHubId()
     {
         return $this->githubId;

--- a/Tests/OAuth/ResourceOwner/FacebookResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/FacebookResourceOwnerTest.php
@@ -18,14 +18,15 @@ class FacebookResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
     protected $userResponse = '{"id": "bar"}';
 
-    public function setup()
+    public function setUp()
     {
         $this->resourceOwner = $this->createResourceOwner($this->getDefaultOptions(), 'oauth2');
     }
 
     protected function getDefaultOptions()
     {
-        return array('client_id' => 'clientid',
+        return array(
+            'client_id'     => 'clientid',
             'client_secret' => 'clientsecret',
         );
     }

--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -17,6 +17,9 @@ use Symfony\Component\HttpFoundation\Request;
 
 class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_Testcase
 {
+    /**
+     * @var GenericOAuth1ResourceOwner
+     */
     protected $resourceOwner;
     protected $buzzClient;
     protected $buzzResponse;
@@ -25,14 +28,15 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_Testcase
 
     protected $userResponse = '{"foo": "bar"}';
 
-    public function setup()
+    public function setUp()
     {
         $this->resourceOwner = $this->createResourceOwner($this->getDefaultOptions(), 'oauth1');
     }
 
     protected function getDefaultOptions()
     {
-        return array('infos_url' => 'http://user.info/', 
+        return array(
+            'infos_url' => 'http://user.info/',
             'client_id' => 'clientid',
             'scope' => '',
             'request_token_url' => 'http://user.request/',
@@ -44,8 +48,10 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_Testcase
 
     protected function getDefaultPaths()
     {
-        return array('username' => 'foo',
-            'displayname' => 'foo_disp',
+        return array(
+            'identifier' => 'id',
+            'nickname'   => 'foo',
+            'realname'   => 'foo_disp',
         );
     }
 
@@ -133,7 +139,8 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_Testcase
             ->will($this->returnValue(array('oauth_token' => 'token', 'oauth_token_secret' => 'secret')));
 
         $request = new Request(array('oauth_token' => 'token', 'oauth_verifier' => 'code'));
-        $accessToken = $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
+
+        $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
     }
 
     /**
@@ -148,7 +155,8 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_Testcase
             ->will($this->returnValue(array('oauth_token' => 'token', 'oauth_token_secret' => 'secret')));
 
         $request = new Request(array('oauth_token' => 'token', 'oauth_verifier' => 'code'));
-        $accessToken = $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
+
+        $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
     }
 
     public function testGetSetName()
@@ -161,14 +169,18 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_Testcase
     public function testCustomResponseClass()
     {
         $options = $this->getDefaultOptions();
-        $options['user_response_class'] = "\HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse";
+        $options['user_response_class'] = '\HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse';
         $resourceOwner = $this->createResourceOwner($options, 'oauth1');
 
         $this->mockBuzz();
+        /**
+         * @var $userResponse \HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse
+         */
         $userResponse = $resourceOwner->getUserInformation(array('oauth_token' => 'token', 'oauth_token_secret' => 'secret'));
 
         $this->assertInstanceOf($options['user_response_class'], $userResponse);
-        $this->assertEquals('foo', $userResponse->getUsername());
+        $this->assertEquals('foo666', $userResponse->getUsername());
+        $this->assertEquals('foo', $userResponse->getNickname());
     }
 
     protected function mockBuzz($response = '', $contentType = 'text/plain')

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -17,6 +17,9 @@ use Symfony\Component\HttpFoundation\Request;
 
 class GenericOAuth2ResourceOwnerTest extends \PHPUnit_Framework_Testcase
 {
+    /**
+     * @var GenericOAuth2ResourceOwner
+     */
     protected $resourceOwner;
     protected $buzzClient;
     protected $buzzResponse;
@@ -24,7 +27,7 @@ class GenericOAuth2ResourceOwnerTest extends \PHPUnit_Framework_Testcase
 
     protected $userResponse = '{"foo": "bar"}';
 
-    public function setup()
+    public function setUp()
     {
         $this->resourceOwner = $this->createResourceOwner($this->getDefaultOptions(), 'oauth2');
     }
@@ -43,8 +46,9 @@ class GenericOAuth2ResourceOwnerTest extends \PHPUnit_Framework_Testcase
     protected function getDefaultPaths()
     {
         return array(
-            'username' => 'foo',
-            'displayname' => 'foo_disp',
+            'identifier' => 'id',
+            'nickname'   => 'foo',
+            'realname'   => 'foo_disp',
         );
     }
 
@@ -124,7 +128,8 @@ class GenericOAuth2ResourceOwnerTest extends \PHPUnit_Framework_Testcase
     {
         $this->mockBuzz('invalid');
         $request = new Request(array('code' => 'code'));
-        $accessToken = $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
+
+        $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
     }
 
     /**
@@ -134,7 +139,8 @@ class GenericOAuth2ResourceOwnerTest extends \PHPUnit_Framework_Testcase
     {
         $this->mockBuzz('error=foo');
         $request = new Request(array('code' => 'code'));
-        $accessToken = $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
+
+        $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
     }
 
     public function testGetSetName()
@@ -151,10 +157,14 @@ class GenericOAuth2ResourceOwnerTest extends \PHPUnit_Framework_Testcase
         $resourceOwner = $this->createResourceOwner($options, 'oauth2');
 
         $this->mockBuzz();
+        /**
+         * @var $userResponse \HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse
+         */
         $userResponse = $resourceOwner->getUserInformation('access_token');
 
         $this->assertInstanceOf($options['user_response_class'], $userResponse);
-        $this->assertEquals('foo', $userResponse->getUsername());
+        $this->assertEquals('foo666', $userResponse->getUsername());
+        $this->assertEquals('foo', $userResponse->getNickname());
     }
 
     protected function mockBuzz($response = '', $contentType = 'text/plain')

--- a/Tests/OAuth/ResourceOwner/GitHubResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GitHubResourceOwnerTest.php
@@ -18,14 +18,15 @@ class GitHubResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
     protected $userResponse = '{"login": "bar"}';
 
-    public function setup()
+    public function setUp()
     {
         $this->resourceOwner = $this->createResourceOwner($this->getDefaultOptions(), 'oauth2');
     }
 
     protected function getDefaultOptions()
     {
-        return array('client_id' => 'clientid',
+        return array(
+            'client_id'     => 'clientid',
             'client_secret' => 'clientsecret',
         );
     }

--- a/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
@@ -19,14 +19,15 @@ class GoogleResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
     protected $userResponse = '{"id": "bar"}';
 
-    public function setup()
+    public function setUp()
     {
         $this->resourceOwner = $this->createResourceOwner($this->getDefaultOptions(), 'oauth2');
     }
 
     protected function getDefaultOptions()
     {
-        return array('client_id' => 'clientid',
+        return array(
+            'client_id'     => 'clientid',
             'client_secret' => 'clientsecret',
         );
     }
@@ -69,6 +70,7 @@ class GoogleResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
     {
         $this->mockBuzz('{"error": "foo"}');
         $request = new Request(array('code' => 'code'));
-        $accessToken = $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
+
+        $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
     }
 }

--- a/Tests/OAuth/ResourceOwner/LinkedinResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/LinkedinResourceOwnerTest.php
@@ -18,14 +18,15 @@ class LinkedinResourceOwnerTest extends GenericOAuth1ResourceOwnerTest
 {
     protected $userResponse = '{"id": "bar"}';
 
-    public function setup()
+    public function setUp()
     {
         $this->resourceOwner = $this->createResourceOwner($this->getDefaultOptions(), 'oauth1');
     }
 
     protected function getDefaultOptions()
     {
-        return array('client_id' => 'clientid',
+        return array(
+            'client_id' => 'clientid',
             'client_secret' => 'clientsecret',
         );
     }

--- a/Tests/OAuth/ResourceOwner/VkontakteResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/VkontakteResourceOwnerTest.php
@@ -18,14 +18,15 @@ class VkontakteResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
     protected $userResponse = '{"id": "bar"}';
 
-    public function setup()
+    public function setUp()
     {
         $this->resourceOwner = $this->createResourceOwner($this->getDefaultOptions(), 'oauth2');
     }
 
     protected function getDefaultOptions()
     {
-        return array('client_id' => 'clientid',
+        return array(
+            'client_id'     => 'clientid',
             'client_secret' => 'clientsecret',
         );
     }

--- a/Tests/OAuth/ResourceOwner/WindowsLiveResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/WindowsLiveResourceOwnerTest.php
@@ -19,14 +19,15 @@ class WindowsLiveResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
     protected $userResponse = '{"id": "bar"}';
 
-    public function setup()
+    public function setUp()
     {
         $this->resourceOwner = $this->createResourceOwner($this->getDefaultOptions(), 'oauth2');
     }
 
     protected function getDefaultOptions()
     {
-        return array('client_id' => 'clientid',
+        return array(
+            'client_id'     => 'clientid',
             'client_secret' => 'clientsecret',
         );
     }
@@ -69,6 +70,7 @@ class WindowsLiveResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
     {
         $this->mockBuzz('{"error": "foo"}');
         $request = new Request(array('code' => 'code'));
-        $accessToken = $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
+
+        $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
     }
 }

--- a/Tests/OAuth/Response/AdvancedPathUserResponseTest.php
+++ b/Tests/OAuth/Response/AdvancedPathUserResponseTest.php
@@ -15,9 +15,9 @@ use HWI\Bundle\OAuthBundle\OAuth\Response\AdvancedPathUserResponse;
 
 class AdvancedPathUserResponseTest extends PathUserResponseTest
 {
-    public function setup()
+    public function setUp()
     {
-        $this->responseObject = new AdvancedPathUserResponse;
+        $this->responseObject = new AdvancedPathUserResponse();
     }
 
     public function testGetEmail()

--- a/Tests/OAuth/Response/PathUserResponseTest.php
+++ b/Tests/OAuth/Response/PathUserResponseTest.php
@@ -15,11 +15,14 @@ use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
 
 class PathUserResponseTest extends \PHPUnit_Framework_Testcase
 {
+    /**
+     * @var PathUserResponse
+     */
     protected $responseObject;
 
-    public function setup()
+    public function setUp()
     {
-        $this->responseObject = new PathUserResponse;
+        $this->responseObject = new PathUserResponse();
     }
 
     public function testGetSetResponse()
@@ -36,7 +39,9 @@ class PathUserResponseTest extends \PHPUnit_Framework_Testcase
     public function testSetInvalidResponse()
     {
         $this->responseObject->setResponse('not_json');
-        $this->assertEquals($response, $this->responseObject->getResponse());
+
+        // should throw exception
+        $this->responseObject->getResponse();
     }
 
     public function testGetSetResourceOwner()
@@ -59,48 +64,58 @@ class PathUserResponseTest extends \PHPUnit_Framework_Testcase
     public function testGetUsername()
     {
         // easy path
-        $paths = array('username' => 'foo');
+        $paths = array('identifier' => 'id');
+        $this->responseObject->setPaths($paths);
+        $this->responseObject->setResponse(json_encode(array('id' => 666)));
+
+        $this->assertEquals(666, $this->responseObject->getUsername());
+    }
+
+    public function testGetNickname()
+    {
+        // easy path
+        $paths = array('nickname' => 'foo');
         $this->responseObject->setPaths($paths);
         $this->responseObject->setResponse(json_encode(array('foo' => 'bar')));
 
-        $this->assertEquals('bar', $this->responseObject->getUsername());
+        $this->assertEquals('bar', $this->responseObject->getNickname());
 
         // nesting
-        $paths = array('username' => 'foo.bar');
+        $paths = array('nickname' => 'foo.bar');
         $this->responseObject->setPaths($paths);
         $this->responseObject->setResponse(json_encode(array('foo' => array('bar' => 'qux'))));
 
-        $this->assertEquals('qux', $this->responseObject->getUsername());
+        $this->assertEquals('qux', $this->responseObject->getNickname());
     }
 
-    public function testGetDisplayName()
+    public function testGetRealName()
     {
         // easy path
-        $paths = array('displayname' => 'foo');
+        $paths = array('realname' => 'foo');
         $this->responseObject->setPaths($paths);
         $this->responseObject->setResponse(json_encode(array('foo' => 'bar')));
 
-        $this->assertEquals('bar', $this->responseObject->getDisplayName());
+        $this->assertEquals('bar', $this->responseObject->getRealName());
     }
 
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
      */
-    public function testGetUsernameInvalidPath()
+    public function testGetDisplayNameInvalidPath()
     {
         // easy path
-        $paths = array('username' => 'non_existing');
+        $paths = array('nickname' => 'non_existing');
         $this->responseObject->setPaths($paths);
         $this->responseObject->setResponse(json_encode(array('foo' => 'bar')));
 
         // should throw exception
-        $this->responseObject->getUsername();
+        $this->responseObject->getNickname();
     }
 
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
      */
-    public function testNoUsernamePath()
+    public function testNoDisplayNamePath()
     {
         // easy path
         $paths = array('non_username' => 'non_existing');
@@ -108,6 +123,6 @@ class PathUserResponseTest extends \PHPUnit_Framework_Testcase
         $this->responseObject->setResponse(json_encode(array('foo' => 'bar')));
 
         // should throw exception
-        $this->responseObject->getUsername();
+        $this->responseObject->getNickname();
     }
 }

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -22,42 +22,6 @@ use HWI\Bundle\OAuthBundle\Tests\Fixtures\OAuthAwareException;
 
 class OAuthProviderTest extends \PHPUnit_Framework_Testcase
 {
-    protected function getOAuthAwareUserProviderMock()
-    {
-        return $this->getMockBuilder('\HWI\Bundle\OAuthBundle\Security\Core\User\OAuthAwareUserProviderInterface')
-            ->getMock();
-    }
-
-    protected function getResourceOwnerMapMock()
-    {
-        return $this->getMockBuilder('\HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap')
-            ->disableOriginalConstructor()->getMock();
-    }
-
-    protected function getOAuthTokenMock()
-    {
-        return $this->getMockBuilder('\HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken')
-            ->disableOriginalConstructor()->getMock();
-    }
-
-    protected function getResourceOwnerMock()
-    {
-        return $this->getMockBuilder('\HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface')
-            ->getMock();
-    }
-
-    protected function getUserResponseMock()
-    {
-        return $this->getMockBuilder('\HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface')
-            ->getMock();
-    }
-
-    protected function getUserMock()
-    {
-        return $this->getMockBuilder('\Symfony\Component\Security\Core\User\UserInterface')
-            ->getMock();
-    }
-
     public function testSupportsOAuthToken()
     {
         $oauthProvider = new OAuthProvider($this->getOAuthAwareUserProviderMock(), $this->getResourceOwnerMapMock());
@@ -139,7 +103,8 @@ class OAuthProviderTest extends \PHPUnit_Framework_Testcase
         $oauthProvider = new OAuthProvider($userProviderMock, $resourceOwnerMapMock);
 
         try {
-            $token = $oauthProvider->authenticate($oauthTokenMock);
+            $oauthProvider->authenticate($oauthTokenMock);
+
             $this->assertTrue(false, "Exception was not thrown.");
         } catch(OAuthAwareException $e) {
             $this->assertTrue(true, "Exception was thrown.");
@@ -147,5 +112,41 @@ class OAuthProviderTest extends \PHPUnit_Framework_Testcase
             $this->assertEquals('github', $e->getResourceOwnerName());
             $this->assertEquals('creds', $e->getAccessToken());
         }
+    }
+
+    protected function getOAuthAwareUserProviderMock()
+    {
+        return $this->getMockBuilder('\HWI\Bundle\OAuthBundle\Security\Core\User\OAuthAwareUserProviderInterface')
+            ->getMock();
+    }
+
+    protected function getResourceOwnerMapMock()
+    {
+        return $this->getMockBuilder('\HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap')
+            ->disableOriginalConstructor()->getMock();
+    }
+
+    protected function getOAuthTokenMock()
+    {
+        return $this->getMockBuilder('\HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken')
+            ->disableOriginalConstructor()->getMock();
+    }
+
+    protected function getResourceOwnerMock()
+    {
+        return $this->getMockBuilder('\HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface')
+            ->getMock();
+    }
+
+    protected function getUserResponseMock()
+    {
+        return $this->getMockBuilder('\HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface')
+            ->getMock();
+    }
+
+    protected function getUserMock()
+    {
+        return $this->getMockBuilder('\Symfony\Component\Security\Core\User\UserInterface')
+            ->getMock();
     }
 }

--- a/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
+++ b/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
@@ -15,8 +15,12 @@ use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 
 class OAuthTokenTest extends \PHPUnit_Framework_Testcase
 {
+    /**
+     * @var OAuthToken
+     */
     protected $token;
-    public function setup()
+
+    public function setUp()
     {
         $this->token = new OAuthToken('access_token', array('ROLE_TEST'));
         $this->token->setResourceOwnerName('github');
@@ -40,6 +44,9 @@ class OAuthTokenTest extends \PHPUnit_Framework_Testcase
 
     public function testSerialization()
     {
+        /**
+         * @var $token OAuthToken
+         */
         $token = unserialize(serialize($this->token));
 
         $this->assertEquals('access_token', $token->getAccessToken());

--- a/Tests/Security/Core/User/EntityUserProviderTest.php
+++ b/Tests/Security/Core/User/EntityUserProviderTest.php
@@ -24,7 +24,7 @@ class EntityUserProviderTest extends \PHPUnit_Framework_Testcase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage No property defined for entity for resource owner 'not_configured'.
      */
     public function testLoadUserByOAuthuserResponseThrowsExceptionWhenNoPropertyIsConfigured()
@@ -34,7 +34,7 @@ class EntityUserProviderTest extends \PHPUnit_Framework_Testcase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage User 'asm89' not found.
      */
     public function testLoadUserByOAuthuserResponseThrowsExceptionWhenUserIsNull()
@@ -50,7 +50,7 @@ class EntityUserProviderTest extends \PHPUnit_Framework_Testcase
     {
         $userResponseMock = $this->createUserResponseMock('asm89', 'github');
 
-        $user = new User;
+        $user = new User();
         $provider = $this->createEntityUserProvider($user);
 
         $loadedUser = $provider->loadUserByOAuthUserResponse($userResponseMock);
@@ -79,6 +79,22 @@ class EntityUserProviderTest extends \PHPUnit_Framework_Testcase
         return $registryMock;
     }
 
+    public function createRepositoryMock($user = false)
+    {
+        $mock = $this->getMockBuilder('Doctrine\ORM\EntityRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        if (false !== $user) {
+            $mock->expects($this->once())
+                ->method('findOneBy')
+                ->with(array('githubId' => 'asm89'))
+                ->will($this->returnValue($user));
+        }
+
+        return $mock;
+    }
+
     protected function createResourceOwnerMock($resourceOwnerName = null)
     {
         $resourceOwnerMock = $this->getMockBuilder('HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface')
@@ -103,25 +119,9 @@ class EntityUserProviderTest extends \PHPUnit_Framework_Testcase
         $emMock
             ->expects($this->once())
             ->method('getRepository')
-            ->will($this->returnValue($this->createReposityMock($user)));
+            ->will($this->returnValue($this->createRepositoryMock($user)));
 
         return $emMock;
-    }
-
-    public function createReposityMock($user = false)
-    {
-        $mock = $this->getMockBuilder('Doctrine\ORM\EntityRepository')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        if (false !== $user) {
-            $mock->expects($this->once())
-                ->method('findOneBy')
-                ->with(array('githubId' => 'asm89'))
-                ->will($this->returnValue($user));
-        }
-
-        return $mock;
     }
 
     protected function createUserResponseMock($username = null, $resourceOwnerName = null)

--- a/Tests/Security/Core/User/FOSUBUserProviderTest.php
+++ b/Tests/Security/Core/User/FOSUBUserProviderTest.php
@@ -24,7 +24,7 @@ class FOSUBUserProviderTest extends \PHPUnit_Framework_Testcase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage No property defined for entity for resource owner 'not_configured'.
      */
     public function testLoadUserByOAuthuserResponseThrowsExceptionWhenNoPropertyIsConfigured()
@@ -34,7 +34,7 @@ class FOSUBUserProviderTest extends \PHPUnit_Framework_Testcase
     }
 
     /**
-     * @expectedException HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException
      * @expectedExceptionMessage User 'asm89' not found.
      */
     public function testLoadUserByOAuthuserResponseThrowsExceptionWhenUserIsNull()
@@ -50,7 +50,7 @@ class FOSUBUserProviderTest extends \PHPUnit_Framework_Testcase
     {
         $userResponseMock = $this->createUserResponseMock('asm89', 'github');
 
-        $user = new User;
+        $user = new User();
         $provider = $this->createFOSUBUserProvider($user);
 
         $loadedUser = $provider->loadUserByOAuthUserResponse($userResponseMock);
@@ -60,7 +60,7 @@ class FOSUBUserProviderTest extends \PHPUnit_Framework_Testcase
 
     public function testConnectUser()
     {
-        $user = new User;
+        $user = new User();
 
         $userResponseMock = $this->createUserResponseMock('asm89', 'github');
         $provider = $this->createFOSUBUserProvider(false, $user);
@@ -71,12 +71,12 @@ class FOSUBUserProviderTest extends \PHPUnit_Framework_Testcase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage Class 'HWI\Bundle\OAuthBundle\Tests\Fixtures\User' should have a method 'setGoogleId'.
      */
     public function testConnectUserWithNoSetterThrowsException()
     {
-        $user = new User;
+        $user = new User();
 
         $userResponseMock = $this->createUserResponseMock(null, 'google');
         $provider = $this->createFOSUBUserProvider();

--- a/Tests/Security/Core/User/OAuthUserProviderTest.php
+++ b/Tests/Security/Core/User/OAuthUserProviderTest.php
@@ -17,18 +17,21 @@ use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser,
 
 class OAuthUserProviderTest extends \PHPUnit_Framework_Testcase
 {
+    /**
+     * @var OAuthUserProvider
+     */
     protected $provider;
 
-    public function setup()
+    public function setUp()
     {
-        $this->provider = new OAuthUserProvider;
+        $this->provider = new OAuthUserProvider();
     }
 
     public function testLoadUserByUsername()
     {
         $user = $this->provider->loadUserByUsername('asm89');
         $this->assertInstanceOf('\HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser', $user);
-        $this->assertEquals('asm89', $user->getUserName());
+        $this->assertEquals('asm89', $user->getUsername());
     }
 
     public function testRefreshUser()
@@ -40,7 +43,7 @@ class OAuthUserProviderTest extends \PHPUnit_Framework_Testcase
     }
 
     /**
-     * @expectedException Symfony\Component\Security\Core\Exception\UnsupportedUserException
+     * @expectedException \Symfony\Component\Security\Core\Exception\UnsupportedUserException
      * @expectedExceptionMessage Unsupported user class "Symfony\Component\Security\Core\User\User"
      */
     public function testRefreshUserUnsupportedClass()
@@ -70,6 +73,6 @@ class OAuthUserProviderTest extends \PHPUnit_Framework_Testcase
 
         $user = $this->provider->loadUserByOAuthUserResponse($responseMock);
         $this->assertInstanceOf('\HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser', $user);
-        $this->assertEquals('asm89', $user->getUserName());
+        $this->assertEquals('asm89', $user->getUsername());
     }
 }

--- a/Tests/Security/Core/User/OAuthUserTest.php
+++ b/Tests/Security/Core/User/OAuthUserTest.php
@@ -43,6 +43,9 @@ class OAuthUserTest extends \PHPUnit_Framework_Testcase
     public function testGetUsername()
     {
         $this->assertEquals('asm89', $this->user->getUsername());
+
+        $user = new OAuthUser('other');
+        $this->assertEquals('other', $user->getUsername());
     }
 
     public function testEraseCredentials()
@@ -52,10 +55,10 @@ class OAuthUserTest extends \PHPUnit_Framework_Testcase
 
     public function testEquals()
     {
-        $user = new OAuthUser('other');
-        $user2 = new OAuthUser('asm89');
+        $otherUser = new OAuthUser('other');
+        $sameUser  = new OAuthUser('asm89');
 
-        $this->assertFalse($this->user->equals($user));
-        $this->assertTrue($this->user->equals($user2));
+        $this->assertFalse($this->user->equals($otherUser));
+        $this->assertTrue($this->user->equals($sameUser));
     }
 }


### PR DESCRIPTION
Changes:
- Added `UserResponseInterface#getRealName()` method, also new default path `realname`
  was added, this path holds real name of user
- Added new path `uuid` that now hold an unique user identifier
- [BC break] Method `UserResponseInterface#getUsername()` now always returns an real
  unique user identifier, an uses path `uuid`
- [BC break] Path `username` no longer holds an unique user identifier
- [BC break] `OAuth1RequestTokenStorageInterface#save()` second param `$token` now
  must be an array

This PR is an replacement for #103.

As those changes are quite big, I would think also about renaming of `profilepicture` to `avatar` / `picture` or so.

Also this is more like PoV than totally working solution, but I would like to know what you think about this @asm89.
