### PR TITLE
Use another class to decorate an oauth resource owner

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -239,6 +239,21 @@ class Configuration implements ConfigurationInterface
                                     ->thenUnset()
                                 ->end()
                             ->end()
+                            ->scalarNode('class')
+                                ->info('Set the class to use, decorating the type')
+                                ->validate()
+                                    ->ifTrue(function($v) {
+                                        return empty($v);
+                                    })
+                                    ->thenUnset()
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(function($class) {
+                                        return !in_array('HWI\\Bundle\\OAuthBundle\\OAuth\\ResourceOwnerInterface', class_implements($class));
+                                    })
+                                    ->thenInvalid('Invalid class "%s", it should implement "HWI\\Bundle\\OAuthBundle\\OAuth\\ResourceOwnerInterface"')
+                                ->end()
+                            ->end()
                             ->arrayNode('paths')
                                 ->useAttributeAsKey('name')
                                 ->prototype('variable')
@@ -297,6 +312,11 @@ class Configuration implements ConfigurationInterface
                                     return false;
                                 }
 
+                                // skip if this is a decorated 'oauth1' or 'oauth2' type - it should handle its own mess
+                                if (isset($c['class'])) {
+                                    return false;
+                                }
+
                                 $children = array('authorization_url', 'access_token_url', 'request_token_url', 'infos_url');
                                 foreach ($children as $child) {
                                     // This option exists only for OAuth1.0a
@@ -322,6 +342,11 @@ class Configuration implements ConfigurationInterface
 
                                 // Only validate the 'oauth2' and 'oauth1' type
                                 if ('oauth2' !== $c['type'] && 'oauth1' !== $c['type']) {
+                                    return false;
+                                }
+
+                                // skip if this is a decorated 'oauth1' or 'oauth2' type - it should handle its own mess
+                                if (isset($c['class'])) {
                                     return false;
                                 }
 

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -139,8 +139,11 @@ class HWIOAuthExtension extends Extension
             $type = $options['type'];
             unset($options['type']);
 
+            $class = isset($options['class']) ? $options['class'] : "%hwi_oauth.resource_owner.$type.class%";
+            unset($options['class']);
+
             $definition = new DefinitionDecorator('hwi_oauth.abstract_resource_owner.'.Configuration::getResourceOwnerType($type));
-            $definition->setClass(isset($options['class']) ? $options['class'] : "%hwi_oauth.resource_owner.$type.class%");
+            $definition->setClass($class);
             $container->setDefinition('hwi_oauth.resource_owner.'.$name, $definition);
             $definition
                 ->replaceArgument(2, $options)

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -140,7 +140,7 @@ class HWIOAuthExtension extends Extension
             unset($options['type']);
 
             $definition = new DefinitionDecorator('hwi_oauth.abstract_resource_owner.'.Configuration::getResourceOwnerType($type));
-            $definition->setClass("%hwi_oauth.resource_owner.$type.class%");
+            $definition->setClass(isset($options['class']) ? $options['class'] : "%hwi_oauth.resource_owner.$type.class%");
             $container->setDefinition('hwi_oauth.resource_owner.'.$name, $definition);
             $definition
                 ->replaceArgument(2, $options)

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -378,6 +378,8 @@ EOF;
 
     protected function getFullConfig()
     {
+        $decoratedClass = get_class($this->getMock('HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface'));
+
         $yaml = <<<EOF
 firewall_name: secured_area
 
@@ -433,6 +435,14 @@ resource_owners:
         paths:
             identifier: id
             nickname:   username
+
+    decorated:
+        type:                oauth
+        class:               {$decoratedClass}
+        client_id:           client_id
+        client_secret:       client_secret
+        options:
+            foo: bar
 
 fosub:
     username_iterations: 30


### PR DESCRIPTION
This is another approach to #718. I added a `class` config key for the resource owners, telling the extension to use this class instead of the matching one for the type, decorating the type. The type should be `oauth1` or `oauth2`, or maybe add a new `custom` type ? I didn't put any verification on it though (should I ?).

this allows to have a custom class for a given type, and to handle the options however we like (put more options, ... etc), as long as the interface is implemented. I was not sure for the verification if I should have matched the verification against the interface or the abstract class... 

I'm open to suggestions.