### PR TITLE
Update user provider config in the Facebook connect document.

### DIFF
--- a/Resources/doc/bonus/facebook-connect.md
+++ b/Resources/doc/bonus/facebook-connect.md
@@ -17,10 +17,6 @@ hwi_oauth:
             client_id:     <client_id>
             client_secret: <client_secret>
             scope:         "email"
-
-services:
-    hwi_oauth.user.provider.entity:
-        class: HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUserProvider
 ```
 
 ### Import Routing
@@ -41,6 +37,11 @@ facebook_login:
 ```yaml
 # app/config/security.yml
 
+providers:
+    # you can have multiple user provider here...
+    hwi_oauth_user_provider:
+        id: hwi_oauth.user.provider
+
 firewalls:
     # ...
     secured_area:
@@ -51,7 +52,7 @@ firewalls:
             login_path:        /demo/secured/login
             failure_path:      /demo/secured/login
             oauth_user_provider:
-                service: hwi_oauth.user.provider.entity
+                service: hwi_oauth.user.provider
 
         # Turn on anonymous for testings need.
         anonymous: ~


### PR DESCRIPTION
The original docs doesn't work with master branch in Symfony 2.3 anymore for some reason, and here is the update.

* Now use `hwi_oauth.user.provider` provider instead of `hwi_oauth.user.provider.entity`.
* Add `hwi_oauth.user.provider` to security.yml's `providers` node.  
Without this line it will throw "There is no user provider for user "HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser"" exception. Other docs didn't mention this part I think.