### PR TITLE
Fix configuration to allow "realm" parameter for oauth1

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -149,6 +149,14 @@ class Configuration implements ConfigurationInterface
                                 ->thenUnset()
                             ->end()
                         ->end()
+                        ->scalarNode('realm')
+                            ->validate()
+                                ->ifTrue(function($v) {
+                                    return empty($v);
+                                })
+                                ->thenUnset()
+                            ->end()
+                        ->end()
                         ->scalarNode('scope')
                         ->end()
                         ->scalarNode('user_response_class')


### PR DESCRIPTION
When using oauth1 as described in the documentation, setting the "realm" parameter results in :

[Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]  
  Unrecognized options "realm" under "hwi_oauth.resource_owners.oauth1"
