### PR TITLE
Embeds email in Vkontakte response

### DIFF
--- a/OAuth/ResourceOwner/VkontakteResourceOwner.php
+++ b/OAuth/ResourceOwner/VkontakteResourceOwner.php
@@ -53,7 +53,7 @@ class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
         $response->setResponse($content);
         $response->setResourceOwner($this);
         $response->setOAuthToken(new OAuthToken($accessToken));
-        
+
         if (isset($accessToken['email'])) {
             $content = $response->getResponse();
             $content['email'] = $accessToken['email'];


### PR DESCRIPTION
For some reason vkontakte provide user email (`scope: "email"`) only with access token request ([see paragraph 4](http://vk.com/dev/auth_sites)). None other vkontakte api [method](http://vk.com/dev/users.get) cannot return email.
