### PR TITLE
Update TwitterResourceOwner.php

### DIFF
--- a/OAuth/ResourceOwner/TwitterResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitterResourceOwner.php
@@ -40,7 +40,7 @@ class TwitterResourceOwner extends GenericOAuth1ResourceOwner
             'authorization_url' => 'https://api.twitter.com/oauth/authenticate',
             'request_token_url' => 'https://api.twitter.com/oauth/request_token',
             'access_token_url'  => 'https://api.twitter.com/oauth/access_token',
-            'infos_url'         => 'http://api.twitter.com/1.1/account/verify_credentials.json',
+            'infos_url'         => 'https://api.twitter.com/1.1/account/verify_credentials.json',
         ));
     }
 }


### PR DESCRIPTION
api.twitter.com now requires SSL/TLS for all connections as of January 14th, 2014. See https://dev.twitter.com/discussions/24239.
