### PR TITLE
Update ConnectController.php

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -56,7 +56,7 @@ class ConnectController extends ContainerAware
         ) {
             $key = time();
             $session = $request->getSession();
-            $session->set('_hwi_oauth.registration_error.'.$key, $error);
+            $session->set('_hwi_oauth.registration_error', $error);
 
             return new RedirectResponse($this->generate('hwi_oauth_connect_registration', array('key' => $key)));
         }
@@ -97,8 +97,8 @@ class ConnectController extends ContainerAware
         }
 
         $session = $request->getSession();
-        $error = $session->get('_hwi_oauth.registration_error.'.$key);
-        $session->remove('_hwi_oauth.registration_error.'.$key);
+        $error = $session->get('_hwi_oauth.registration_error');
+        $session->remove('_hwi_oauth.registration_error');
 
         if (!($error instanceof AccountNotLinkedException) || (time() - $key > 300)) {
             // todo: fix this
@@ -131,7 +131,7 @@ class ConnectController extends ContainerAware
 
         // reset the error in the session
         $key = time();
-        $session->set('_hwi_oauth.registration_error.'.$key, $error);
+        $session->set('_hwi_oauth.registration_error', $error);
 
         return $this->container->get('templating')->renderResponse('HWIOAuthBundle:Connect:registration.html.' . $this->getTemplatingEngine(), array(
             'key' => $key,


### PR DESCRIPTION
Problem: When you are in a connect confirmation type page with a registration form (URL: `/connect/registration/{key})`, it renders fine. However if the user refresh the page for any reason it will throw a 500 error because it full fills line # 103 requirement.

Reason: This is because the error session variable is suffixed with the timestamp (Eg: `"_hwi_oauth.registration_error.$key"`). When you refresh the page, at line # 100 & # 101 refers to a session variable with the `{key}` from URL, while the real variable is has a different name (set at line # 134).

Solution: Refer to a uniform error session variable. Drop the uniqueness of the variable by removing the appended `$key` value. This will change line # 59, # 100, # 101 & # 134. This session variable is not referred anywhere in the project but this controller file. Looks like it is safe to change the variable name. I made this change in my local project and work without any issues.

Thanks.
