### PR TITLE
Fixed bug. Bug: normalizer adds "?" suffix to $redirect_uri

### DIFF
--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -200,7 +200,9 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
     protected function normalizeUrl($url, array $parameters = array())
     {
         $normalizedUrl  = $url;
-        $normalizedUrl .= (false !== strpos($url, '?') ? '&' : '?').http_build_query($parameters, '', '&');
+        if (!empty($parameters)) {
+            $normalizedUrl .= (false !== strpos($url, '?') ? '&' : '?').http_build_query($parameters, '', '&');
+        }
 
         return $normalizedUrl;
     }


### PR DESCRIPTION
Fixed bug. Bug: normalizer adds "?" suffix to $redirect_uri ("http://host.dev/login/check-facebook" => "http://host.dev/login/check-facebook?") and then facebook responses "Error validating verification code. Please make sure your redirect_uri is identical to the one you used in the OAuth dialog request".
