### PR TITLE
Wordpress resource owner requires access token to be sent as header when calling API

### DIFF
--- a/OAuth/ResourceOwner/WordpressResourceOwner.php
+++ b/OAuth/ResourceOwner/WordpressResourceOwner.php
@@ -11,6 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -30,6 +31,21 @@ class WordpressResourceOwner extends GenericOAuth2ResourceOwner
         'email'          => 'email',
         'profilepicture' => 'avatar_URL',
     );
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getUserInformation(array $accessToken, array $extraParameters = array())
+    {
+        $content = $this->httpRequest($this->normalizeUrl($this->options['infos_url']), null, array('Authorization: Bearer '.$accessToken['access_token']))->getContent();
+
+        $response = $this->getUserResponse();
+        $response->setResponse($content);
+        $response->setResourceOwner($this);
+        $response->setOAuthToken(new OAuthToken($accessToken));
+
+        return $response;
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Replaces #489. Fixes #479.
