### PR TITLE
Twitter now requires https as of Jan 14, 2014.

### DIFF
--- a/OAuth/ResourceOwner/TwitterResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitterResourceOwner.php
@@ -40,7 +40,7 @@ class TwitterResourceOwner extends GenericOAuth1ResourceOwner
             'authorization_url' => 'https://api.twitter.com/oauth/authenticate',
             'request_token_url' => 'https://api.twitter.com/oauth/request_token',
             'access_token_url'  => 'https://api.twitter.com/oauth/access_token',
-            'infos_url'         => 'http://api.twitter.com/1.1/account/verify_credentials.json',
+            'infos_url'         => 'https://api.twitter.com/1.1/account/verify_credentials.json',
         ));
     }
 }


### PR DESCRIPTION
This fixes the problem of not getting data back about the user (eg. id_str, screen_name).
