### PR TITLE
hotfix - facebook - error field incompatibility

### DIFF
--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -46,13 +46,4 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
     {
         $this->options['scope'] = str_replace(',', ' ', $this->options['scope']);
     }
-
-    /**
-     * Facebook unfortunately breaks the spec by sending an array instead of a string
-     * as an error.
-     */
-    protected function getErrorMessage($error)
-    {
-        return parent::getErrorMessage($error['message']);
-    }
 }

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -77,7 +77,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
         $response = $this->getResponseContent($response);
 
         if (isset($response['error'])) {
-            throw new AuthenticationException($this->getErrorMessage($response['error']));
+            throw new AuthenticationException(sprintf('OAuth error: "%s"', isset($response['error']['message']) ? $response['error']['message'] : $response['error']));
         }
 
         if (!isset($response['access_token'])) {
@@ -109,16 +109,5 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
     protected function doGetUserInformationRequest($url, array $parameters = array())
     {
         return $this->httpRequest($url);
-    }
-
-    /**
-     * Creates error message.
-     *
-     * @param mixed $error
-     * @return string
-     */
-    protected function getErrorMessage($error)
-    {
-        return sprintf('OAuth error: "%s"', $error);
     }
 }


### PR DESCRIPTION
While every other oAuth service provider sends a string as a error (if one arises during authentication), Facebook sends an array in form `{"message": "the error message", "type": "OAuthException", "code": 100}`. This caused the bundle to crash.
