### PR TITLE
OAuthToken protected properties

### DIFF
--- a/Security/Core/Authentication/Token/OAuthToken.php
+++ b/Security/Core/Authentication/Token/OAuthToken.php
@@ -25,37 +25,37 @@ class OAuthToken extends AbstractToken
     /**
      * @var string
      */
-    private $accessToken;
+    protected $accessToken;
 
     /**
      * @var array
      */
-    private $rawToken;
+    protected $rawToken;
 
     /**
      * @var string
      */
-    private $refreshToken;
+    protected $refreshToken;
 
     /**
      * @var integer
      */
-    private $expiresIn;
+    protected $expiresIn;
 
     /**
      * @var integer
      */
-    private $createdAt;
+    protected $createdAt;
 
     /**
      * @var string
      */
-    private $tokenSecret;
+    protected $tokenSecret;
 
     /**
      * @var string
      */
-    private $resourceOwnerName;
+    protected $resourceOwnerName;
 
     /**
      * @param string|array $accessToken The OAuth access token


### PR DESCRIPTION
I really need in fact to extend OAuthToken (see #700), and to do so I need to access to parent properties, `protected` instead or `private` won't harm the existing and would allow much more flexibility.

Thanks