### PR TITLE
Add `hd` parameter to GoogleResourceOwner

### DIFF
--- a/OAuth/ResourceOwner/GoogleResourceOwner.php
+++ b/OAuth/ResourceOwner/GoogleResourceOwner.php
@@ -35,6 +35,8 @@ class GoogleResourceOwner extends GenericOAuth2ResourceOwner
         'request_visible_actions' => null,
         // sometimes we need to force for approval prompt (e.g. when we lost refresh token)
         'approval_prompt'         => null,
+        // Identifying a particular hosted domain account to be accessed (for example, 'mycollege.edu')
+        'hd'                      => null,
     );
 
     /**
@@ -56,7 +58,8 @@ class GoogleResourceOwner extends GenericOAuth2ResourceOwner
         return parent::getAuthorizationUrl($redirectUri, array_merge(array(
             'access_type'             => $this->getOption('access_type'),
             'approval_prompt'         => $this->getOption('approval_prompt'),
-            'request_visible_actions' => $this->getOption('request_visible_actions')
+            'request_visible_actions' => $this->getOption('request_visible_actions'),
+            'hd'                      => $this->getOption('hd')
         ), $extraParameters));
     }
 

--- a/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
@@ -61,6 +61,15 @@ json;
         );
     }
 
+    public function testHdParameter()
+    {
+        $resourceOwner = $this->createResourceOwner('google', array('hd' => 'mycollege.edu'));
+        $this->assertEquals(
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&hd=mycollege.edu',
+            $resourceOwner->getAuthorizationUrl('http://redirect.to/')
+        );
+    }
+
     public function testRevokeToken()
     {
         $this->buzzResponseHttpCode = 200;


### PR DESCRIPTION
It allows "locking" to particular domains with user can sign-in.

Fix #216.
