### PR TITLE
Fix revokeToken methods for Google and Facebook

### DIFF
--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -67,10 +67,9 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
             'client_secret' => $this->options['client_secret'],
         );
 
-        $response = $this->httpRequest($this->normalizeUrl($this->options['revoke_token_url'], array('token' => $token)), $parameters, array(), HttpRequestInterface::METHOD_POST);
-        $response = $this->getResponseContent($response);
+        $response = $this->httpRequest($this->normalizeUrl($this->options['revoke_token_url'], array('access_token' => $token)), $parameters, array(), HttpRequestInterface::METHOD_DELETE);
 
-        return 'true' == $response;
+        return 200 == $response->getStatusCode();
     }
 
     /**
@@ -83,7 +82,7 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
         $resolver->setDefaults(array(
             'authorization_url'   => 'https://www.facebook.com/dialog/oauth',
             'access_token_url'    => 'https://graph.facebook.com/oauth/access_token',
-            'revoke_token_url'    => 'https://graph.facebook.com/me/permissions',
+            'revoke_token_url'    => 'https://graph.facebook.com/me/permissions',//'https://graph.facebook.com/me/permissions',
             'infos_url'           => 'https://graph.facebook.com/me',
 
             'use_commas_in_scope' => true,

--- a/OAuth/ResourceOwner/GoogleResourceOwner.php
+++ b/OAuth/ResourceOwner/GoogleResourceOwner.php
@@ -11,6 +11,9 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
+use Buzz\Browser;
+use Buzz\Client\Curl;
+use Buzz\Message\RequestInterface as HttpRequestInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -44,6 +47,16 @@ class GoogleResourceOwner extends GenericOAuth2ResourceOwner
             'hd'                      => $this->options['hd'],
             'prompt'                  => $this->options['prompt']
         ), $extraParameters));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function revokeToken($token)
+    {
+        $response = $this->httpRequest($this->normalizeUrl($this->options['revoke_token_url'], array('token' => $token)));
+
+        return 200 == $response->getStatusCode();
     }
 
     /**

--- a/Tests/OAuth/ResourceOwner/FacebookResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/FacebookResourceOwnerTest.php
@@ -45,7 +45,7 @@ json;
         $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, array('display' => 'popup'));
 
         $this->assertEquals(
-            $this->options['authorization_url'] . '&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&display=popup',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&display=popup',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }
@@ -60,14 +60,16 @@ json;
 
     public function testRevokeToken()
     {
-        $this->mockBuzz('true', 'application/json');
+        $this->buzzResponseHttpCode = 200;
+        $this->mockBuzz('{"access_token": "bar"}', 'application/json');
 
         $this->assertTrue($this->resourceOwner->revokeToken('token'));
     }
 
     public function testRevokeTokenFails()
     {
-        $this->mockBuzz('false', 'application/json');
+        $this->buzzResponseHttpCode = 401;
+        $this->mockBuzz('{"access_token": "bar"}', 'application/json');
 
         $this->assertFalse($this->resourceOwner->revokeToken('token'));
     }
@@ -81,7 +83,7 @@ json;
 
         $request = new Request(array(
             'error_code'    => 901,
-            'error_message' => 'This app is in sandbox mode.  Edit the app configuration at http://developers.facebook.com/apps to make the app publicly visible.'
+            'error_message' => 'This app is in sandbox mode.  Edit the app configuration at http://developers.facebook.com/apps to make the app publicly visible.',
         ));
 
         $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');


### PR DESCRIPTION
This commit fixes the way the resource owners revoke tokens for Google and Facebook