### PR TITLE
Added missing tokenSecret in OAuth1 serialize/unserialize

### DIFF
--- a/Security/Core/Authentication/Token/OAuthToken.php
+++ b/Security/Core/Authentication/Token/OAuthToken.php
@@ -247,5 +247,8 @@ class OAuthToken extends AbstractToken
         ) = unserialize($serialized);
 
         parent::unserialize($parent);
+
+        if (isset($this->rawToken['oauth_token_secret']) && ! $this->tokenSecret)
+            $this->setTokenSecret($this->rawToken['oauth_token_secret']);
     }
 }

--- a/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
+++ b/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
@@ -65,4 +65,20 @@ class OAuthTokenTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('access_token', $token->getAccessToken());
         $this->assertEquals('github', $token->getResourceOwnerName());
     }
+
+    public function testSerializationOfOAuth1Token()
+    {
+        $oauth1Token = new OAuthToken(array(
+            'oauth_token' => 'oauth1_access_token',
+            'oauth_token_secret' => 'oauth1_token_secret'
+        ), array('ROLE_TEST'));
+
+        $oauth1Token->setResourceOwnerName('twitter');
+
+        $oauth1Token = unserialize(serialize($oauth1Token));
+
+        $this->assertEquals('oauth1_access_token', $oauth1Token->getAccessToken());
+        $this->assertEquals('oauth1_token_secret', $oauth1Token->getTokenSecret());
+        $this->assertEquals('twitter', $oauth1Token->getResourceOwnerName());
+    }
 }


### PR DESCRIPTION
Somehow the tokenSecret for OAuth 1 token was lost in the serialization process. This PR fixes it.
