### PR TITLE
Replace 'expires' by 'expires_in' in Facebook's accessToken

### DIFF
--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -11,6 +11,8 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
+use Symfony\Component\HttpFoundation\Request;
+
 /**
  * FacebookResourceOwner
  *
@@ -58,6 +60,21 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
     public function getAuthorizationUrl($redirectUri, array $extraParameters = array())
     {
         return parent::getAuthorizationUrl($redirectUri, array_merge(array('display' => $this->getOption('display')), $extraParameters));
+    }
+
+    /**
+     * Facebook unfortunately breaks the spec by using 'expires' instead of 'expires_in'
+     */
+    public function getAccessToken(Request $request, $redirectUri, array $extraParameters = array())
+    {
+        $accessToken = parent::getAccessToken($request, $redirectUri, $extraParameters);
+
+        if (isset($accessToken['expires'])) {
+            $accessToken['expires_in'] = $accessToken['expires'];
+            unset($accessToken['expires']);
+        }
+
+        return $accessToken;
     }
 
     /**


### PR DESCRIPTION
Facebook breaks OAuth2's [specification](http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.2.2) by using `expires` instead of `expires_in`. This PR fixes that issue.
