### PR TITLE
Allow overriding the OAuthToken class.

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -333,7 +333,7 @@ class ConnectController extends ContainerAware
             return;
         }
 
-        $token = new OAuthToken($accessToken, $user->getRoles());
+        $token = $this->getOAuthTokenFactory()->build($accessToken, $user->getRoles());
         $token->setResourceOwnerName($resourceOwnerName);
         $token->setUser($user);
         $token->setAuthenticated(true);
@@ -347,6 +347,14 @@ class ConnectController extends ContainerAware
                 new InteractiveLoginEvent($request, $token)
             );
         }
+    }
+
+    /**
+     * @return \HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory
+     */
+    protected function getOAuthTokenFactory()
+    {
+        return $this->container->get('hwi_oauth.authentication.token_factory.oauth');
     }
 
     /**

--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -350,7 +350,7 @@ class ConnectController extends ContainerAware
     }
 
     /**
-     * @return \HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory
+     * @return \HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactoryInterface
      */
     protected function getOAuthTokenFactory()
     {

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -145,7 +145,6 @@ class HWIOAuthExtension extends Extension
             $definition
                 ->replaceArgument(2, $options)
                 ->replaceArgument(3, $name)
-                ->replaceArgument(5, new Reference('hwi_oauth.authentication.token_factory.oauth'))
             ;
         }
     }

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -145,6 +145,7 @@ class HWIOAuthExtension extends Extension
             $definition
                 ->replaceArgument(2, $options)
                 ->replaceArgument(3, $name)
+                ->replaceArgument(5, new Reference('hwi_oauth.authentication.token_factory.oauth'))
             ;
         }
     }

--- a/DependencyInjection/Security/Factory/OAuthFactory.php
+++ b/DependencyInjection/Security/Factory/OAuthFactory.php
@@ -105,6 +105,7 @@ class OAuthFactory extends AbstractFactory
             ->addArgument($this->createOAuthAwareUserProvider($container, $id, $config['oauth_user_provider']))
             ->addArgument($this->getResourceOwnerMapReference($id))
             ->addArgument(new Reference('hwi_oauth.user_checker'))
+            ->addArgument(new Reference('hwi_oauth.authentication.token_factory.oauth'))
         ;
 
         return $providerId;
@@ -170,6 +171,7 @@ class OAuthFactory extends AbstractFactory
             ->getDefinition($listenerId)
             ->addMethodCall('setResourceOwnerMap', array($this->getResourceOwnerMapReference($id)))
             ->addMethodCall('setCheckPaths', array($checkPaths))
+            ->addMethodCall('setOAuthTokenFactory', array(new Reference('hwi_oauth.authentication.token_factory.oauth')))
         ;
 
         return $listenerId;

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -20,6 +20,7 @@ use HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -66,18 +67,31 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
     protected $storage;
 
     /**
-     * @param HttpClientInterface         $httpClient Buzz http client
-     * @param HttpUtils                   $httpUtils  Http utils
-     * @param array                       $options    Options for the resource owner
-     * @param string                      $name       Name for the resource owner
-     * @param RequestDataStorageInterface $storage    Request token storage
+     * @var OAuthTokenFactory
      */
-    public function __construct(HttpClientInterface $httpClient, HttpUtils $httpUtils, array $options, $name, RequestDataStorageInterface $storage)
-    {
-        $this->httpClient = $httpClient;
-        $this->httpUtils  = $httpUtils;
-        $this->name       = $name;
-        $this->storage    = $storage;
+    protected $oAuthTokenFactory;
+
+    /**
+     * @param HttpClientInterface         $httpClient        Buzz http client
+     * @param HttpUtils                   $httpUtils         Http utils
+     * @param array                       $options           Options for the resource owner
+     * @param string                      $name              Name for the resource owner
+     * @param RequestDataStorageInterface $storage           Request token storage
+     * @param OAuthTokenFactory           $oAuthTokenFactory OAuth Token factory
+     */
+    public function __construct(
+        HttpClientInterface $httpClient,
+        HttpUtils $httpUtils,
+        array $options,
+        $name,
+        RequestDataStorageInterface $storage,
+        OAuthTokenFactory $oAuthTokenFactory
+    ) {
+        $this->httpClient        = $httpClient;
+        $this->httpUtils         = $httpUtils;
+        $this->name              = $name;
+        $this->storage           = $storage;
+        $this->oAuthTokenFactory = $oAuthTokenFactory;
 
         if (!empty($options['paths'])) {
             $this->addPaths($options['paths']);

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -20,7 +20,7 @@ use HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactoryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -67,7 +67,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
     protected $storage;
 
     /**
-     * @var OAuthTokenFactory
+     * @var OAuthTokenFactoryInterface
      */
     protected $oAuthTokenFactory;
 
@@ -77,7 +77,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      * @param array                       $options           Options for the resource owner
      * @param string                      $name              Name for the resource owner
      * @param RequestDataStorageInterface $storage           Request token storage
-     * @param OAuthTokenFactory           $oAuthTokenFactory OAuth Token factory
+     * @param OAuthTokenFactoryInterface  $oAuthTokenFactory OAuth Token factory
      */
     public function __construct(
         HttpClientInterface $httpClient,
@@ -85,7 +85,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
         array $options,
         $name,
         RequestDataStorageInterface $storage,
-        OAuthTokenFactory $oAuthTokenFactory
+        OAuthTokenFactoryInterface $oAuthTokenFactory
     ) {
         $this->httpClient        = $httpClient;
         $this->httpUtils         = $httpUtils;

--- a/OAuth/ResourceOwner/FlickrResourceOwner.php
+++ b/OAuth/ResourceOwner/FlickrResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -54,7 +53,7 @@ class FlickrResourceOwner extends GenericOAuth1ResourceOwner
         $response = $this->getUserResponse();
         $response->setResponse($accessToken);
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $response->setOAuthToken($this->oAuthTokenFactory->build($accessToken));
 
         return $response;
     }

--- a/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -54,7 +53,7 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
         $response = $this->getUserResponse();
         $response->setResponse($content);
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $response->setOAuthToken($this->oAuthTokenFactory->build($accessToken));
 
         return $response;
     }

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -40,7 +39,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
         $response->setResponse($content->getContent());
 
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $response->setOAuthToken($this->oAuthTokenFactory->build($accessToken));
 
         return $response;
     }

--- a/OAuth/ResourceOwner/JiraResourceOwner.php
+++ b/OAuth/ResourceOwner/JiraResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -77,7 +76,7 @@ class JiraResourceOwner extends GenericOAuth1ResourceOwner
         $response = $this->getUserResponse();
         $response->setResponse($content);
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $response->setOAuthToken($this->oAuthTokenFactory->build($accessToken));
 
         return $response;
     }

--- a/OAuth/ResourceOwner/MailRuResourceOwner.php
+++ b/OAuth/ResourceOwner/MailRuResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -56,7 +55,7 @@ class MailRuResourceOwner extends GenericOAuth2ResourceOwner
         $response = $this->getUserResponse();
         $response->setResponse($content);
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $response->setOAuthToken($this->oAuthTokenFactory->build($accessToken));
 
         return $response;
     }

--- a/OAuth/ResourceOwner/OdnoklassnikiResourceOwner.php
+++ b/OAuth/ResourceOwner/OdnoklassnikiResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -47,7 +46,7 @@ class OdnoklassnikiResourceOwner extends GenericOAuth2ResourceOwner
         $response = $this->getUserResponse();
         $response->setResponse($content);
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $response->setOAuthToken($this->oAuthTokenFactory->build($accessToken));
 
         return $response;
     }

--- a/OAuth/ResourceOwner/QQResourceOwner.php
+++ b/OAuth/ResourceOwner/QQResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\MessageInterface as HttpMessageInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
@@ -68,7 +67,7 @@ class QQResourceOwner extends GenericOAuth2ResourceOwner
         $response = $this->getUserResponse();
         $response->setResponse($content);
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $response->setOAuthToken($this->oAuthTokenFactory->build($accessToken));
 
         return $response;
     }

--- a/OAuth/ResourceOwner/SinaWeiboResourceOwner.php
+++ b/OAuth/ResourceOwner/SinaWeiboResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class SinaWeiboResourceOwner extends GenericOAuth2ResourceOwner
@@ -41,7 +40,7 @@ class SinaWeiboResourceOwner extends GenericOAuth2ResourceOwner
         $response = $this->getUserResponse();
         $response->setResponse($content);
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $response->setOAuthToken($this->oAuthTokenFactory->build($accessToken));
 
         return $response;
     }

--- a/OAuth/ResourceOwner/StereomoodResourceOwner.php
+++ b/OAuth/ResourceOwner/StereomoodResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -34,7 +33,7 @@ class StereomoodResourceOwner extends GenericOAuth1ResourceOwner
         $response = $this->getUserResponse();
         $response->setResponse($accessToken);
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $response->setOAuthToken($this->oAuthTokenFactory->build($accessToken));
 
         return $response;
     }

--- a/OAuth/ResourceOwner/VkontakteResourceOwner.php
+++ b/OAuth/ResourceOwner/VkontakteResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\OptionsResolver\Options;
 
@@ -52,7 +51,7 @@ class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
         $response = $this->getUserResponse();
         $response->setResponse($content);
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $response->setOAuthToken($this->oAuthTokenFactory->build($accessToken));
 
         if (isset($accessToken['email'])) {
             $content = $response->getResponse();

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -132,11 +132,13 @@
         <service id="hwi_oauth.abstract_resource_owner.oauth2" class="%hwi_oauth.resource_owner.oauth2.class%"
                  parent="hwi_oauth.abstract_resource_owner.generic" abstract="true">
             <argument type="service" id="hwi_oauth.storage.session" />
+            <argument type="service" id="hwi_oauth.authentication.token_factory.oauth" />
         </service>
 
         <service id="hwi_oauth.abstract_resource_owner.oauth1" class="%hwi_oauth.resource_owner.oauth1.class%"
                  parent="hwi_oauth.abstract_resource_owner.generic" abstract="true">
             <argument type="service" id="hwi_oauth.storage.session" />
+            <argument type="service" id="hwi_oauth.authentication.token_factory.oauth" />
         </service>
     </services>
 </container>

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="hwi_oauth.authentication.listener.oauth.class">HWI\Bundle\OAuthBundle\Security\Http\Firewall\OAuthListener</parameter>
         <parameter key="hwi_oauth.authentication.provider.oauth.class">HWI\Bundle\OAuthBundle\Security\Core\Authentication\Provider\OAuthProvider</parameter>
+        <parameter key="hwi_oauth.authentication.token_factory.oauth.class">HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory</parameter>
         <parameter key="hwi_oauth.authentication.entry_point.oauth.class">HWI\Bundle\OAuthBundle\Security\Http\EntryPoint\OAuthEntryPoint</parameter>
         <parameter key="hwi_oauth.user.provider.class">HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUserProvider</parameter>
         <parameter key="hwi_oauth.user.provider.entity.class">HWI\Bundle\OAuthBundle\Security\Core\User\EntityUserProvider</parameter>
@@ -81,6 +82,7 @@
             <argument type="service" id="http_kernel" />
             <argument type="service" id="security.http_utils" />
         </service>
+        <service id="hwi_oauth.authentication.token_factory.oauth" class="%hwi_oauth.authentication.token_factory.oauth.class%" />
         <service id="hwi_oauth.user.provider" class="%hwi_oauth.user.provider.class%" public="false" />
         <service id="hwi_oauth.user.provider.entity" class="%hwi_oauth.user.provider.entity.class%" abstract="true" public="false">
             <argument type="service" id="doctrine" />

--- a/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -81,7 +81,7 @@ class OAuthProvider implements AuthenticationProviderInterface
             throw $e;
         }
 
-        $token = new OAuthToken($token->getRawToken(), $user->getRoles());
+        $token = $this->createOAuthToken($token->getRawToken(), $user->getRoles());
         $token->setResourceOwnerName($resourceOwner->getName());
         $token->setUser($user);
         $token->setAuthenticated(true);
@@ -89,5 +89,16 @@ class OAuthProvider implements AuthenticationProviderInterface
         $this->userChecker->checkPostAuth($user);
 
         return $token;
+    }
+
+    /**
+     * @param string $accessToken
+     * @param array  $roles
+     *
+     * @return \HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken
+     */
+    protected function createOAuthToken($accessToken, array $roles = array())
+    {
+        return new OAuthToken($accessToken, $roles);
     }
 }

--- a/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Security\Core\Authentication\Provider;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactoryInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAwareExceptionInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthAwareUserProviderInterface;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
@@ -44,7 +44,7 @@ class OAuthProvider implements AuthenticationProviderInterface
     private $userChecker;
 
     /**
-     * @var OAuthTokenFactory
+     * @var OAuthTokenFactoryInterface
      */
     private $oAuthTokenFactory;
 
@@ -52,13 +52,13 @@ class OAuthProvider implements AuthenticationProviderInterface
      * @param OAuthAwareUserProviderInterface $userProvider      User provider
      * @param ResourceOwnerMap                $resourceOwnerMap  Resource owner map
      * @param UserCheckerInterface            $userChecker       User checker
-     * @param OAuthTokenFactory               $oAuthTokenFactory OAuth Token factory
+     * @param OAuthTokenFactoryInterface      $oAuthTokenFactory OAuth Token factory
      */
     public function __construct(
         OAuthAwareUserProviderInterface $userProvider,
         ResourceOwnerMap $resourceOwnerMap,
         UserCheckerInterface $userChecker,
-        OAuthTokenFactory $oAuthTokenFactory
+        OAuthTokenFactoryInterface $oAuthTokenFactory
     ) {
         $this->userProvider      = $userProvider;
         $this->resourceOwnerMap  = $resourceOwnerMap;

--- a/Security/Core/Authentication/Token/OAuthTokenFactory.php
+++ b/Security/Core/Authentication/Token/OAuthTokenFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token;
+
+/**
+ * Builds an OAuth Token.
+ */
+class OAuthTokenFactory
+{
+    /**
+     * @param string|array $accessToken The OAuth access token
+     * @param array        $roles       Roles for the token
+     *
+     * @return OAuthToken|\Symfony\Component\Security\Core\Authentication\Token\TokenInterface
+     */
+    public function build($accessToken, array $roles = array())
+    {
+        return new OAuthToken($accessToken, $roles);
+    }
+}

--- a/Security/Core/Authentication/Token/OAuthTokenFactory.php
+++ b/Security/Core/Authentication/Token/OAuthTokenFactory.php
@@ -5,13 +5,10 @@ namespace HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token;
 /**
  * Builds an OAuth Token.
  */
-class OAuthTokenFactory
+class OAuthTokenFactory implements OAuthTokenFactoryInterface
 {
     /**
-     * @param string|array $accessToken The OAuth access token
-     * @param array        $roles       Roles for the token
-     *
-     * @return OAuthToken|\Symfony\Component\Security\Core\Authentication\Token\TokenInterface
+     * {@inheritDoc}
      */
     public function build($accessToken, array $roles = array())
     {

--- a/Security/Core/Authentication/Token/OAuthTokenFactoryInterface.php
+++ b/Security/Core/Authentication/Token/OAuthTokenFactoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token;
+
+/**
+ * Interface for OAuthTokenFactory.
+ */
+interface OAuthTokenFactoryInterface
+{
+    /**
+     * @param string|array $accessToken The OAuth access token
+     * @param array        $roles       Roles for the token
+     *
+     * @return \HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken
+     */
+    public function build($accessToken, array $roles = array());
+}

--- a/Security/Http/Firewall/OAuthListener.php
+++ b/Security/Http/Firewall/OAuthListener.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Security\Http\Firewall;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactoryInterface;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -38,7 +38,7 @@ class OAuthListener extends AbstractAuthenticationListener
     private $checkPaths;
 
     /**
-     * @var OAuthTokenFactory
+     * @var OAuthTokenFactoryInterface
      */
     private $oAuthTokenFactory;
 
@@ -59,9 +59,9 @@ class OAuthListener extends AbstractAuthenticationListener
     }
 
     /**
-     * @param OAuthTokenFactory $oAuthTokenFactory
+     * @param OAuthTokenFactoryInterface $oAuthTokenFactory
      */
-    public function setOAuthTokenFactory(OAuthTokenFactory $oAuthTokenFactory)
+    public function setOAuthTokenFactory(OAuthTokenFactoryInterface $oAuthTokenFactory)
     {
         $this->oAuthTokenFactory = $oAuthTokenFactory;
     }

--- a/Security/Http/Firewall/OAuthListener.php
+++ b/Security/Http/Firewall/OAuthListener.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Security\Http\Firewall;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -38,7 +38,12 @@ class OAuthListener extends AbstractAuthenticationListener
     private $checkPaths;
 
     /**
-     * @var ResourceOwnerMap $resourceOwnerMap
+     * @var OAuthTokenFactory
+     */
+    private $oAuthTokenFactory;
+
+    /**
+     * @param ResourceOwnerMap $resourceOwnerMap
      */
     public function setResourceOwnerMap(ResourceOwnerMap $resourceOwnerMap)
     {
@@ -51,6 +56,14 @@ class OAuthListener extends AbstractAuthenticationListener
     public function setCheckPaths(array $checkPaths)
     {
         $this->checkPaths = $checkPaths;
+    }
+
+    /**
+     * @param OAuthTokenFactory $oAuthTokenFactory
+     */
+    public function setOAuthTokenFactory(OAuthTokenFactory $oAuthTokenFactory)
+    {
+        $this->oAuthTokenFactory = $oAuthTokenFactory;
     }
 
     /**
@@ -100,7 +113,7 @@ class OAuthListener extends AbstractAuthenticationListener
             $this->httpUtils->createRequest($request, $checkPath)->getUri()
         );
 
-        $token = new OAuthToken($accessToken);
+        $token = $this->oAuthTokenFactory->build($accessToken);
         $token->setResourceOwnerName($resourceOwner->getName());
 
         return $this->authenticationManager->authenticate($token);

--- a/Tests/OAuth/ResourceOwner/AmazonResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/AmazonResourceOwnerTest.php
@@ -37,6 +37,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new AmazonResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new AmazonResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/Auth0ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/Auth0ResourceOwnerTest.php
@@ -57,6 +57,6 @@ json;
             $options
         );
 
-        return new Auth0ResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new Auth0ResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/BitbucketResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/BitbucketResourceOwnerTest.php
@@ -46,6 +46,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new BitbucketResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new BitbucketResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/BitlyResourceOnwerTest.php
+++ b/Tests/OAuth/ResourceOwner/BitlyResourceOnwerTest.php
@@ -34,6 +34,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new BitlyResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new BitlyResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/BoxResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/BoxResourceOwnerTest.php
@@ -50,6 +50,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new BoxResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new BoxResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/DailymotionResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/DailymotionResourceOwnerTest.php
@@ -48,6 +48,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new DailymotionResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new DailymotionResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/DeviantartResourceOnwerTest.php
+++ b/Tests/OAuth/ResourceOwner/DeviantartResourceOnwerTest.php
@@ -48,6 +48,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new DeviantartResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new DeviantartResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/DisqusResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/DisqusResourceOwnerTest.php
@@ -38,6 +38,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new DisqusResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new DisqusResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/DropboxResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/DropboxResourceOwnerTest.php
@@ -33,6 +33,6 @@ class DropboxResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new DropboxResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new DropboxResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/EveOnlineResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/EveOnlineResourceOwnerTest.php
@@ -30,6 +30,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new EveOnlineResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new EveOnlineResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/EventbriteResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/EventbriteResourceOwnerTest.php
@@ -34,6 +34,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new EventbriteResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new EventbriteResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/FacebookResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/FacebookResourceOwnerTest.php
@@ -89,6 +89,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new FacebookResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new FacebookResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/FlickrResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/FlickrResourceOwnerTest.php
@@ -79,6 +79,6 @@ class FlickrResourceOwnerTest extends GenericOAuth1ResourceOwnerTest
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new FlickrResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new FlickrResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/FoursquareResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/FoursquareResourceOwnerTest.php
@@ -35,6 +35,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new FoursquareResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new FoursquareResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth1ResourceOwner;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory;
 use Symfony\Component\HttpFoundation\Request;
 
 class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
@@ -25,6 +26,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     protected $buzzResponse;
     protected $buzzResponseContentType;
     protected $storage;
+    protected $oAuthTokenFactory;
 
     protected $options = array(
         'client_id'           => 'clientid',
@@ -319,6 +321,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()->getMock();
 
         $this->storage = $this->getMock('\HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface');
+        $this->oAuthTokenFactory = new OAuthTokenFactory();
 
         $resourceOwner = $this->setUpResourceOwner($name, $httpUtils, array_merge($this->options, $options));
         $resourceOwner->addPaths(array_merge($this->paths, $paths));
@@ -328,6 +331,6 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new GenericOAuth1ResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new GenericOAuth1ResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth1ResourceOwner;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpFoundation\Request;
 
 class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
@@ -321,7 +321,16 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()->getMock();
 
         $this->storage = $this->getMock('\HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface');
-        $this->oAuthTokenFactory = new OAuthTokenFactory();
+        $this->oAuthTokenFactory = $this->getMock('\HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory');
+        $this->oAuthTokenFactory->expects($this->any())
+            ->method('build')
+            ->will(
+                $this->returnCallback(
+                    function ($accessToken, array $roles = array()) {
+                        return new OAuthToken($accessToken, $roles);
+                    }
+                )
+            );
 
         $resourceOwner = $this->setUpResourceOwner($name, $httpUtils, array_merge($this->options, $options));
         $resourceOwner->addPaths(array_merge($this->paths, $paths));

--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -321,7 +321,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()->getMock();
 
         $this->storage = $this->getMock('\HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface');
-        $this->oAuthTokenFactory = $this->getMock('\HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory');
+        $this->oAuthTokenFactory = $this->getMock('\HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactoryInterface');
         $this->oAuthTokenFactory->expects($this->any())
             ->method('build')
             ->will(

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -356,7 +356,7 @@ json;
             ->disableOriginalConstructor()->getMock();
 
         $this->storage = $this->getMock('\HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface');
-        $this->oAuthTokenFactory = $this->getMock('\HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory');
+        $this->oAuthTokenFactory = $this->getMock('\HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactoryInterface');
         $this->oAuthTokenFactory->expects($this->any())
             ->method('build')
             ->will(

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -14,6 +14,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
 use Buzz\Message\MessageInterface;
 use Buzz\Message\RequestInterface;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory;
 use Symfony\Component\HttpFoundation\Request;
 
 class GenericOAuth2ResourceOwnerTest extends \PHPUnit_Framework_TestCase
@@ -28,6 +29,7 @@ class GenericOAuth2ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     protected $buzzResponseContentType;
     protected $buzzResponseHttpCode = 200;
     protected $storage;
+    protected $oAuthTokenFactory;
     protected $state = 'random';
     protected $csrf = false;
 
@@ -354,6 +356,7 @@ json;
             ->disableOriginalConstructor()->getMock();
 
         $this->storage = $this->getMock('\HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface');
+        $this->oAuthTokenFactory = new OAuthTokenFactory();
 
         $resourceOwner = $this->setUpResourceOwner($name, $httpUtils, array_merge($this->options, $options));
         $resourceOwner->addPaths(array_merge($this->paths, $paths));
@@ -368,6 +371,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new GenericOAuth2ResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new GenericOAuth2ResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -14,7 +14,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
 use Buzz\Message\MessageInterface;
 use Buzz\Message\RequestInterface;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpFoundation\Request;
 
 class GenericOAuth2ResourceOwnerTest extends \PHPUnit_Framework_TestCase
@@ -356,7 +356,16 @@ json;
             ->disableOriginalConstructor()->getMock();
 
         $this->storage = $this->getMock('\HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface');
-        $this->oAuthTokenFactory = new OAuthTokenFactory();
+        $this->oAuthTokenFactory = $this->getMock('\HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory');
+        $this->oAuthTokenFactory->expects($this->any())
+            ->method('build')
+            ->will(
+                $this->returnCallback(
+                    function ($accessToken, array $roles = array()) {
+                        return new OAuthToken($accessToken, $roles);
+                    }
+                )
+            );
 
         $resourceOwner = $this->setUpResourceOwner($name, $httpUtils, array_merge($this->options, $options));
         $resourceOwner->addPaths(array_merge($this->paths, $paths));

--- a/Tests/OAuth/ResourceOwner/GitHubResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GitHubResourceOwnerTest.php
@@ -48,6 +48,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new GitHubResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new GitHubResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
@@ -113,6 +113,6 @@ json;
             $options
         );
 
-        return new GoogleResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new GoogleResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/HubicResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/HubicResourceOwnerTest.php
@@ -33,6 +33,6 @@ class HubicResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new HubicResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new HubicResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/InstagramResourceOnwerTest.php
+++ b/Tests/OAuth/ResourceOwner/InstagramResourceOnwerTest.php
@@ -44,6 +44,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new InstagramResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new InstagramResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/JiraResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/JiraResourceOwnerTest.php
@@ -80,6 +80,6 @@ class JiraResourceOwnerTest extends GenericOAuth1ResourceOwnerTest
             $options
         );
 
-        return new JiraResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new JiraResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/LinkedinResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/LinkedinResourceOwnerTest.php
@@ -36,6 +36,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new LinkedinResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new LinkedinResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/MailRuResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/MailRuResourceOwnerTest.php
@@ -33,6 +33,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new MailRuResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new MailRuResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/OdnoklassnikiResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/OdnoklassnikiResourceOwnerTest.php
@@ -37,6 +37,6 @@ json;
             $options
         );
 
-        return new OdnoklassnikiResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new OdnoklassnikiResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/PaypalResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/PaypalResourceOwnerTest.php
@@ -40,6 +40,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new PaypalResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new PaypalResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/QQResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/QQResourceOwnerTest.php
@@ -43,7 +43,7 @@ json;
             $options
         );
 
-        return new QQResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new QQResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 
     /**

--- a/Tests/OAuth/ResourceOwner/RedditResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/RedditResourceOwnerTest.php
@@ -37,6 +37,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new RedditResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new RedditResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/SalesforceResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/SalesforceResourceOwnerTest.php
@@ -57,6 +57,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new SalesforceResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new SalesforceResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/SensioConnectResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/SensioConnectResourceOwnerTest.php
@@ -44,6 +44,6 @@ class SensioConnectResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new SensioConnectResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new SensioConnectResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/SinaWeiboResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/SinaWeiboResourceOwnerTest.php
@@ -31,7 +31,7 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new SinaWeiboResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new SinaWeiboResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 
     public function testGetUserInformation()

--- a/Tests/OAuth/ResourceOwner/SoundcloudResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/SoundcloudResourceOwnerTest.php
@@ -36,6 +36,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new SoundcloudResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new SoundcloudResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/StackExchangeResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/StackExchangeResourceOwnerTest.php
@@ -35,6 +35,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new StackExchangeResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new StackExchangeResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/StereomoodResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/StereomoodResourceOwnerTest.php
@@ -62,6 +62,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new StereomoodResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new StereomoodResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwnerTest.php
@@ -38,6 +38,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new ThirtySevenSignalsResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new ThirtySevenSignalsResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/ToshlResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/ToshlResourceOwnerTest.php
@@ -70,6 +70,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new ToshlResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new ToshlResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/TrelloResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/TrelloResourceOwnerTest.php
@@ -32,6 +32,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new TrelloResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new TrelloResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/TwitchResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/TwitchResourceOwnerTest.php
@@ -35,6 +35,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new TwitchResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new TwitchResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/TwitterResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/TwitterResourceOwnerTest.php
@@ -44,6 +44,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new TwitterResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new TwitterResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/VkontakteResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/VkontakteResourceOwnerTest.php
@@ -32,6 +32,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new VkontakteResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new VkontakteResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/WindowsLiveResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/WindowsLiveResourceOwnerTest.php
@@ -30,6 +30,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new WindowsLiveResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new WindowsLiveResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/WordpressResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/WordpressResourceOwnerTest.php
@@ -35,6 +35,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new WordpressResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new WordpressResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/XingResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/XingResourceOwnerTest.php
@@ -58,6 +58,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new XingResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new XingResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/YahooResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/YahooResourceOwnerTest.php
@@ -62,6 +62,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new YahooResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new YahooResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/OAuth/ResourceOwner/YandexResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/YandexResourceOwnerTest.php
@@ -31,6 +31,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new YandexResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new YandexResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage, $this->oAuthTokenFactory);
     }
 }

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -13,7 +13,6 @@ namespace HWI\Bundle\OAuthBundle\Tests\Security\Core\Authentication\Provider;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Provider\OAuthProvider;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\OAuthAwareException;
 
 class OAuthProviderTest extends \PHPUnit_Framework_TestCase
@@ -212,7 +211,7 @@ class OAuthProviderTest extends \PHPUnit_Framework_TestCase
 
     protected function getOAuthTokenFactoryMock()
     {
-        return $this->getMock('\HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory');
+        return $this->getMock('\HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactoryInterface');
     }
 
     protected function getUserMock()

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -13,13 +13,19 @@ namespace HWI\Bundle\OAuthBundle\Tests\Security\Core\Authentication\Provider;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Provider\OAuthProvider;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\OAuthAwareException;
 
 class OAuthProviderTest extends \PHPUnit_Framework_TestCase
 {
     public function testSupportsOAuthToken()
     {
-        $oauthProvider = new OAuthProvider($this->getOAuthAwareUserProviderMock(), $this->getResourceOwnerMapMock(), $this->getUserCheckerMock());
+        $oauthProvider = new OAuthProvider(
+            $this->getOAuthAwareUserProviderMock(),
+            $this->getResourceOwnerMapMock(),
+            $this->getUserCheckerMock(),
+            $this->getOAuthTokenFactoryMock()
+        );
         $this->assertTrue($oauthProvider->supports(new OAuthToken('')));
     }
 
@@ -31,6 +37,7 @@ class OAuthProviderTest extends \PHPUnit_Framework_TestCase
             'expires_in'    => '666',
             'oauth_token_secret' => 'secret'
         );
+        $expectedRoles = array('ROLE_TEST');
 
         $oauthTokenMock = $this->getOAuthTokenMock();
         $oauthTokenMock->expects($this->once())
@@ -58,7 +65,7 @@ class OAuthProviderTest extends \PHPUnit_Framework_TestCase
         $userMock = $this->getUserMock();
         $userMock->expects($this->once())
             ->method('getRoles')
-            ->will($this->returnValue(array('ROLE_TEST')));
+            ->will($this->returnValue($expectedRoles));
 
         $userProviderMock = $this->getOAuthAwareUserProviderMock();
         $userProviderMock->expects($this->once())
@@ -70,7 +77,17 @@ class OAuthProviderTest extends \PHPUnit_Framework_TestCase
             ->method('checkPostAuth')
             ->with($userMock);
 
-        $oauthProvider = new OAuthProvider($userProviderMock, $resourceOwnerMapMock, $userCheckerMock);
+        $oAuthTokenFactoryMock = $this->getOAuthTokenFactoryMock();
+        $oAuthTokenFactoryMock->expects($this->once())
+            ->method('build')
+            ->will($this->returnValue(new OAuthToken($expectedToken, $expectedRoles)));
+
+        $oauthProvider = new OAuthProvider(
+            $userProviderMock,
+            $resourceOwnerMapMock,
+            $userCheckerMock,
+            $oAuthTokenFactoryMock
+        );
 
         $token = $oauthProvider->authenticate($oauthTokenMock);
         $this->assertTrue($token->isAuthenticated());
@@ -136,7 +153,14 @@ class OAuthProviderTest extends \PHPUnit_Framework_TestCase
 
         $userCheckerMock = $this->getUserCheckerMock();
 
-        $oauthProvider = new OAuthProvider($userProviderMock, $resourceOwnerMapMock, $userCheckerMock);
+        $oAuthTokenFactoryMock = $this->getOAuthTokenFactoryMock();
+
+        $oauthProvider = new OAuthProvider(
+            $userProviderMock,
+            $resourceOwnerMapMock,
+            $userCheckerMock,
+            $oAuthTokenFactoryMock
+        );
 
         try {
             $oauthProvider->authenticate($oauthTokenMock);
@@ -184,6 +208,11 @@ class OAuthProviderTest extends \PHPUnit_Framework_TestCase
     protected function getUserCheckerMock()
     {
         return $this->getMock('\Symfony\Component\Security\Core\User\UserCheckerInterface');
+    }
+
+    protected function getOAuthTokenFactoryMock()
+    {
+        return $this->getMock('\HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthTokenFactory');
     }
 
     protected function getUserMock()


### PR DESCRIPTION
Hello,

To integrate this bundle inside OroCRM, I need to have my own Token that will extend OAuthToken and implement `Oro\Bundle\SecurityBundle\Authentication\Token\OrganizationContextTokenInterface`.

To do that, I need to be able to change every creation of `OAuthToken` class by my own.
How would you do that ? Create a Factory class ? WDYT ?