### PR TITLE
Add json_decode for Content-Type: text/javascript responses

### DIFF
--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -237,7 +237,8 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      */
     protected function getResponseContent(HttpMessageInterface $rawResponse)
     {
-        if (false !== strpos($rawResponse->getHeader('Content-Type'), 'application/json')) {
+        $contentType = $rawResponse->getHeader('Content-Type');
+        if (false !== strpos($contentType, 'application/json') || false !== strpos($contentType, 'text/javascript')) {
             $response = json_decode($rawResponse->getContent(), true);
         } else {
             parse_str($rawResponse->getContent(), $response);

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -149,6 +149,30 @@ json;
         );
     }
 
+    public function testGetAccessTokenTextJavascriptResponse()
+    {
+        $this->mockBuzz('{"access_token": "code"}', 'text/javascript');
+
+        $request = new Request(array('code' => 'somecode'));
+
+        $this->assertEquals(
+            array('access_token' => 'code'),
+            $this->resourceOwner->getAccessToken($request, 'http://redirect.to/')
+        );
+    }
+
+    public function testGetAccessTokenTextJavascriptCharsetResponse()
+    {
+        $this->mockBuzz('{"access_token": "code"}', 'text/javascript; charset=utf-8');
+
+        $request = new Request(array('code' => 'somecode'));
+
+        $this->assertEquals(
+            array('access_token' => 'code'),
+            $this->resourceOwner->getAccessToken($request, 'http://redirect.to/')
+        );
+    }
+
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
      */


### PR DESCRIPTION
Some OAuth providers return responses with Content-type "text/javascript". These responses should be treated like JSON.

I have this issue while implementing "mail.ru" resource owner
