### PR TITLE
add Mail.ru resource owner

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ class Configuration implements ConfigurationInterface
             'github',
             'google',
             'instagram',
+            'mailru',
             'odnoklassniki',
             'sensio_connect',
             'stack_exchange',

--- a/OAuth/ResourceOwner/MailruResourceOwner.php
+++ b/OAuth/ResourceOwner/MailruResourceOwner.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
+
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+
+/**
+* MailruResourceOwner
+*
+* @author Gregory <gridsane@gmail.com>
+*/
+class MailruResourceOwner extends GenericOAuth2ResourceOwner
+{
+    protected $defaultOptions = array(
+        'client_private'    => null,
+        'authorization_url' => 'https://connect.mail.ru/oauth/authorize',
+        'access_token_url'  => 'https://connect.mail.ru/oauth/token',
+        'infos_url'         => 'http://www.appsmail.ru/platform/api?method=users.getInfo',
+        'scope'             => null,
+        'csrf'              => false,
+    );
+
+    protected $paths = array(
+        'identifier'     => '0.uid',
+        'nickname'       => '0.nick',
+        'realname'       => array('0.last_name', '0.first_name'),
+        'email'          => '0.email',
+        'profilepicture' => '0.pic_190',
+    );
+
+    /**
+     * Override to add 'sig' parameter (http://api.mail.ru/docs/guides/restapi/#sig (Russian))
+     *
+     * {@inheritDoc}
+     */
+    public function getUserInformation(array $accessToken, array $extraParameters = array())
+    {
+        $params = array();
+        parse_str(parse_url($this->getOption('infos_url'))['query'], $params);
+
+        $params = array_merge($params, array(
+            'app_id' => $this->getOption('client_id'),
+            'session_key' => $accessToken['access_token'],
+        ));
+
+        $concatenatedParams = '';
+        ksort($params);
+        foreach ($params as $k => $v) {
+            $concatenatedParams .= "$k=$v";
+        }
+
+        // 'x_mailru_vid' contains current user's id
+        $params['sig'] = md5($accessToken['x_mailru_vid'] . $concatenatedParams . $this->getOption('client_private'));
+
+        $url = $this->normalizeUrl($this->getOption('infos_url'), $params);
+
+        $content = $this->doGetUserInformationRequest($url)->getContent();
+
+        $response = $this->getUserResponse();
+        $response->setResponse($content);
+        $response->setResourceOwner($this);
+        $response->setOAuthToken(new OAuthToken($accessToken));
+
+        return $response;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This bundle contains support for 20+ different providers:
 * GitHub,
 * Google,
 * Instagram,
+* Mail.ru
 * JIRA,
 * LinkedIn,
 * Odnoklassniki,

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -30,6 +30,7 @@
         <parameter key="hwi_oauth.resource_owner.github.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GitHubResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.google.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GoogleResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.instagram.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\InstagramResourceOwner</parameter>
+        <parameter key="hwi_oauth.resource_owner.mailru.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\MailruResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.jira.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\JiraResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.linkedin.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\LinkedinResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sensio_connect.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SensioConnectResourceOwner</parameter>
@@ -132,6 +133,8 @@
         <service id="hwi_oauth.abstract_resource_owner.google" class="%hwi_oauth.resource_owner.google.class%"
                  parent="hwi_oauth.abstract_resource_owner.oauth2" abstract="true" />
         <service id="hwi_oauth.abstract_resource_owner.instagram" class="%hwi_oauth.resource_owner.instagram.class%"
+                 parent="hwi_oauth.abstract_resource_owner.oauth2" abstract="true" />
+        <service id="hwi_oauth.abstract_resource_owner.mailru" class="%hwi_oauth.resource_owner.mailru.class%"
                  parent="hwi_oauth.abstract_resource_owner.oauth2" abstract="true" />
         <service id="hwi_oauth.abstract_resource_owner.sensio_connect" class="%hwi_oauth.resource_owner.sensio_connect.class%"
                  parent="hwi_oauth.abstract_resource_owner.oauth2" abstract="true" />

--- a/Resources/doc/2-configuring_resource_owners.md
+++ b/Resources/doc/2-configuring_resource_owners.md
@@ -41,6 +41,7 @@ hwi_oauth:
 - [GitHub](resource_owners/github.md)
 - [Google](resource_owners/google.md)
 - [Instagram](resource_owners/instagram.md)
+- [Mail.ru](resource_owners/mailru.md)
 - [Jira](resource_owners/jira.md)
 - [Linkedin](resource_owners/linkedin.md)
 - [Odnoklassniki](resource_owners/odnoklassniki.md)

--- a/Resources/doc/resource_owners/mailru.md
+++ b/Resources/doc/resource_owners/mailru.md
@@ -1,0 +1,27 @@
+Step 2x: Setup Mail.ru
+=================================
+First you will have to register your application on [Mail.ru](http://api.mail.ru/sites/my/add/).
+
+Next configure a resource owner of type `mailru` with appropriate
+`client_id`, `client_secret` and `client_private`. Note: unlike others, `client_private`
+must be defined under the `options` section. All those information will be visible at
+edit page for application you just added.
+
+```yaml
+# app/config/config.yml
+
+hwi_oauth:
+    resource_owners:
+        any_name:
+            type:                mailru
+            client_id:           <client_id>
+            client_secret:       <client_secret>
+            options:
+                client_private: <client_private>
+```
+
+When you're done. Continue by configuring the security layer or go back to
+setup more resource owners.
+
+- [Step 2: Configuring resource owners (Facebook, GitHub, Google, Windows Live and others](../2-configuring_resource_owners.md)
+- [Step 3: Configuring the security layer](../3-configuring_the_security_layer.md).

--- a/Tests/OAuth/ResourceOwner/MailruResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/MailruResourceOwnerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\MailruResourceOwner;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * MailruResourceOwnerTest
+ *
+ * @author Gregory <gridsane@gmail.com>
+ */
+class MailruResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
+{
+    protected $userResponse = <<<json
+{
+    "uid": "1",
+    "first_name": "",
+    "last_name": "1",
+    "nick": "bar",
+    "email": "foobar@mail.ru",
+    "profilepicture": "http://mail.ru/picture.png"
+}
+json;
+
+    protected $paths = array(
+        'identifier' => 'uid',
+        'nickname'   => 'nick',
+        'realname'   => array('last_name', 'first_name'),
+    );
+
+    public function testGetUserInformation()
+    {
+        $this->mockBuzz($this->userResponse, 'application/json; charset=utf-8');
+
+        /**
+         * @var $userResponse \HWI\Bundle\OAuthBundle\OAuth\Response\AbstractUserResponse
+         */
+        $userResponse = $this->resourceOwner->getUserInformation(array(
+            'access_token' => 'token',
+            'x_mailru_vid' => 1
+        ));
+
+        $this->assertEquals('1', $userResponse->getUsername());
+        $this->assertEquals('bar', $userResponse->getNickname());
+        $this->assertEquals('token', $userResponse->getAccessToken());
+        $this->assertNull($userResponse->getRefreshToken());
+        $this->assertNull($userResponse->getExpiresIn());
+    }
+
+    public function testCustomResponseClass()
+    {
+        $class         = '\HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse';
+        $resourceOwner = $this->createResourceOwner('oauth2', array('user_response_class' => $class));
+
+        $this->mockBuzz();
+
+        /**
+         * @var $userResponse \HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse
+         */
+        $userResponse = $resourceOwner->getUserInformation(array(
+            'access_token' => 'token',
+            'x_mailru_vid' => 1
+        ));
+
+        $this->assertInstanceOf($class, $userResponse);
+        $this->assertEquals('foo666', $userResponse->getUsername());
+        $this->assertEquals('foo', $userResponse->getNickname());
+        $this->assertEquals('token', $userResponse->getAccessToken());
+        $this->assertNull($userResponse->getRefreshToken());
+        $this->assertNull($userResponse->getExpiresIn());
+    }
+
+    protected function setUpResourceOwner($name, $httpUtils, array $options)
+    {
+        $options = array_merge(
+            array(
+                'authorization_url'   => 'https://connect.mail.ru/oauth/authorize',
+                'access_token_url'    => 'https://connect.mail.ru/oauth/token',
+                'infos_url'           => 'http://www.appsmail.ru/platform/api?method=users.getInfo',
+                'client_private'      => 'private_key',
+            ),
+            $options
+        );
+
+        return new MailruResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+    }
+}


### PR DESCRIPTION
Mail.ru is a large and popular russian social network and email provider.

It requires some specific logic in `getUserInformation` method, so it cannot be implemented only on configuration layer. I hope there are no restrictions to resource owner's language and mail.ru can be added to project.
