### PR TITLE
fixed wrong access token URL for Amazon resource owner

### DIFF
--- a/OAuth/ResourceOwner/AmazonResourceOwner.php
+++ b/OAuth/ResourceOwner/AmazonResourceOwner.php
@@ -23,7 +23,7 @@ class AmazonResourceOwner extends GenericOAuth2ResourceOwner
      */
     protected $options = array(
         'authorization_url' => 'https://www.amazon.com/ap/oa',
-        'access_token_url'  => 'https://www.amazon.com/auth/o2/token',
+        'access_token_url'  => 'https://api.amazon.com/auth/o2/token',
         'infos_url'         => 'https://api.amazon.com/user/profile',
 
         'scope'             => 'profile',

--- a/Tests/OAuth/ResourceOwner/AmazonResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/AmazonResourceOwnerTest.php
@@ -35,7 +35,7 @@ json;
         $options = array_merge(
             array(
                  'authorization_url' => 'https://www.amazon.com/ap/oa',
-                 'access_token_url'  => 'https://www.amazon.com/auth/o2/token',
+                 'access_token_url'  => 'https://api.amazon.com/auth/o2/token',
                  'infos_url'         => 'https://api.amazon.com/user/profile',
 
                  'scope'             => 'profile',


### PR DESCRIPTION
URL was stated wrongly in Amazon's documentation
