### PR TITLE
OAuthToken: Facebook uses "expires" instead of "expires_in"

### DIFF
--- a/Security/Core/Authentication/Token/OAuthToken.php
+++ b/Security/Core/Authentication/Token/OAuthToken.php
@@ -113,6 +113,9 @@ class OAuthToken extends AbstractToken
                 $this->setExpiresIn($token['expires_in']);
             } elseif (isset($token['oauth_expires_in'])) {
                 $this->setExpiresIn($token['oauth_expires_in']);
+            } elseif (isset($token['expires'])) {
+                // Facebook unfortunately breaks the spec by using 'expires' instead of 'expires_in'
+                $this->setExpiresIn($token['expires']);
             }
 
             if (isset($token['oauth_token_secret'])) {

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -116,7 +116,7 @@ class OAuthProviderTest extends \PHPUnit_Framework_TestCase
         $oauthTokenMock->expects($this->once())
             ->method('getTokenSecret')
             ->will($this->returnValue($expectedToken['oauth_token_secret']));
-        
+
         $resourceOwnerMock = $this->getResourceOwnerMock();
         $resourceOwnerMock->expects($this->once())
             ->method('getUserInformation')


### PR DESCRIPTION
Replaces https://github.com/hwi/HWIOAuthBundle/pull/388
