### PR TITLE
Configurable OAuthFactory

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -82,6 +82,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('firewall_name')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('target_path_parameter')->defaultNull()->end()
                 ->scalarNode('templating_engine')->defaultValue('twig')->end()
+                ->scalarNode('oauth_factory')->defaultValue('HWI\Bundle\OAuthBundle\DependencyInjection\Security\Factory\OAuthFactory')->end()
             ->end()
         ;
 

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -25,8 +26,22 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  * @author Geoffrey Bachelet <geoffrey.bachelet@gmail.com>
  * @author Alexander <iam.asm89@gmail.com>
  */
-class HWIOAuthExtension extends Extension
+class HWIOAuthExtension extends Extension implements PrependExtensionInterface
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        $bundleConfigs = $container->getExtensionConfig($this->getAlias());
+        $config = $this->processConfiguration(new Configuration(), $bundleConfigs);
+
+        // inject configured factory into SF2 security extension
+        $factoryClass      = $config['oauth_factory'];
+        $securityExtension = $container->getExtension('security');
+        $securityExtension->addSecurityListenerFactory(new $factoryClass);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/HWIOAuthBundle.php
+++ b/HWIOAuthBundle.php
@@ -32,9 +32,6 @@ class HWIOAuthBundle extends Bundle
     {
         parent::build($container);
 
-        $extension = $container->getExtension('security');
-        $extension->addSecurityListenerFactory(new OAuthFactory());
-
         $container->addCompilerPass(new SetResourceOwnerServiceNameCompilerPass());
     }
 


### PR DESCRIPTION
We're in need to inject an overridden `OAuthFactory` into your bundle. I made this possible utilizing the `PrependExtensionInterface` (introduced with SF2.2).
Users of your bundle _may_ change the default `OAuthFactory` implementation by configuring their own class' FQCN in the _oauth_factory_ configuration key.
