### PR TITLE
Correct casing of PHPUnit_Framework_Testcase to PHPUnit_Framework_TestCase

### DIFF
--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -15,7 +15,7 @@ use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth1ResourceOwner;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpFoundation\Request;
 
-class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_Testcase
+class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var GenericOAuth1ResourceOwner

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -15,7 +15,7 @@ use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpFoundation\Request;
 
-class GenericOAuth2ResourceOwnerTest extends \PHPUnit_Framework_Testcase
+class GenericOAuth2ResourceOwnerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var GenericOAuth2ResourceOwner

--- a/Tests/OAuth/ResourceOwner/SensioConnectResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/SensioConnectResourceOwnerTest.php
@@ -13,7 +13,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SensioConnectResourceOwner;
 
-class SensioConnectResourceOwnerTest extends \PHPUnit_Framework_Testcase
+class SensioConnectResourceOwnerTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {

--- a/Tests/OAuth/Response/PathUserResponseTest.php
+++ b/Tests/OAuth/Response/PathUserResponseTest.php
@@ -13,7 +13,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\OAuth\Response;
 
 use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
 
-class PathUserResponseTest extends \PHPUnit_Framework_Testcase
+class PathUserResponseTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var PathUserResponse

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -20,7 +20,7 @@ use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken,
 
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\OAuthAwareException;
 
-class OAuthProviderTest extends \PHPUnit_Framework_Testcase
+class OAuthProviderTest extends \PHPUnit_Framework_TestCase
 {
     public function testSupportsOAuthToken()
     {

--- a/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
+++ b/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
@@ -13,7 +13,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\Security\Core\Authentication\Token;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 
-class OAuthTokenTest extends \PHPUnit_Framework_Testcase
+class OAuthTokenTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var OAuthToken

--- a/Tests/Security/Core/User/EntityUserProviderTest.php
+++ b/Tests/Security/Core/User/EntityUserProviderTest.php
@@ -14,7 +14,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\Security\Core\User;
 use HWI\Bundle\OAuthBundle\Security\Core\User\EntityUserProvider,
     HWI\Bundle\OAuthBundle\Tests\Fixtures\User;
 
-class EntityUserProviderTest extends \PHPUnit_Framework_Testcase
+class EntityUserProviderTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {

--- a/Tests/Security/Core/User/FOSUBUserProviderTest.php
+++ b/Tests/Security/Core/User/FOSUBUserProviderTest.php
@@ -14,7 +14,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\Security\Core\User;
 use HWI\Bundle\OAuthBundle\Security\Core\User\FOSUBUserProvider,
     HWI\Bundle\OAuthBundle\Tests\Fixtures\User;
 
-class FOSUBUserProviderTest extends \PHPUnit_Framework_Testcase
+class FOSUBUserProviderTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {

--- a/Tests/Security/Core/User/OAuthUserProviderTest.php
+++ b/Tests/Security/Core/User/OAuthUserProviderTest.php
@@ -15,7 +15,7 @@ use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser,
     HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUserProvider,
     Symfony\Component\Security\Core\User\User;
 
-class OAuthUserProviderTest extends \PHPUnit_Framework_Testcase
+class OAuthUserProviderTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var OAuthUserProvider

--- a/Tests/Security/Core/User/OAuthUserTest.php
+++ b/Tests/Security/Core/User/OAuthUserTest.php
@@ -13,7 +13,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\Security\Core\User;
 
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser;
 
-class OAuthUserTest extends \PHPUnit_Framework_Testcase
+class OAuthUserTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var OAuthUser


### PR DESCRIPTION
Correct casing of PHPUnit_Framework_Testcase to PHPUnit_Framework_TestCase so that autoloading works on case sensitive filesystems.
