### PR TITLE
First draft for real path mapping in FOSUserRegistrationHandler

### DIFF
--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -163,6 +163,7 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
                 if($path == 'username'){
                     $value = $this->getUniqueUsername($value);
                 }
+                $user->$func($value);
             }
         }
         return $user;

--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -146,7 +146,8 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
     }
 
     /**
-     * Set user information from form
+     * Set user information from form 
+     * and takes paths into account for mapping
      *
      * @param UserInterface         $user
      * @param UserResponseInterface $userInformation
@@ -155,12 +156,15 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
      */
     protected function setUserInformation(UserInterface $user, UserResponseInterface $userInformation)
     {
-        $user->setUsername($this->getUniqueUsername($userInformation->getNickname()));
-
-        if (method_exists($user, 'setEmail')) {
-            $user->setEmail($userInformation->getEmail());
+        foreach($userInformation->getPaths() as $path){
+            $func = 'set'.ucfirst($path);
+            if(method_exists($user, $func)){
+                $value = $userInformation->getValueForPath($path);
+                if($path == 'username'){
+                    $value = $this->getUniqueUsername($value);
+                }
+            }
         }
-
         return $user;
     }
 }

--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -156,7 +156,7 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
      */
     protected function setUserInformation(UserInterface $user, UserResponseInterface $userInformation)
     {
-        foreach($userInformation->getPaths() as $path){
+        foreach($userInformation->getPaths() as $path => $source){
             $func = 'set'.ucfirst($path);
             if(method_exists($user, $func)){
                 $value = $userInformation->getValueForPath($path);

--- a/OAuth/Response/PathUserResponse.php
+++ b/OAuth/Response/PathUserResponse.php
@@ -108,7 +108,7 @@ class PathUserResponse extends AbstractUserResponse
      *
      * @return null|string
      */
-    protected function getValueForPath($path)
+    public function getValueForPath($path)
     {
         $response = $this->response;
         if (!$response) {

--- a/Tests/Fixtures/FOSUser.php
+++ b/Tests/Fixtures/FOSUser.php
@@ -22,7 +22,6 @@ class FOSUser extends BaseUser
 {
     private $githubId;
     
-    /*
     public function getUsername()
     {
         if(isset($this->username)){
@@ -30,7 +29,7 @@ class FOSUser extends BaseUser
         }
         return 'foo';
     }
-    */
+    
 
     public function getRoles()
     {

--- a/Tests/Fixtures/FOSUser.php
+++ b/Tests/Fixtures/FOSUser.php
@@ -21,11 +21,16 @@ use FOS\UserBundle\Model\User as BaseUser;
 class FOSUser extends BaseUser
 {
     private $githubId;
-
+    
+    /*
     public function getUsername()
     {
+        if(isset($this->username)){
+           return parent::getUsername(); 
+        }
         return 'foo';
     }
+    */
 
     public function getRoles()
     {

--- a/Tests/Form/FOSUBRegistrationFormHandlerTest.php
+++ b/Tests/Form/FOSUBRegistrationFormHandlerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\Form;
+
+
+use HWI\Bundle\OAuthBundle\Tests\Fixtures\FOSUser as User;
+use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
+use HWI\Bundle\OAuthBundle\Form\FOSUBRegistrationFormHandler;
+
+class FOSUBRegistrationFormHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    
+    protected $resp;
+    
+    protected $handler;
+    
+    protected $facebookPaths = array(
+        'identifier' => 'id',
+        'username' => 'username',
+    //'nickname'   => 'username',
+        'realname'   => 'name',
+        'email'      => 'email',
+    );
+    
+    protected function setUp()
+    {
+        if (!interface_exists('FOS\UserBundle\Model\UserManagerInterface')) {
+            $this->markTestSkipped('FOSUserBundle is not available');
+        }
+        $this->resp = array(
+            'id' => '723491248',   
+            'name' => 'Max Mustermann',
+            'first_name' => 'Max',
+            'last_name' => 'Mustermann',
+            'link' => 'https://www.facebook.com/maxmuster',
+            'gender' => 'male',
+            'email' => 'max@muster.de',
+            'timezone' => 1,
+            'locale' => 'en_US',
+            'verified' => true,
+            'updated_time' => '2013-11-09T17:18:53+0000',
+            'username' => 'maxmuster',
+        );
+        
+        $this->handler = new FOSUBRegistrationFormHandler($this->createUserManagerMock(),$this->createMailerMock());
+
+    }
+
+    public function testSetUserInformationWithDefaultPaths(){
+        
+        $responseObj = new PathUserResponse();
+        $responseObj->setPaths($this->facebookPaths);
+        $responseObj->setResponse($this->resp);
+        $user = new User();
+        
+        $class = new \ReflectionClass($this->handler);
+        $method = $class->getMethod('setUserInformation');
+        $method->setAccessible(true);
+        $args = array($user, $responseObj);
+        
+        $method->invokeArgs($this->handler, $args);
+        
+        $this->assertEquals('maxmuster', $user->getUsername());
+        $this->assertEquals('max@muster.de', $user->getEmail());
+    }
+    
+    protected function createUserManagerMock(){
+        $userManagerMock = $this->getMockBuilder('FOS\UserBundle\Model\UserManagerInterface')
+            ->getMock();  
+        return $userManagerMock;
+    }
+    
+    protected function createMailerMock(){
+        $mailerMock = $this->getMockBuilder('FOS\UserBundle\Mailer\MailerInterface')
+                        ->getMock();
+        return $mailerMock;
+    }
+}


### PR DESCRIPTION
This is a idea in order to enhance the pathresponse. With that you could create custom mapping in configuration for your users. (If they are based on FOSUSerbundle).

My usecase is that facebook provides more data then currently is mapped. And we have already the possibility to map those values in the response object. But the mapping from this responseobject to the user was hardcoded and only allowed to set the username and the email. With this PR you could be able to  map firstName, lastName etc. 

I would like to get feedback on this. But have a look at the impact with the Response->getNickname() <-> username mapping. Maybe we would need to change the default mapping for some resources owners.

Any feedback on this?
