### PR TITLE
Handle situation when user doesn't accept permissions during connection process

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -183,6 +183,16 @@ class ConnectController extends ContainerAware
             $accessToken = $session->get('_hwi_oauth.connect_confirmation.'.$key);
         }
 
+        if ($accessToken === null) {
+            $this->container->get("session")->getFlashBag()->add("error", $this->container->get("translator")->trans("connect.error", array(), 'HWIOAuthBundle'));
+            $route = $this->container->getParameter('hwi_oauth.error_path_parameter');
+            if ($route) {
+                return new RedirectResponse($this->generate($route));
+            } else {
+                return new RedirectResponse("/");
+            }
+        }
+
         $userInformation = $resourceOwner->getUserInformation($accessToken);
 
         // Show confirmation page?

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -123,6 +123,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('firewall_name')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('target_path_parameter')->defaultNull()->end()
+                ->scalarNode('error_path_parameter')->defaultNull()->end()
                 ->booleanNode('use_referer')->defaultFalse()->end()
                 ->scalarNode('templating_engine')->defaultValue('twig')->end()
             ->end()

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -58,6 +58,9 @@ class HWIOAuthExtension extends Extension
         // set target path parameter
         $container->setParameter('hwi_oauth.target_path_parameter', $config['target_path_parameter']);
 
+        // set error path parameter
+        $container->setParameter('hwi_oauth.error_path_parameter', $config['error_path_parameter']);
+
         // set use referer parameter
         $container->setParameter('hwi_oauth.use_referer', $config['use_referer']);
 

--- a/Resources/translations/HWIOAuthBundle.en.yml
+++ b/Resources/translations/HWIOAuthBundle.en.yml
@@ -12,3 +12,4 @@ connect:
     registration:
         cancel: Cancel
         submit: Register account
+    error: Something went wrong.

--- a/Resources/translations/HWIOAuthBundle.pl.yml
+++ b/Resources/translations/HWIOAuthBundle.pl.yml
@@ -12,3 +12,4 @@ connect:
     registration:
         cancel: Anuluj
         submit: Zarejestruj konto
+    error: Wystąpił błąd


### PR DESCRIPTION
### Problem description:

For example in case of Facebook, if user doesn't accept permissions it will be redirected but url will not contains code but error. In such case there will be an exception because accessToken will be null.
### My solution:

If access token is null, user is redirected (path can be defined in config) and error message is added to flashBag. 
