### PR TITLE
Security Issue: Send authorization via header instead of parameter

### DIFF
--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -30,11 +30,9 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
      */
     public function getUserInformation(array $accessToken, array $extraParameters = array())
     {
-        $url = $this->normalizeUrl($this->options['infos_url'], array(
-            'access_token' => $accessToken['access_token']
-        ));
+        $url = $this->normalizeUrl($this->options['infos_url']);
 
-        $content = $this->doGetUserInformationRequest($url)->getContent();
+        $content = $this->httpRequest($url, null, array('Authorization: Bearer '.$accessToken['access_token']))->getContent();
 
         $response = $this->getUserResponse();
         $response->setResponse($content);


### PR DESCRIPTION
All OAuth2 provider should accept the authorization via header.  The parameter is optional. 

"Clients SHOULD make authenticated requests with a bearer token using the Authorization request header field with the Bearer HTTP authorization scheme. Resource servers MUST support this method."
http://self-issued.info/docs/draft-ietf-oauth-v2-bearer.html#authz-header )

It is also a huge security issue to send the access token via parameters, because all logs will store the full url with paramters.
