### PR TITLE
create resource owner salesforce sandbox

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -52,6 +52,7 @@ class Configuration implements ConfigurationInterface
             'qq',
             'reddit',
             'salesforce',
+			'salesforce_sandbox',
             'sensio_connect',
             'sina_weibo',
             'soundcloud',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -52,7 +52,7 @@ class Configuration implements ConfigurationInterface
             'qq',
             'reddit',
             'salesforce',
-			'salesforce_sandbox',
+	    'salesforce_sandbox',
             'sensio_connect',
             'sina_weibo',
             'soundcloud',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -52,7 +52,7 @@ class Configuration implements ConfigurationInterface
             'qq',
             'reddit',
             'salesforce',
-	    'salesforce_sandbox',
+			'salesforce_sandbox',
             'sensio_connect',
             'sina_weibo',
             'soundcloud',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -52,7 +52,7 @@ class Configuration implements ConfigurationInterface
             'qq',
             'reddit',
             'salesforce',
-	    'salesforce_sandbox',
+	        'salesforce_sandbox',
             'sensio_connect',
             'sina_weibo',
             'soundcloud',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -52,7 +52,7 @@ class Configuration implements ConfigurationInterface
             'qq',
             'reddit',
             'salesforce',
-	        'salesforce_sandbox',
+            'salesforce_sandbox',
             'sensio_connect',
             'sina_weibo',
             'soundcloud',

--- a/OAuth/ResourceOwner/SalesforceSandboxResourceOwner.php
+++ b/OAuth/ResourceOwner/SalesforceSandboxResourceOwner.php
@@ -1,56 +1,25 @@
 <?php
 
-namespace Technogym\OAuthBundle\OAuth\ResourceOwner;
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
-use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner;
 
 /**
  * Salesforce Sandbox Resource Owner
  *
  * @author Matteo Rossi <orionerossi@libero.it>
  */
-class SalesforceSandboxResourceOwner extends GenericOAuth2ResourceOwner
+class SalesforceSandboxResourceOwner extends SalesforceResourceOwner
 {
-    /**
-     * {@inheritDoc}
-     */
-    protected $paths = array(
-        'identifier'     => 'user_id',
-        'nickname'       => 'nick_name',
-        'realname'       => 'nick_name',
-        'email'          => 'email',
-        'profilepicture' => 'photos.picture',
-    );
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getUserInformation(array $accessToken, array $extraParameters = array())
-    {
-        // SalesForce returns the infos_url in the OAuth Response Token
-        $this->options['infos_url'] = $accessToken['id'];
-
-        return parent::getUserInformation($accessToken, $extraParameters);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function doGetUserInformationRequest($url, array $parameters = array())
-    {
-        // Salesforce requires format parameter in order for API to return json response
-        $url = $this->normalizeUrl($url, array(
-            'format' => $this->options['format']
-        ));
-
-        // Salesforce require to pass the OAuth token as 'oauth_token' instead of 'access_token'
-        $url = str_replace('access_token', 'oauth_token', $url);
-
-        return $this->httpRequest($url);
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/OAuth/ResourceOwner/SalesforceSandboxResourceOwner.php
+++ b/OAuth/ResourceOwner/SalesforceSandboxResourceOwner.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Technogym\OAuthBundle\OAuth\ResourceOwner;
+
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner;
+
+/**
+ * Salesforce Sandbox Resource Owner
+ *
+ * @author Matteo Rossi <orionerossi@libero.it>
+ */
+class SalesforceSandboxResourceOwner extends GenericOAuth2ResourceOwner
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $paths = array(
+        'identifier'     => 'user_id',
+        'nickname'       => 'nick_name',
+        'realname'       => 'nick_name',
+        'email'          => 'email',
+        'profilepicture' => 'photos.picture',
+    );
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getUserInformation(array $accessToken, array $extraParameters = array())
+    {
+        // SalesForce returns the infos_url in the OAuth Response Token
+        $this->options['infos_url'] = $accessToken['id'];
+
+        return parent::getUserInformation($accessToken, $extraParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function doGetUserInformationRequest($url, array $parameters = array())
+    {
+        // Salesforce requires format parameter in order for API to return json response
+        $url = $this->normalizeUrl($url, array(
+            'format' => $this->options['format']
+        ));
+
+        // Salesforce require to pass the OAuth token as 'oauth_token' instead of 'access_token'
+        $url = str_replace('access_token', 'oauth_token', $url);
+
+        return $this->httpRequest($url);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function configureOptions(OptionsResolverInterface $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults(array(
+            'authorization_url' => 'https://test.salesforce.com/services/oauth2/authorize',
+            'access_token_url'  => 'https://test.salesforce.com/services/oauth2/token',
+
+            // @see SalesforceResourceOwner::getUserInformation()
+            'infos_url'         => null,
+
+            // @see SalesforceResourceOwner::doGetUserInformationRequest()
+            'format'            => 'json',
+        ));
+    }
+
+}

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -41,7 +41,7 @@
         <parameter key="hwi_oauth.resource_owner.qq.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\QQResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.reddit.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\RedditResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.salesforce.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SalesforceResourceOwner</parameter>
-		<parameter key="hwi_oauth.resource_owner.salesforce_sandbox.class">Technogym\OAuthBundle\OAuth\ResourceOwner\SalesforceSandboxResourceOwner</parameter>
+        <parameter key="hwi_oauth.resource_owner.salesforce_sandbox.class">Technogym\OAuthBundle\OAuth\ResourceOwner\SalesforceSandboxResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sensio_connect.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SensioConnectResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sina_weibo.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SinaWeiboResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.soundcloud.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SoundcloudResourceOwner</parameter>

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -41,7 +41,7 @@
         <parameter key="hwi_oauth.resource_owner.qq.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\QQResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.reddit.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\RedditResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.salesforce.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SalesforceResourceOwner</parameter>
-	<parameter key="hwi_oauth.resource_owner.salesforce_sandbox.class">Technogym\OAuthBundle\OAuth\ResourceOwner\SalesforceSandboxResourceOwner</parameter>
+		<parameter key="hwi_oauth.resource_owner.salesforce_sandbox.class">Technogym\OAuthBundle\OAuth\ResourceOwner\SalesforceSandboxResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sensio_connect.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SensioConnectResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sina_weibo.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SinaWeiboResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.soundcloud.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SoundcloudResourceOwner</parameter>

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -41,7 +41,7 @@
         <parameter key="hwi_oauth.resource_owner.qq.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\QQResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.reddit.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\RedditResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.salesforce.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SalesforceResourceOwner</parameter>
-        <parameter key="hwi_oauth.resource_owner.salesforce_sandbox.class">Technogym\OAuthBundle\OAuth\ResourceOwner\SalesforceSandboxResourceOwner</parameter>
+        <parameter key="hwi_oauth.resource_owner.salesforce_sandbox.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SalesforceSandboxResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sensio_connect.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SensioConnectResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sina_weibo.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SinaWeiboResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.soundcloud.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SoundcloudResourceOwner</parameter>

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -41,6 +41,7 @@
         <parameter key="hwi_oauth.resource_owner.qq.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\QQResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.reddit.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\RedditResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.salesforce.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SalesforceResourceOwner</parameter>
+		<parameter key="hwi_oauth.resource_owner.salesforce_sandbox.class">Technogym\OAuthBundle\OAuth\ResourceOwner\SalesforceSandboxResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sensio_connect.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SensioConnectResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sina_weibo.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SinaWeiboResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.soundcloud.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SoundcloudResourceOwner</parameter>

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -41,7 +41,7 @@
         <parameter key="hwi_oauth.resource_owner.qq.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\QQResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.reddit.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\RedditResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.salesforce.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SalesforceResourceOwner</parameter>
-		<parameter key="hwi_oauth.resource_owner.salesforce_sandbox.class">Technogym\OAuthBundle\OAuth\ResourceOwner\SalesforceSandboxResourceOwner</parameter>
+	<parameter key="hwi_oauth.resource_owner.salesforce_sandbox.class">Technogym\OAuthBundle\OAuth\ResourceOwner\SalesforceSandboxResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sensio_connect.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SensioConnectResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sina_weibo.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SinaWeiboResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.soundcloud.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SoundcloudResourceOwner</parameter>


### PR DESCRIPTION
Salesforce oauth service comes in production and sandbox (testing) environments, with different authorization and access_token urls, so I simply added a resource owner to test and use salesforce in a sandboxed environment.
Unfortunately it's not possible to locally configure salesforce sandbox because info_url is not static but a dinamically created one along with access token from salesforce.