### PR TITLE
Fixed registration form

### DIFF
--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -86,11 +86,7 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
                 $form->bindRequest($request);
             }
 
-            if ($form->isValid()) {
-                $this->setUserInformation($form->getData(), $userInformation);
-
-                return true;
-            }
+            return $form->isValid();
         }
 
         return false;


### PR DESCRIPTION
The registration form is broken since https://github.com/hwi/HWIOAuthBundle/commit/6bde3ebb9f815bb0aa3a3338c665e0e884b18032, it is not possible anymore to override the provided oauth username and email address.
