### PR TITLE
Compatibility with OAuth 1.0 Server (new version)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type":        "symfony-bundle",
     "description": "Support for authenticating users via oauth in Symfony2.",
     "keywords":    ["security", "firewall", "oauth", "facebook", "oauth2", "github", "google", "windows live", "vkontakte", "oauth1", "twitter", "linkedin", "sensio connect"],
-    "homepage":    "http://github.com/VincentCasse/HWIOAuthBundle",
+    "homepage":    "http://github.com/hwi/HWIOAuthBundle",
     "license":     "MIT",
 
     "authors": [


### PR DESCRIPTION
Delete the first coma in HTTP header for OAuth1.0
