### PR TITLE
Fix revoke token for github.

### DIFF
--- a/OAuth/ResourceOwner/GitHubResourceOwner.php
+++ b/OAuth/ResourceOwner/GitHubResourceOwner.php
@@ -37,19 +37,12 @@ class GitHubResourceOwner extends GenericOAuth2ResourceOwner
      */
     public function revokeToken($token)
     {
-        $parameters = array(
-            'client_id'     => $this->options['client_id'],
-            'client_secret' => $this->options['client_secret'],
-        );
-
         /* @var $response \Buzz\Message\Response */
-        $response = $this->httpRequest(sprintf('https://api.github.com/applications/%s/tokens/%s', $this->options['client_id'], $token), $parameters);
-        if (404 === $response->getStatusCode()) {
-            return false;
-        }
-
-        $response = $this->getResponseContent($response);
-        $response = $this->httpRequest(sprintf('https://api.github.com/authorizations/%s', $response['id']), $parameters, array(), 'DELETE');
+        $response = $this->httpRequest(
+                sprintf('https://api.github.com/applications/%s/tokens/%s', $this->options['client_id'], $token),
+                null,
+                array('Authorization: Basic '.base64_encode($this->options['client_id'] .':'. $this->options['client_secret'])),
+                'DELETE');
 
         return 204 === $response->getStatusCode();
     }


### PR DESCRIPTION
https://developer.github.com/v3/oauth_authorizations/#revoke-an-authorization-for-an-application

The old code did not work for me. Judging from the commit that added it i
assume it was part of a copy+paste job. According to the documentatio from
github to revoke a token you need to send a DELETE request. And its a one
step process.

Works for me.
