### PR TITLE
Configurable redirect when user denies auth. Resolves #363

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -184,7 +184,7 @@ class ConnectController extends ContainerAware
         }
 
         // Redirect to the login path if the token is empty (Eg. User cancelled auth)
-        if ($accessToken === null) {
+        if (null === $accessToken) {
             $redirect = $this->container->getParameter('hwi_oauth.failed_auth_path');
 
             return new RedirectResponse($this->generate($redirect));

--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -183,6 +183,13 @@ class ConnectController extends ContainerAware
             $accessToken = $session->get('_hwi_oauth.connect_confirmation.'.$key);
         }
 
+        // Redirect to the login path if the token is empty (Eg. User cancelled auth)
+        if ($accessToken === null) {
+            $redirect = $this->container->getParameter('hwi_oauth.failed_auth_path');
+
+            return new RedirectResponse($this->generate($redirect));
+        }
+        
         $userInformation = $resourceOwner->getUserInformation($accessToken);
 
         // Show confirmation page?

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -129,6 +129,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('target_path_parameter')->defaultNull()->end()
                 ->booleanNode('use_referer')->defaultFalse()->end()
                 ->scalarNode('templating_engine')->defaultValue('twig')->end()
+                ->scalarNode('failed_auth_path')->defaultValue('hwi_oauth_connect')->end()
             ->end()
         ;
 

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -60,6 +60,9 @@ class HWIOAuthExtension extends Extension
         // set use referer parameter
         $container->setParameter('hwi_oauth.use_referer', $config['use_referer']);
 
+        // set failed auth path
+        $container->setParameter('hwi_oauth.failed_auth_path', $config['failed_auth_path']);
+        
         // setup services for all configured resource owners
         $resourceOwners = array();
         foreach ($config['resource_owners'] as $name => $options) {

--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -139,7 +139,7 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
             throw new UsernameNotFoundException(sprintf('User with ID "%d" could not be reloaded.', $userId));
         }
 
-        return $reloadedUser;
+        return $user;
     }
 
     /**

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -242,6 +242,7 @@ class HWIOAuthExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertParameter('secured_area', 'hwi_oauth.firewall_name');
         $this->assertParameter(null, 'hwi_oauth.target_path_parameter');
         $this->assertParameter(false, 'hwi_oauth.use_referer');
+        $this->assertParameter('hwi_oauth_connect', 'hwi_oauth.failed_auth_path');
         $this->assertParameter(array('any_name', 'some_service'), 'hwi_oauth.resource_owners');
 
         $this->assertNotHasDefinition('hwi_oauth.user.provider.fosub_bridge');


### PR DESCRIPTION
Added config param to set a custom path if the user denies auth at the other end (eg. clicking cancel on the Twitter auth page), otherwise defaults to return to the connect services path.