### PR TITLE
Hotfix: Make it work without FOSUserBundle

### DIFF
--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -77,7 +77,7 @@
         </service>
 
         <!-- fosub bridges -->
-        <service id="hwi_oauth.user.provider.fosub_bridge.def" class="%hwi_oauth.user.provider.fosub_bridge.class%">
+        <service id="hwi_oauth.user.provider.fosub_bridge.def" class="%hwi_oauth.user.provider.fosub_bridge.class%" abstract="true">
             <argument type="service" id="fos_user.user_manager" />
         </service>
         <service id="hwi_oauth.registration.form.handler.fosub_bridge.def" class="%hwi_oauth.registration.form.handler.fosub_bridge.class%" abstract="true">


### PR DESCRIPTION
DIC was trying to make class, because it's was not annotated as abstract. There was exception when using this bundle without FOSUserBundle
