### PR TITLE
Allow approval_prompt option to GoogleResourceOwner to be null.

### DIFF
--- a/OAuth/ResourceOwner/GoogleResourceOwner.php
+++ b/OAuth/ResourceOwner/GoogleResourceOwner.php
@@ -75,7 +75,7 @@ class GoogleResourceOwner extends GenericOAuth2ResourceOwner
             // @link https://developers.google.com/accounts/docs/OAuth2WebServer#offline
             'access_type'     => array('online', 'offline'),
             // sometimes we need to force for approval prompt (e.g. when we lost refresh token)
-            'approval_prompt' => array('force', 'auto'),
+            'approval_prompt' => array(null, 'force', 'auto'),
             // @link https://developers.google.com/accounts/docs/OAuth2Login#authenticationuriparameters
             'display'         => array('page', 'popup', 'touch', 'wap'),
             'login_hint'      => array('email address', 'sub'),


### PR DESCRIPTION
The approval_prompt and prompt query string parameters cannot be used together with google auth.  The GoogleResourceOwner was requiring a value for approval_prompt which means that prompt could never be used.  This change makes approval_prompt optional.

One note - a unit test run against the master HEAD (before this change) had about 78 failures in my environment (PHP 5.4 on Debian wheezy).  Is  that expected?