### PR TITLE
Check profilePicture exists before using it.

### DIFF
--- a/Resources/views/Connect/connect_confirm.html.twig
+++ b/Resources/views/Connect/connect_confirm.html.twig
@@ -16,7 +16,7 @@
             </p>
         </div>
         <div class="span6">
-            {% if userInformation.profilePicture is not empty %}
+            {% if userInformation.profilePicture is defined and userInformation.profilePicture is not empty %}
                 <img src="{{ userInformation.profilePicture }}" />
             {% endif %}
         </div>


### PR DESCRIPTION
Hi, just made a small change to the connect confirmation template to check that profilePicture exists. If RecourceOwner didn't have it mapped in the paths it created a Twig error.
