### PR TITLE
change private to protected properties and method

### DIFF
--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -33,22 +33,22 @@ class OAuthUtils
     /**
      * @var boolean
      */
-    private $connect;
+    protected $connect;
 
     /**
      * @var HttpUtils
      */
-    private $httpUtils;
+    protected $httpUtils;
 
     /**
      * @var ResourceOwnerMap
      */
-    private $ownerMap;
+    protected $ownerMap;
 
     /**
      * @var SecurityContextInterface
      */
-    private $securityContext;
+    protected $securityContext;
 
     /**
      * @param HttpUtils                $httpUtils
@@ -213,7 +213,7 @@ class OAuthUtils
      *
      * @throws \RuntimeException
      */
-    private function getResourceOwner($name)
+    protected function getResourceOwner($name)
     {
         $resourceOwner = $this->ownerMap->getResourceOwnerByName($name);
         if (!$resourceOwner instanceof ResourceOwnerInterface) {


### PR DESCRIPTION
Changed the private properties and methods to protected, so you can inherit from a class OAuthUtils, for example, to write the implementation of the method getAuthorizationUrl
