### PR TITLE
Extract method to disconnect users

### DIFF
--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -109,7 +109,7 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
         $username = $response->getUsername();
 
         if (null !== $previousUser = $this->userManager->findUserBy(array($property => $username))) {
-            $this->disconnect($previousUser);
+            $this->disconnect($previousUser, $response);
         }
 
         $this->accessor->setValue($user, $property, $username);
@@ -122,7 +122,7 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
      * 
      * @param UserInterface $user
      */
-    public function disconnect(UserInterface $user)
+    public function disconnect(UserInterface $user, UserResponseInterface $response)
     {
         $property = $this->getProperty($response);
 

--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -121,6 +121,7 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
      * Disconnects a user
      * 
      * @param UserInterface $user
+     * @param UserResponseInterface $response
      */
     public function disconnect(UserInterface $user, UserResponseInterface $response)
     {

--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -109,13 +109,24 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
         $username = $response->getUsername();
 
         if (null !== $previousUser = $this->userManager->findUserBy(array($property => $username))) {
-            $this->accessor->setValue($previousUser, $property, null);
-
-            $this->userManager->updateUser($previousUser);
+            $this->disconnect($previousUser);
         }
 
         $this->accessor->setValue($user, $property, $username);
 
+        $this->userManager->updateUser($user);
+    }
+    
+    /**
+     * Disconnects a user
+     * 
+     * @param UserInterface $user
+     */
+    public function disconnect(UserInterface $user)
+    {
+        $property = $this->getProperty($response);
+
+        $this->accessor->setValue($user, $property, null);
         $this->userManager->updateUser($user);
     }
 


### PR DESCRIPTION
This lets me override parts of the code to add token-storage without having to copy paste the whole connect logic:

```php
class UserProvider extends FOSUBUserProvider
{
    public function loadUserByOAuthUserResponse(UserResponseInterface $response)
    {
        $user = parent::loadUserByOAuthUserResponse($response);
        $user->setGithubToken($response->getAccessToken());

        return $user;
    }

    public function disconnect(UserInterface $user)
    {
        $user->setGithubToken(null);
        parent::disconnectUser($user);
    }
}
```