### PR TITLE
Add getter / setter for OAuthToken createdAt property

### DIFF
--- a/Security/Core/Authentication/Token/OAuthToken.php
+++ b/Security/Core/Authentication/Token/OAuthToken.php
@@ -176,6 +176,22 @@ class OAuthToken extends AbstractToken
     }
 
     /**
+     * @param integer $createdAt The token creation date in seconds
+     */
+    public function setCreatedAt($createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    /**
      * @return integer
      */
     public function getExpiresAt()


### PR DESCRIPTION
Hi there,

I need to persist the OAuthToken in database, and I'd like to only persist `rawToken` information to avoid unnecessary user serialization.

I need to do so to be able to re-inject a createdAt value in a freshly created OAuthToken object.

Can I also create another PR where variables are `protected` and not `private` to be able to extend more easily the OAuthToken class?

Thanks a lot

Best