### PR TITLE
Implement UserProviderInterface in EntityUserProvider

### DIFF
--- a/Security/Core/User/EntityUserProvider.php
+++ b/Security/Core/User/EntityUserProvider.php
@@ -16,6 +16,7 @@ use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
  * User provider for the ORM that loads users given a mapping between resource
@@ -23,7 +24,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  *
  * @author Alexander <iam.asm89@gmail.com>
  */
-class EntityUserProvider implements OAuthAwareUserProviderInterface
+class EntityUserProvider implements OAuthAwareUserProviderInterface, UserProviderInterface
 {
     /**
      * @var string


### PR DESCRIPTION
All the methods are already implemented, but the provider can not be used, as the basic UserProviderInterface is not used.
