### PR TITLE
fix the version for fosuserbundle changing major version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,8 @@
         "symfony/security-bundle":      "~2.1",
         "symfony/options-resolver":     "~2.1",
         "kriswallsmith/buzz":           "~0.7",
-        "symfony/yaml": "~2.3"
+        "symfony/yaml": "~2.3",
+        "friendsofsymfony/user-bundle": ">2@dev"
     },
 
     "require-dev": {


### PR DESCRIPTION
In version 2 development FosUserBundle the namespace changes and they are no longer compatible with the retro implementation that is in the bundle