### PR TITLE
SensioConnect: Disable use_bearer_authorization

### DIFF
--- a/OAuth/ResourceOwner/SensioConnectResourceOwner.php
+++ b/OAuth/ResourceOwner/SensioConnectResourceOwner.php
@@ -52,6 +52,8 @@ class SensioConnectResourceOwner extends GenericOAuth2ResourceOwner
             'user_response_class' => '\HWI\Bundle\OAuthBundle\OAuth\Response\SensioConnectUserResponse',
 
             'response_type'       => 'code',
+
+            'use_bearer_authorization' => false,
         ));
     }
 }


### PR DESCRIPTION
With `use_bearer_authorization` set by befault to true, the `GenericOAuth2ResourceOwner.getUserInformation()` method will return a response that do not contain any information about user, and an `AuthenticationException` will be thrown. 

Response contains:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<api
    xmlns:xhtml="http://www.w3.org/1999/xhtml"
    xmlns:atom="http://www.w3.org/2005/Atom"
    xmlns:foaf="http://xmlns.com/foaf/0.1/"
    xmlns:bio="http://purl.org/vocab/bio/0.1/"
    xmlns:fc="http://xmlns.com/foaf/corp#"
    xmlns:wot="http://xmlns.com/wot/0.1/"
    xmlns:vcard="http://www.w3.org/2006/vcard/ns"
    xmlns:doap="http://usefulinc.com/ns/doap#"
    xmlns:cv="http://kaste.lv/~captsolo/semweb/resume/cv.rdfs">
    <root>
        <atom:link rel="https://rels.connect.sensiolabs.com/users" href="https://connect.sensiolabs.com/api/users" type="application/vnd.com.sensiolabs.connect+xml"/>
        <atom:link rel="https://rels.connect.sensiolabs.com/clubs" href="https://connect.sensiolabs.com/api/clubs" type="application/vnd.com.sensiolabs.connect+xml" />
        <atom:link rel="https://rels.connect.sensiolabs.com/badges" href="https://connect.sensiolabs.com/api/badges" type="application/vnd.com.sensiolabs.connect+xml" />
        <atom:link rel="https://rels.connect.sensiolabs.com/projects" href="https://connect.sensiolabs.com/api/projects" type="application/vnd.com.sensiolabs.connect+xml" />
        <xhtml:form id="search_users" method="GET" action="https://connect.sensiolabs.com/api/users" enctype="application/x-www-form-urlencoded">
            <xhtml:input type="text" name="q" required="required" />
        </xhtml:form>
        <xhtml:form id="search_clubs" method="GET" action="https://connect.sensiolabs.com/api/clubs" enctype="application/x-www-form-urlencoded">
            <xhtml:input type="text" name="q" required="required" />
        </xhtml:form>
        <xhtml:form id="search_projects" method="GET" action="https://connect.sensiolabs.com/api/projects" enctype="application/x-www-form-urlencoded">
            <xhtml:input type="text" name="q" required="required" />
        </xhtml:form>
    </root>
</api>
```

With `use_bearer_authorization` set to false, we get user information without problems, and can log-in successfully (ohh yeahh).

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<api
    xmlns:xhtml="http://www.w3.org/1999/xhtml"
    xmlns:atom="http://www.w3.org/2005/Atom"
    xmlns:foaf="http://xmlns.com/foaf/0.1/"
    xmlns:bio="http://purl.org/vocab/bio/0.1/"
    xmlns:fc="http://xmlns.com/foaf/corp#"
    xmlns:wot="http://xmlns.com/wot/0.1/"
    xmlns:vcard="http://www.w3.org/2006/vcard/ns"
    xmlns:doap="http://usefulinc.com/ns/doap#"
    xmlns:cv="http://kaste.lv/~captsolo/semweb/resume/cv.rdfs">
    <root>
        <atom:link rel="https://rels.connect.sensiolabs.com/users" href="https://connect.sensiolabs.com/api/users" type="application/vnd.com.sensiolabs.connect+xml"/>
        <atom:link rel="https://rels.connect.sensiolabs.com/clubs" href="https://connect.sensiolabs.com/api/clubs" type="application/vnd.com.sensiolabs.connect+xml" />
        <atom:link rel="https://rels.connect.sensiolabs.com/badges" href="https://connect.sensiolabs.com/api/badges" type="application/vnd.com.sensiolabs.connect+xml" />
        <atom:link rel="https://rels.connect.sensiolabs.com/projects" href="https://connect.sensiolabs.com/api/projects" type="application/vnd.com.sensiolabs.connect+xml" />
        <foaf:Person id="beb9b3bb-6a99-49c9-bb7b-6d5ab172e996">
            <foaf:name><![CDATA[Alain Tiemblo]]></foaf:name>
            <foaf:mbox_sha1sum>c584231f774ce7abd15276f500c27accb9c15851</foaf:mbox_sha1sum>
            <atom:link rel="https://rels.connect.sensiolabs.com/image" href="https://connect.sensiolabs.com/api/images/beb9b3bb-6a99-49c9-bb7b-6d5ab172e996.png" type="image/png" />
            <atom:link rel="self" href="https://connect.sensiolabs.com/api/users/beb9b3bb-6a99-49c9-bb7b-6d5ab172e996" type="application/vnd.com.sensiolabs.connect+xml"/>
            <atom:link rel="self" href="https://connect.sensiolabs.com/api/alternates/beb9b3bb-6a99-49c9-bb7b-6d5ab172e996" type="text/html" />
            <bio:olb><![CDATA[Hello, world!]]></bio:olb>
            <foaf:account>
                <foaf:OnlineAccount>
                    <foaf:name>SensioLabs Connect</foaf:name>
                    <foaf:accountName><![CDATA[ninsuo]]></foaf:accountName>
                    <since>Thu, 11 Jul 2013 18:23:17 +0200</since>
                </foaf:OnlineAccount>
                <foaf:OnlineAccount>
                    <foaf:name>github</foaf:name>
                    <foaf:accountName><![CDATA[Ninsuo]]></foaf:accountName>
                </foaf:OnlineAccount>
                (...)
        </foaf:Person>
        <xhtml:form id="search_users" method="GET" action="https://connect.sensiolabs.com/api/users" enctype="application/x-www-form-urlencoded">
            <xhtml:input type="text" name="q" required="required" />
        </xhtml:form>
        <xhtml:form id="search_clubs" method="GET" action="https://connect.sensiolabs.com/api/clubs" enctype="application/x-www-form-urlencoded">
            <xhtml:input type="text" name="q" required="required" />
        </xhtml:form>
        <xhtml:form id="search_projects" method="GET" action="https://connect.sensiolabs.com/api/projects" enctype="application/x-www-form-urlencoded">
            <xhtml:input type="text" name="q" required="required" />
        </xhtml:form>
    </root>
</api>
```
