### PR TITLE
Avoid AlreadyBoundException

### DIFF
--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -67,7 +67,7 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
             $processed = $formHandler->process();
 
             // if the form is not posted we'll try to set some properties
-            if ('POST' === $request->getMethod()) {
+            if ('POST' !== $request->getMethod()) {
                 $user = $this->setUserInformation($form->getData(), $userInformation);
 
                 $form->setData($user);


### PR DESCRIPTION
The registration process throws an `AlreadyBoundException`, this should fix it (source: https://github.com/hwi/HWIOAuthBundle/commit/765eeac5923f36e6f63403295fe32c978b0580db#L2R70).
