### PR TITLE
linkedin scope option

### DIFF
--- a/OAuth/ResourceOwner/LinkedinResourceOwner.php
+++ b/OAuth/ResourceOwner/LinkedinResourceOwner.php
@@ -28,7 +28,6 @@ class LinkedinResourceOwner extends GenericOAuth1ResourceOwner
         'infos_url'           => 'http://api.linkedin.com/v1/people/~:(id,formatted-name)',
         'user_response_class' => '\HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse',
         'realm'               => 'http://api.linkedin.com',
-        // e.g. r_emailaddress (see https://developer.linkedin.com/documents/profile-fields)
         'scope'               => null
     );
 

--- a/Resources/doc/2x-linkedin.md
+++ b/Resources/doc/2x-linkedin.md
@@ -4,7 +4,9 @@ First you will have to register your application on Linkedin. Check out the
 documentation for more information: https://developer.linkedin.com/documents/authentication.
 
 Next configure a resource owner of type `linkedin` with appropriate `client_id`,
-`client_secret`.
+`client_secret` and `scope`.
+Example of values for scope: `r_basicprofile`, `r_emailaddress`, `r_fullprofile` 
+as described by [Linkedin API](https://developer.linkedin.com/documents/profile-fields)
 
 ``` yaml
 # app/config.yml
@@ -15,6 +17,7 @@ hwi_oauth:
             type:                linkedin
             client_id:           <client_id>
             client_secret:       <client_secret>
+            scope: <scope>
 ```
 
 When you're done. Continue by configuring the security layer or go back to


### PR DESCRIPTION
Linkedin supports the scope when requesting the token (e.g. permissions to get email address)

https://developer.linkedin.com/documents/authentication#granting

Passing the scope via URL did not work. 
It seems the scope should be passed as an argument to getRequestToken()

I've implemented it on the linkedin class. 
If some other oauth1 providers need a similar option, this logic can be moved to the parent class.
