### PR TITLE
Updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The HWIOAuthBundle adds support for authenticating users via OAuth1.0a or OAuth2
 This bundle contains support for 20+ different providers:
 * 37signals,
 * Amazon,
+* Auth0,
 * Bitbucket,
 * Bitly,
 * Box,

--- a/Resources/doc/resource_owners/auth0.md
+++ b/Resources/doc/resource_owners/auth0.md
@@ -14,7 +14,7 @@ hwi_oauth:
             type:           auth0
             client_id:      <client_id>
             client_secret:  <client_secret>
-            domain:         <domain>
+            base_url:       https://<domain>
             scope:          <scope>
 ```
 


### PR DESCRIPTION
The previous documentation required a new option called domain, it was changed for the exiting option base_url, but the documentation wasn't updated
