### PR TITLE
Simplify `AbstractResourceOwner::getResponseContent()` method

### DIFF
--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -233,15 +233,19 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      *
      * @param HttpMessageInterface $rawResponse
      *
-     * @return mixed
+     * @return array
      */
     protected function getResponseContent(HttpMessageInterface $rawResponse)
     {
-        $contentType = $rawResponse->getHeader('Content-Type');
-        if (false !== strpos($contentType, 'application/json') || false !== strpos($contentType, 'text/javascript')) {
-            $response = json_decode($rawResponse->getContent(), true);
-        } else {
-            parse_str($rawResponse->getContent(), $response);
+        // First check that content in response exists, due too bug: https://bugs.php.net/bug.php?id=54484
+        $content = $rawResponse->getContent();
+        if (!$content) {
+            return array();
+        }
+
+        $response = json_decode($content, true);
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            parse_str($content, $response);
         }
 
         return $response;

--- a/OAuth/Response/AbstractUserResponse.php
+++ b/OAuth/Response/AbstractUserResponse.php
@@ -109,10 +109,15 @@ abstract class AbstractUserResponse implements UserResponseInterface
         if (is_array($response)) {
             $this->response = $response;
         } else {
-            $this->response = json_decode($response, true);
+            // First check that response exists, due too bug: https://bugs.php.net/bug.php?id=54484
+            if (!$response) {
+                $this->response = array();
+            } else {
+                $this->response = json_decode($response, true);
 
-            if (JSON_ERROR_NONE !== json_last_error()) {
-                throw new AuthenticationException('Response is not a valid JSON code.');
+                if (JSON_ERROR_NONE !== json_last_error()) {
+                    throw new AuthenticationException('Response is not a valid JSON code.');
+                }
             }
         }
     }

--- a/Tests/OAuth/ResourceOwner/GitHubResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GitHubResourceOwnerTest.php
@@ -40,8 +40,6 @@ json;
             ->method('send')
             ->will($this->returnCallback(array($this, 'buzzSendMock')));
 
-        $this->buzzResponse = '';
-
         $this->buzzClient->expects($this->at(1))
             ->method('send')
             ->will($this->returnCallback(array($this, 'buzzSendMock')));


### PR DESCRIPTION
Now it will always try to parse json, and only in case of failure, try to parse it as string.

Refs #338.

ps. Test was changed due too fast reset of responses between calls.
