### PR TITLE
[fix] Use parameters in doGetUserInformationRequest

### DIFF
--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -155,6 +155,6 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
      */
     protected function doGetUserInformationRequest($url, array $parameters = array())
     {
-        return $this->httpRequest($url);
+        return $this->httpRequest($url, http_build_query($parameters));
     }
 }


### PR DESCRIPTION
I think `$parameters` should be used probably :)
