### PR TITLE
Enable support for FOSUserBundle 1.x and 2.x

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -74,6 +74,8 @@ class ConnectController extends ContainerAware
      * @param Request $request A request.
      * @param string  $key     Key used for retrieving the right information for the registration form.
      *
+     * @throws \Exception
+     *
      * @return Response
      */
     public function registrationAction(Request $request, $key)
@@ -93,7 +95,12 @@ class ConnectController extends ContainerAware
         $userInformation = $this->getResourceOwnerByName($error->getResourceOwnerName())
             ->getUserInformation($error->getAccessToken());
 
-        $form = $this->container->get('hwi_oauth.registration.form');
+        if ($this->container->has('hwi_oauth.registration.form')) {
+            $form = $this->container->get('hwi_oauth.registration.form');
+        } else {
+            $form = $this->container->get('hwi_oauth.registration.form.factory')->createForm();
+        }
+
         $formHandler = $this->container->get('hwi_oauth.registration.form.handler');
         if ($formHandler->process($request, $form, $userInformation)) {
             $this->container->get('hwi_oauth.account.connector')->connect($form->getData(), $userInformation);

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -81,7 +81,13 @@ class HWIOAuthExtension extends Extension
                     ->setScope('request');
 
                 $container->setAlias('hwi_oauth.registration.form.handler', 'hwi_oauth.registration.form.handler.fosub_bridge');
-                $container->setAlias('hwi_oauth.registration.form', 'fos_user.registration.form');
+
+                // enable compatibility with FOSUserBundle 1.3.x and 2.x
+                if (interface_exists('FOS\UserBundle\Form\Factory\FactoryInterface')) {
+                    $container->setAlias('hwi_oauth.registration.form.factory', 'fos_user.registration.form.factory');
+                } else {
+                    $container->setAlias('hwi_oauth.registration.form', 'fos_user.registration.form');
+                }
             }
 
             foreach ($config['connect'] as $key => $serviceId) {

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -59,10 +59,12 @@
             <argument type="service" id="fos_user.user_manager" />
         </service>
         <service id="hwi_oauth.registration.form.handler.fosub_bridge.def" class="%hwi_oauth.registration.form.handler.fosub_bridge.class%" abstract="true">
-            <argument type="service" id="fos_user.registration.form.handler" />
             <argument type="service" id="fos_user.user_manager" />
             <argument type="service" id="fos_user.mailer" />
             <argument type="service" id="fos_user.util.token_generator" on-invalid="null"/>
+            <call method="setFormHandler">
+                <argument type="service" id="fos_user.registration.form.handler" on-invalid="null" />
+            </call>
         </service>
 
         <!-- Session storage -->


### PR DESCRIPTION
This PR is an attempt to make HWIOAuthBundle compatible with FOSUserBundle 1.3 and 2.0. This is based on [#163](https://github.com/hwi/HWIOAuthBundle/pull/163). There are still some obstacles like the dynamically setting the alias which doesn't yet work.

Any suggestion is appreciated.
