### PR TITLE
Fix FOSUBUserProvider::refreshUser not returning reloaded user

### DIFF
--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -123,7 +123,7 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
             throw new UsernameNotFoundException(sprintf('User with ID "%d" could not be reloaded.', $user->getId()));
         }
 
-        return $user;
+        return $reloadedUser;
     }
 
     /**


### PR DESCRIPTION
$user is returned instead of $reloadedUser, so not all user data is available later

see: FOSUBUserProvider (https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Security/UserProvider.php#L71), which I guess this method was copied from
