### PR TITLE
FoursquareResourceOwner Fix

### DIFF
--- a/OAuth/ResourceOwner/FoursquareResourceOwner.php
+++ b/OAuth/ResourceOwner/FoursquareResourceOwner.php
@@ -82,12 +82,14 @@ class FoursquareResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
-            'authorization_url' => 'https://foursquare.com/oauth2/authorize',
+            'authorization_url' => 'https://foursquare.com/oauth2/authenticate',
             'access_token_url'  => 'https://foursquare.com/oauth2/access_token',
             'infos_url'         => 'https://api.foursquare.com/v2/users/self',
 
             // @link https://developer.foursquare.com/overview/versioning
             'version'           => '20121206',
+            
+            'use_bearer_authorization' => false,
         ));
     }
 }


### PR DESCRIPTION
Foursquare support was broken. This one fixed it by disabling `use_bearer_authorization` so that 
`FoursquareResourceOwner::doGetUserInformationRequest` is actually used to retrieve user the information.

Also changed `authorization_url` to use `https://foursquare.com/oauth2/authenticate` as recommended in https://developer.foursquare.com/overview/auth.html

> /authenticate handles both user authentication and app authorization and automatically redirects if a user has already authorized the calling app. Conversely, /authorize will prompt the user to accept the the auth request every time.
