### PR TITLE
Allow using HTTP REFERER as a fallback return URL

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -235,15 +235,26 @@ class ConnectController extends ContainerAware
      */
     public function redirectToServiceAction(Request $request, $service)
     {
-        // Check for a specified target path and store it before redirect if present
-        $param = $this->container->getParameter('hwi_oauth.target_path_parameter');
+        $authorizationUrl = $this->container->get('hwi_oauth.security.oauth_utils')->getAuthorizationUrl($request, $service);
 
-        if (!empty($param) && $request->hasSession() && $targetUrl = $request->get($param, null, true)) {
+        // Check for a return path and store it before redirect
+        if ($request->hasSession()) {
+            $session = $request->getSession();
+
             $providerKey = $this->container->getParameter('hwi_oauth.firewall_name');
-            $request->getSession()->set('_security.' . $providerKey . '.target_path', $targetUrl);
+            $sessionKey = '_security.' . $providerKey . '.target_path';
+
+            $param = $this->container->getParameter('hwi_oauth.target_path_parameter');
+            if (!empty($param) && $targetUrl = $request->get($param, null, true)) {
+                $session->set($sessionKey, $targetUrl);
+            }
+            
+            if ($this->container->getParameter('hwi_oauth.use_referer') && !$session->has($sessionKey) && ($targetUrl = $request->headers->get('Referer')) && $targetUrl !== $authorizationUrl) {
+                $session->set($sessionKey, $targetUrl);
+            }
         }
 
-        return new RedirectResponse($this->container->get('hwi_oauth.security.oauth_utils')->getAuthorizationUrl($request, $service));
+        return new RedirectResponse($authorizationUrl);
     }
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -81,6 +81,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('firewall_name')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('target_path_parameter')->defaultNull()->end()
+                ->booleanNode('use_referer')->defaultFalse()->end()
                 ->scalarNode('templating_engine')->defaultValue('twig')->end()
             ->end()
         ;

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -55,6 +55,9 @@ class HWIOAuthExtension extends Extension
         // set target path parameter
         $container->setParameter('hwi_oauth.target_path_parameter', $config['target_path_parameter']);
 
+        // set use referer parameter
+        $container->setParameter('hwi_oauth.use_referer', $config['use_referer']);
+
         // setup services for all configured resource owners
         $resourceOwners = array();
         foreach ($config['resource_owners'] as $name => $options) {

--- a/Resources/doc/2-configuring_resource_owners.md
+++ b/Resources/doc/2-configuring_resource_owners.md
@@ -22,6 +22,12 @@ hwi_oauth:
     # [target_path_parameter for form login](http://symfony.com/doc/2.0/cookbook/security/form_login.html).
     # target_path_parameter: _destination
 
+    # an optional setting to use the HTTP REFERER header to be used in case no
+    # previous URL was stored in the session (i.e. no resource was requested).
+    # This is similar to the behaviour of
+    # [using the referring URL for form login](http://symfony.com/doc/2.0/cookbook/security/form_login.html#using-the-referring-url).
+    # use_referer: true
+
     # here you will add one (or more) configurations for resource owners
     # and other settings you want to adjust in this bundle, just checkout the list below!
 ```

--- a/Resources/doc/internals/reference_configuration.md
+++ b/Resources/doc/internals/reference_configuration.md
@@ -64,6 +64,12 @@ hwi_oauth:
     # name of the firewall the oauth bundle is active in
     firewall_name: secured_area
 
+    # optional target_path_parameter to provide an explicit return URL
+    #target_path_parameter: _destination
+
+    # use referer as fallback to determine default return URL
+    #use_referer: true
+
     # optional FOSUserBundle integration
     fosub:
         # try 30 times to check if a username is available (foo, foo1, foo2 etc)

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -241,6 +241,7 @@ class HWIOAuthExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertParameter('secured_area', 'hwi_oauth.firewall_name');
         $this->assertParameter(null, 'hwi_oauth.target_path_parameter');
+        $this->assertParameter(false, 'hwi_oauth.use_referer');
         $this->assertParameter(array('any_name', 'some_service'), 'hwi_oauth.resource_owners');
 
         $this->assertNotHasDefinition('hwi_oauth.user.provider.fosub_bridge');


### PR DESCRIPTION
Several use cases (such as personalized UX and connection widgets) would be greatly improved by this feature.

N.B.: Just like form_login behavior, the feature is turned off by default.
