### PR TITLE
Update EntityUserProvider.php

### DIFF
--- a/Security/Core/User/EntityUserProvider.php
+++ b/Security/Core/User/EntityUserProvider.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Security\Core\User;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use FOS\UserBundle\Model\UserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;


### PR DESCRIPTION
Fix Issue #429 - use statement should not contain reference to FOS and should maintain compatibility with Symfony\Component\Security\Core\User\UserProviderInterface.

Causes:
FatalErrorException: Compile Error: Declaration of HWI\Bundle\OAuthBundle\Security\Core\User\EntityUserProvider::refreshUser() must be compatible with Symfony\Component\Security\Core\User\UserProviderInterface::refreshUser(Symfony\Component\Security\Core\User\UserInterface $user)
when trying to initialize a user provider extending EntityUserProvider and implementing UserProviderInterface
