### PR TITLE
Avoid logic to be executed at class initialization

### DIFF
--- a/Security/Core/User/EntityUserProvider.php
+++ b/Security/Core/User/EntityUserProvider.php
@@ -33,7 +33,7 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
      * @var ObjectManager
      */
     protected $em;
-    
+
     /**
      * @var string
      */
@@ -63,7 +63,6 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
     {
         $this->em         = $registry->getManager($managerName);
         $this->class      = $class;
-        $this->repository = $this->em->getRepository($class);
         $this->properties = array_merge($this->properties, $properties);
     }
 
@@ -72,7 +71,7 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
      */
     public function loadUserByUsername($username)
     {
-        $user = $this->repository->findOneBy(array('username' => $username));
+        $user = $this->findUser(array('username' => $username));
         if (!$user) {
             throw new UsernameNotFoundException(sprintf("User '%s' not found.", $username));
         }
@@ -92,7 +91,7 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
         }
 
         $username = $response->getUsername();
-        if (null === $user = $this->repository->findOneBy(array($this->properties[$resourceOwnerName] => $username))) {
+        if (null === $user = $this->findUser(array($this->properties[$resourceOwnerName] => $username))) {
             throw new UsernameNotFoundException(sprintf("User '%s' not found.", $username));
         }
 
@@ -111,7 +110,7 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
         }
 
         $userId = $accessor->getValue($user, $identifier);
-        if (null === $user = $this->repository->findOneBy(array($identifier => $userId))) {
+        if (null === $user = $this->findUser(array($identifier => $userId))) {
             throw new UsernameNotFoundException(sprintf('User with ID "%d" could not be reloaded.', $userId));
         }
 
@@ -124,5 +123,19 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
     public function supportsClass($class)
     {
         return $class === $this->class || is_subclass_of($class, $this->class);
+    }
+
+    /**
+     * @param array $criteria
+     *
+     * @return object
+     */
+    private function findUser(array $criteria)
+    {
+        if (null === $this->repository) {
+            $this->repository = $this->em->getRepository($this->class);
+        }
+
+        return $this->repository->findOneBy($criteria);
     }
 }

--- a/Security/Core/User/EntityUserProvider.php
+++ b/Security/Core/User/EntityUserProvider.php
@@ -130,7 +130,7 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
      *
      * @return object
      */
-    private function findUser(array $criteria)
+    protected function findUser(array $criteria)
     {
         if (null === $this->repository) {
             $this->repository = $this->em->getRepository($this->class);

--- a/Tests/Security/Core/User/EntityUserProviderTest.php
+++ b/Tests/Security/Core/User/EntityUserProviderTest.php
@@ -116,7 +116,7 @@ class EntityUserProviderTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $emMock
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getRepository')
             ->will($this->returnValue($this->createRepositoryMock($user)));
 


### PR DESCRIPTION
When using the Oro Platform (or sub-products, like OroCRM), the entity manager is overridden at runtime in order to add dynamic fields to entities (via configuration).

However, if a repository is fetched in the constructor of a service (like it was the case here), the repository does not yet have this runtime magic applied and it breaks the application.

This commit is meant to delay the fetching of the repository to the last possible moment (when querying for users), so that the kernel loading process does not break applications. Moreover, I think removing as much logic as possible from the constructor is a good idea overall.