### PR TITLE
make GenericOAuth1ResourceOwner getRequestToken public

### DIFF
--- a/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -132,7 +132,7 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function getRequestToken($redirectUri, array $extraParameters = array())
+    public function getRequestToken($redirectUri, array $extraParameters = array())
     {
         $timestamp = time();
 


### PR DESCRIPTION
The getRequestToken method should be public so we can access the `login_url` and other attributes of the request token
