### PR TITLE
Fix #691: compatibility with Symfony <2.5

### DIFF
--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -159,7 +159,12 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
         $accessor = PropertyAccess::createPropertyAccessor();
         $accessor->setValue($user, 'username', $this->getUniqueUserName($userInformation->getNickname()));
 
-        if ($accessor->isWritable($user, 'email')) {
+        // compatibility with Symfony <2.5
+        if (!method_exists($accessor, 'isWritable')) {
+            if (is_callable(array($user, 'setEmail'))) {
+                $user->setEmail($userInformation->getEmail());
+            }
+        } elseif ($accessor->isWritable($user, 'email')) {
             $accessor->setValue($user, 'email', $userInformation->getEmail());
         }
 

--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -102,7 +102,15 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
 
         $property = $this->getProperty($response);
 
-        if (!$this->accessor->isWritable($user, $property)) {
+        // compatibility with Symfony <2.5
+        if (!method_exists($this->accessor, 'isWritable')) {
+            $camelizedSetter = 'set'.strtr(ucwords(strtr($property, array('_' => ' '))), array(' ' => ''));
+            $isPropertyWritable = is_callable(array($user, $camelizedSetter));
+        } else {
+            $isPropertyWritable = $this->accessor->isWritable($user, $property);
+        }
+
+        if (!$isPropertyWritable) {
             throw new \RuntimeException(sprintf("Class '%s' must have defined setter method for property: '%s'.", get_class($user), $property));
         }
 

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
 
     "require-dev": {
         "doctrine/orm":                 "~2.3",
-        "symfony/property-access":      "~2.5",
+        "symfony/property-access":      "~2.3",
         "symfony/validator":            "~2.1",
         "symfony/twig-bundle":          "~2.1"
     },


### PR DESCRIPTION
`PropertyAccess::isWritable` was only [introduced](http://symfony.com/doc/2.5/components/property_access/introduction.html#checking-property-paths) in Symfony 2.5