### PR TITLE
- Changed dependency on kriswallsmith/buzz to 0.7 or later

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php":                ">=5.3.2",
         "symfony/framework-bundle": ">=2.0,<2.2-dev",
         "symfony/security-bundle": ">=2.0,<2.2-dev",
-        "kriswallsmith/buzz": "0.7"
+        "kriswallsmith/buzz": ">=0.7"
     },
 
     "require-dev": {


### PR DESCRIPTION
Please change the dependency version. It's a bad idea to require a specific version as other bundles are referencing kriswallsmith/buzz, too. Some of them require dev-master, which is incompatible with 0.7. Composer will report errors, so you can't even install the bundles. Depending on 0.7 or later should be fine.
