### PR TITLE
Do not insert a comma after the Authorization header for OAuth1.0 Resource Owners

### DIFF
--- a/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -198,9 +198,17 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
             $authorization = 'Authorization: OAuth realm="' . rawurlencode($this->getOption('realm')) . '"';
         }
 
+        $authorization .= ' ';
+
+        $parameter_count = count($parameters);
+        $i = 0;
         foreach ($parameters as $key => $value) {
             $value = rawurlencode($value);
-            $authorization .= ", $key=\"$value\"";
+
+            $authorization .= "$key=\"$value\"";
+            if (++$i !== $parameter_count) {
+                $authorization .= ", ";
+            }
         }
 
         $headers[] = $authorization;


### PR DESCRIPTION
[According to the OAuth1.0 standard](http://oauth.net/core/1.0/#auth_header) there should be no comma after `Authorization: OAuth` in the Authorization header. This is not stated specifically in the standard but the example it provides says so:

```
Authorization: OAuth realm="http://sp.example.com/",
oauth_consumer_key="0685bd9184jfhq22",
...
```

Currently there is a comma after `Authorization: OAuth`:

```
Authorization: OAuth, realm="http://sp.example.com/",
oauth_consumer_key="0685bd9184jfhq22",
...
```

This comma breaks Google's implementation of OAuth 1.0, which returns the following error:

```
parameter_absent
oauth_parameters_absent:oauth_consumer_key&oauth_signature_method&
oauth_signature&oauth_timestamp&oauth_nonce&scope
```

This PR fixes this issue.
