### PR TITLE
fix incoming redirects from facebook app center

### DIFF
--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -11,7 +11,8 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use \Symfony\Component\HttpFoundation\Request;
+use \Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * FacebookResourceOwner
@@ -76,5 +77,18 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
             // @link https://developers.facebook.com/docs/reference/dialogs/#display
             'display' => array('page', 'popup', 'touch'),
         ));
+    }
+    
+    public function getAccessToken(Request $request, $redirectUri, array $extraParameters = array()) {
+        $redirectUri = $request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo()."?";
+        
+        foreach($request->query->all() as $param => $value){
+            if($param !== "code")
+                $redirectUri .= $param."=".$value."&";
+        }
+        
+        $redirectUri = substr($redirectUri,0, -1);
+        
+        return parent::getAccessToken($request, $redirectUri, $extraParameters);
     }
 }


### PR DESCRIPTION
Facebook requires the `redirect_uri` parameters to be same while requesting `authorization code` and `access token`. The `uri` from app center contains 2 extra parameters `fb_source` and `fb_appcenter` that must be present in the `redirect_uri` while requesting `access_token`
