### PR TITLE
For in memory provider use clean nickname not resource identifiers

### DIFF
--- a/Security/Core/User/OAuthUserProvider.php
+++ b/Security/Core/User/OAuthUserProvider.php
@@ -39,7 +39,7 @@ class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProvider
      */
     public function loadUserByOAuthUserResponse(UserResponseInterface $response)
     {
-        return $this->loadUserByUsername($response->getUsername());
+        return $this->loadUserByUsername($response->getNickname());
     }
 
     /**

--- a/Tests/Security/Core/User/OAuthUserProviderTest.php
+++ b/Tests/Security/Core/User/OAuthUserProviderTest.php
@@ -68,8 +68,9 @@ class OAuthUserProviderTest extends \PHPUnit_Framework_TestCase
 
         $responseMock
             ->expects($this->once())
-            ->method('getUsername')
-            ->will($this->returnValue('asm89'));
+            ->method('getNickname')
+            ->will($this->returnValue('asm89'))
+        ;
 
         $user = $this->provider->loadUserByOAuthUserResponse($responseMock);
         $this->assertInstanceOf('\HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser', $user);


### PR DESCRIPTION
For in memory provider use clean nickname not resource identifiers i.e.:

```
# google - actual
Welcome 4545666121!
# google - mine
Welcome stloyd!
```
