### PR TITLE
Clone buzz.client service definition to avoid side-effects

### DIFF
--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -42,7 +42,7 @@ class HWIOAuthExtension extends Extension
         $config = $processor->processConfiguration(new Configuration(), $configs);
 
         // setup buzz client settings
-        $httpClient = $container->getDefinition('buzz.client');
+        $httpClient = clone $container->getDefinition('buzz.client');
         $httpClient->addMethodCall('setVerifyPeer', array($config['http_client']['verify_peer']));
         $httpClient->addMethodCall('setTimeout', array($config['http_client']['timeout']));
         $httpClient->addMethodCall('setMaxRedirects', array($config['http_client']['max_redirects']));


### PR DESCRIPTION
This commit prevents bundle to change `buzz.client` configuration. `hwi_oauth.http_client` should be a new service definition based on default buzz.client configuration.
