### PR TITLE
Spread the $parameters argument to the httpRequest call

### DIFF
--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -177,7 +177,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
      */
     protected function doGetUserInformationRequest($url, array $parameters = array())
     {
-        return $this->httpRequest($url);
+        return $this->httpRequest($url, http_build_query($parameters, '', '&'));
     }
 
     /**


### PR DESCRIPTION
If we deactivate the option use_bearer_authorization, and use a set of parameters instead, the httpRequest did not receive these parameters as they aren't used