### PR TITLE
remove username deprecated property

### DIFF
--- a/Resources/doc/internals/response_object_and_paths.md
+++ b/Resources/doc/internals/response_object_and_paths.md
@@ -25,7 +25,7 @@ hwi_oauth:
             client_id:     <client_id>
             client_secret: <client_secret>
             scope:         "email"
-            infos_url:     "https://graph.facebook.com/me?fields=username,name,email,picture.type(square)"
+            infos_url:     "https://graph.facebook.com/me?fields=id,name,email,picture.type(square)"
             paths:
                 email:          email
                 profilepicture: picture.data.url


### PR DESCRIPTION
username is no more supporter in v2 api see http://stackoverflow.com/questions/23456238/how-to-get-users-username-in-v2-0-or-later-of-facebooks-graph-api
