### PR TITLE
Adding createdAt property to serialization

### DIFF
--- a/Security/Core/Authentication/Token/OAuthToken.php
+++ b/Security/Core/Authentication/Token/OAuthToken.php
@@ -230,6 +230,7 @@ class OAuthToken extends AbstractToken
             $this->rawToken,
             $this->refreshToken,
             $this->expiresIn,
+            $this->createdAt,
             $this->resourceOwnerName,
             parent::serialize()
         ));
@@ -245,6 +246,7 @@ class OAuthToken extends AbstractToken
             $this->rawToken,
             $this->refreshToken,
             $this->expiresIn,
+            $this->createdAt,
             $this->resourceOwnerName,
             $parent,
         ) = unserialize($serialized);


### PR DESCRIPTION
The createdAt property was not serialized so the isExpired() method was not working as intended.
