### PR TITLE
Fixes a small bug in config validation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -267,7 +267,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->validate()
                         ->ifTrue(function($c) {
-                            return isset($c['service']) && 1 !== count($c);
+                            return isset($c['service']) && 2 < count($c);
                         })
                         ->thenInvalid("If you're setting a service, no other arguments should be set.")
                     ->end()


### PR DESCRIPTION
It seems `$c['paths']` is always populated as an empty array at the point of validation even if it's not set in configuration so the minimum acceptable size for the array $c should be 2.
