### PR TITLE
Prevent fatal error if access token data is array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+### 2013-05-06
+* Added `AbstractUserResponse::getOAuthToken()` method to allow fetching only OAuth token details
+
 ### 2013-03-26
 * Added support for a `target_path_parameter` in order to control the redirect path after login
 

--- a/OAuth/Response/AbstractUserResponse.php
+++ b/OAuth/Response/AbstractUserResponse.php
@@ -38,6 +38,11 @@ abstract class AbstractUserResponse implements UserResponseInterface
     protected $accessToken;
 
     /**
+     * @var string
+     */
+    protected $oauthToken;
+
+    /**
      * {@inheritdoc}
      */
     public function getAccessToken()
@@ -50,7 +55,19 @@ abstract class AbstractUserResponse implements UserResponseInterface
      */
     public function setAccessToken($accessToken)
     {
+        if (is_array($accessToken) && isset($accessToken['oauth_token'])) {
+            $this->oauthToken = $accessToken['oauth_token'];
+        }
+
         $this->accessToken = $accessToken;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getOAuthToken()
+    {
+        return $this->oauthToken ?: $this->accessToken;
     }
 
     /**
@@ -69,7 +86,7 @@ abstract class AbstractUserResponse implements UserResponseInterface
         $this->response = json_decode($response, true);
 
         if (JSON_ERROR_NONE !== json_last_error()) {
-            throw new AuthenticationException(sprintf('Not a valid JSON response.'));
+            throw new AuthenticationException('Not a valid JSON response.');
         }
     }
 

--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -87,6 +87,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('1', $userResponse->getUsername());
         $this->assertEquals('bar', $userResponse->getNickname());
         $this->assertEquals($accessToken, $userResponse->getAccessToken());
+        $this->assertEquals($accessToken['oauth_token'], $userResponse->getOAuthToken());
     }
 
     public function testGetAuthorizationUrlContainOAuthTokenAndSecret()

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -172,6 +172,8 @@ json;
         $this->assertInstanceOf($class, $userResponse);
         $this->assertEquals('foo666', $userResponse->getUsername());
         $this->assertEquals('foo', $userResponse->getNickname());
+        $this->assertEquals('access_token', $userResponse->getAccessToken());
+        $this->assertEquals('access_token', $userResponse->getOAuthToken());
     }
 
     public function buzzSendMock($request, $response)

--- a/Tests/OAuth/ResourceOwner/JiraResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/JiraResourceOwnerTest.php
@@ -43,6 +43,7 @@ class JiraResourceOwnerTest extends GenericOAuth1ResourceOwnerTest
         $this->assertEquals('asm89', $userResponse->getUsername());
         $this->assertEquals('asm89', $userResponse->getNickname());
         $this->assertEquals($accessToken, $userResponse->getAccessToken());
+        $this->assertEquals($accessToken['oauth_token'], $userResponse->getOAuthToken());
     }
 
     public function testCustomResponseClass()

--- a/Tests/OAuth/ResourceOwner/LinkedinResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/LinkedinResourceOwnerTest.php
@@ -22,6 +22,19 @@ class LinkedinResourceOwnerTest extends GenericOAuth1ResourceOwnerTest
         'realname'   => 'formattedName',
     );
 
+    public function testGetUserInformation()
+    {
+        $this->mockBuzz($this->userResponse, 'application/json; charset=utf-8');
+
+        $accessToken  = array('oauth_token' => 'token', 'oauth_token_secret' => 'secret', 'oauth_expires_in' => '5183997', 'oauth_authorization_expires_in' => '5183997');
+        $userResponse = $this->resourceOwner->getUserInformation($accessToken);
+
+        $this->assertEquals('1', $userResponse->getUsername());
+        $this->assertEquals('bar', $userResponse->getNickname());
+        $this->assertEquals($accessToken, $userResponse->getAccessToken());
+        $this->assertEquals($accessToken['oauth_token'], $userResponse->getOAuthToken());
+    }
+
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
         $options = array_merge(

--- a/Tests/OAuth/ResourceOwner/TwitterResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/TwitterResourceOwnerTest.php
@@ -27,6 +27,19 @@ json;
         'realname'   => 'name',
     );
 
+    public function testGetUserInformation()
+    {
+        $this->mockBuzz($this->userResponse, 'application/json; charset=utf-8');
+
+        $accessToken  = array('oauth_token' => 'token', 'oauth_token_secret' => 'secret', 'user_id' => '1', 'screen_name' => 'bar');
+        $userResponse = $this->resourceOwner->getUserInformation($accessToken);
+
+        $this->assertEquals('1', $userResponse->getUsername());
+        $this->assertEquals('bar', $userResponse->getNickname());
+        $this->assertEquals($accessToken, $userResponse->getAccessToken());
+        $this->assertEquals($accessToken['oauth_token'], $userResponse->getOAuthToken());
+    }
+
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
         $options = array_merge(

--- a/Tests/OAuth/ResourceOwner/YahooResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/YahooResourceOwnerTest.php
@@ -39,6 +39,7 @@ json;
         $this->assertEquals('1', $userResponse->getUsername());
         $this->assertEquals('bar', $userResponse->getNickname());
         $this->assertEquals($accessToken, $userResponse->getAccessToken());
+        $this->assertEquals($accessToken['oauth_token'], $userResponse->getOAuthToken());
     }
 
     public function testCustomResponseClass()


### PR DESCRIPTION
Fix #239, closes #240.

@asm89 This is bugfix, what do you think?
