### PR TITLE
Display option added

### DIFF
--- a/Resources/doc/bonus/facebook-connect.md
+++ b/Resources/doc/bonus/facebook-connect.md
@@ -17,6 +17,8 @@ hwi_oauth:
             client_id:     <client_id>
             client_secret: <client_secret>
             scope:         "email"
+            options:
+                display: popup #dialog is optimized for popup window            
 
 services:
     hwi_oauth.user.provider.entity:


### PR DESCRIPTION
Display option is required. An error occurs if the display option is not defined ("The option "display" with value null is invalid. Accepted values are: "page", "popup", "touch".").