### PR TITLE
Use IS_AUTHENTICATED_FULLY instead of IS_AUTHENTICATED_REMEMBERED

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -45,7 +45,7 @@ class ConnectController extends ContainerAware
     public function connectAction(Request $request)
     {
         $connect = $this->container->getParameter('hwi_oauth.connect');
-        $hasUser = $this->container->get('security.context')->isGranted('IS_AUTHENTICATED_REMEMBERED');
+        $hasUser = $this->container->get('security.context')->isGranted('IS_AUTHENTICATED_FULLY');
 
         $error = $this->getErrorForRequest($request);
 
@@ -91,7 +91,7 @@ class ConnectController extends ContainerAware
             throw new NotFoundHttpException();
         }
 
-        $hasUser = $this->container->get('security.context')->isGranted('IS_AUTHENTICATED_REMEMBERED');
+        $hasUser = $this->container->get('security.context')->isGranted('IS_AUTHENTICATED_FULLY');
         if ($hasUser) {
             throw new AccessDeniedException('Cannot connect already registered account.');
         }
@@ -160,7 +160,7 @@ class ConnectController extends ContainerAware
             throw new NotFoundHttpException();
         }
 
-        $hasUser = $this->container->get('security.context')->isGranted('IS_AUTHENTICATED_REMEMBERED');
+        $hasUser = $this->container->get('security.context')->isGranted('IS_AUTHENTICATED_FULLY');
         if (!$hasUser) {
             throw new AccessDeniedException('Cannot connect an account.');
         }

--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -91,7 +91,7 @@ class OAuthUtils
     public function getAuthorizationUrl(Request $request, $name, $redirectUrl = null, array $extraParameters = array())
     {
         if (null === $redirectUrl) {
-            if (!$this->connect || !$this->securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
+            if (!$this->connect || !$this->securityContext->isGranted('IS_AUTHENTICATED_FULLY')) {
                 $redirectUrl = $this->httpUtils->generateUri($request, $this->ownerMap->getResourceOwnerCheckPath($name));
             } else {
                 $request->attributes->set('service', $name);

--- a/Tests/Security/OAuthUtilsTest.php
+++ b/Tests/Security/OAuthUtilsTest.php
@@ -181,7 +181,7 @@ class OAuthUtilsTest extends \PHPUnit_Framework_TestCase
         $mock
             ->expects($this->once())
             ->method('isGranted')
-            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->with('IS_AUTHENTICATED_FULLY')
             ->will($this->returnValue($hasUser));
 
         return $mock;


### PR DESCRIPTION
In the case of an `anonymous: ~` firewall, if someone wishes to authenticate themselves and the remember_me feature hasn't kicked in yet, the behavior is pretty weird:

The user is not logged in but WHI asks him if he wants to connect his account. (Rather than simply logging the user is or sending the user to the connect_registration page). This behavior seems misguided and since the OAuthListener (position http) runs before the RememberMeListener (position remember_me), this most definitely looks like a bug to me...

Since I wasn't able to find any discussion on why REMEMBERED is used instead of (the usual) FULLY, I though it would be a nice way to start the discussion if one's needed.
