### PR TITLE
[BC Break] Symfony 2.6+ compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,14 @@ php:
   - 5.5
   - 5.6
   - hhvm
- 
+
 matrix:
     allow_failures:
         - php: hhvm
 
 env:
-  - SYMFONY_VERSION='2.3.*' FOSUSERBUNDLE_VERSION='~1.2'
-  - SYMFONY_VERSION='2.4.*' FOSUSERBUNDLE_VERSION='~1.2'
-  - SYMFONY_VERSION='2.3.*' FOSUSERBUNDLE_VERSION='2.0.*@dev'
-  - SYMFONY_VERSION='2.4.*' FOSUSERBUNDLE_VERSION='2.0.*@dev'
+  - SYMFONY_VERSION='2.6.*' FOSUSERBUNDLE_VERSION='~1.3'
+  - SYMFONY_VERSION='2.6.*' FOSUSERBUNDLE_VERSION='2.0.*@dev'
 
 before_script:
     - composer require --no-update symfony/symfony=${SYMFONY_VERSION}

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -21,7 +21,6 @@ use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\HttpUtils;
 
@@ -301,9 +300,9 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
     /**
      * Configure the option resolver
      *
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setRequired(array(
             'client_id',

--- a/OAuth/ResourceOwner/AmazonResourceOwner.php
+++ b/OAuth/ResourceOwner/AmazonResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * AmazonResourceOwner
@@ -33,7 +33,7 @@ class AmazonResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/Auth0ResourceOwner.php
+++ b/OAuth/ResourceOwner/Auth0ResourceOwner.php
@@ -11,10 +11,9 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Buzz\Message\Response;
-use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Buzz\Message\RequestInterface as HttpRequestInterface;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Auth0ResourceOwner
@@ -51,7 +50,7 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults(array(

--- a/OAuth/ResourceOwner/BitbucketResourceOwner.php
+++ b/OAuth/ResourceOwner/BitbucketResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * BitbucketResourceOwner
@@ -33,7 +33,7 @@ class BitbucketResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/BitlyResourceOwner.php
+++ b/OAuth/ResourceOwner/BitlyResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * BitlyResourceOwner
@@ -33,7 +33,7 @@ class BitlyResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/BoxResourceOwner.php
+++ b/OAuth/ResourceOwner/BoxResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * BoxResourceOwner
@@ -51,7 +51,7 @@ class BoxResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/DailymotionResourceOwner.php
+++ b/OAuth/ResourceOwner/DailymotionResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * DailymotionResourceOwner
@@ -42,7 +42,7 @@ class DailymotionResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/DeviantartResourceOwner.php
+++ b/OAuth/ResourceOwner/DeviantartResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * DeviantartResourceOwner
@@ -32,7 +32,7 @@ class DeviantartResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/DisqusResourceOwner.php
+++ b/OAuth/ResourceOwner/DisqusResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * DisqusResourceOwner
@@ -46,7 +46,7 @@ class DisqusResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/DropboxResourceOwner.php
+++ b/OAuth/ResourceOwner/DropboxResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * DropboxResourceOwner
@@ -33,7 +33,7 @@ class DropboxResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/EveOnlineResourceOwner.php
+++ b/OAuth/ResourceOwner/EveOnlineResourceOwner.php
@@ -11,8 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * EveOnlineResourceOwner
@@ -33,7 +32,7 @@ class EveOnlineResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/EventbriteResourceOwner.php
+++ b/OAuth/ResourceOwner/EventbriteResourceOwner.php
@@ -12,8 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * EventbriteResourceOwner
@@ -43,7 +42,7 @@ class EventbriteResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -13,7 +13,7 @@ namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * FacebookResourceOwner
@@ -76,7 +76,7 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/FlickrResourceOwner.php
+++ b/OAuth/ResourceOwner/FlickrResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * FlickrResourceOwner
@@ -62,7 +62,7 @@ class FlickrResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/FoursquareResourceOwner.php
+++ b/OAuth/ResourceOwner/FoursquareResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\MessageInterface as HttpMessageInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * FoursquareResourceOwner
@@ -77,7 +77,7 @@ class FoursquareResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 
@@ -90,7 +90,7 @@ class FoursquareResourceOwner extends GenericOAuth2ResourceOwner
             'version'                  => '20121206',
 
             'use_bearer_authorization' => false,
-            
+
             'use_bearer_authorization' => false,
         ));
     }

--- a/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -15,7 +15,7 @@ use Buzz\Message\RequestInterface as HttpRequestInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
@@ -215,7 +215,7 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -14,7 +14,7 @@ namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
@@ -203,7 +203,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 
@@ -213,7 +213,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
             'use_bearer_authorization' => true,
         ));
 
-        $resolver->setOptional(array(
+        $resolver->setDefined(array(
             'revoke_token_url',
         ));
 

--- a/OAuth/ResourceOwner/GitHubResourceOwner.php
+++ b/OAuth/ResourceOwner/GitHubResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * GitHubResourceOwner
@@ -51,7 +51,7 @@ class GitHubResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/GoogleResourceOwner.php
+++ b/OAuth/ResourceOwner/GoogleResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * GoogleResourceOwner
@@ -49,7 +49,7 @@ class GoogleResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/HubicResourceOwner.php
+++ b/OAuth/ResourceOwner/HubicResourceOwner.php
@@ -11,8 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * HubicResourceOwner
@@ -34,7 +33,7 @@ class HubicResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/InstagramResourceOwner.php
+++ b/OAuth/ResourceOwner/InstagramResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * InstagramResourceOwner
@@ -33,7 +33,7 @@ class InstagramResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/JiraResourceOwner.php
+++ b/OAuth/ResourceOwner/JiraResourceOwner.php
@@ -15,7 +15,7 @@ use Buzz\Message\RequestInterface as HttpRequestInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * JiraResourceOwner
@@ -85,7 +85,7 @@ class JiraResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/LinkedinResourceOwner.php
+++ b/OAuth/ResourceOwner/LinkedinResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * LinkedinResourceOwner
@@ -53,7 +53,7 @@ class LinkedinResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/MailRuResourceOwner.php
+++ b/OAuth/ResourceOwner/MailRuResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * MailRuResourceOwner
@@ -64,7 +64,7 @@ class MailRuResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/OdnoklassnikiResourceOwner.php
+++ b/OAuth/ResourceOwner/OdnoklassnikiResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * OdnoklassnikiResourceOwner
@@ -55,7 +55,7 @@ class OdnoklassnikiResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/PaypalResourceOwner.php
+++ b/OAuth/ResourceOwner/PaypalResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * PaypalResourceOwner
@@ -33,7 +33,7 @@ class PaypalResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/QQResourceOwner.php
+++ b/OAuth/ResourceOwner/QQResourceOwner.php
@@ -13,7 +13,7 @@ namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\MessageInterface as HttpMessageInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class QQResourceOwner extends GenericOAuth2ResourceOwner
@@ -76,7 +76,7 @@ class QQResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/RedditResourceOwner.php
+++ b/OAuth/ResourceOwner/RedditResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * RedditResourceOwner
@@ -41,7 +41,7 @@ class RedditResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 
@@ -49,7 +49,7 @@ class RedditResourceOwner extends GenericOAuth2ResourceOwner
             'authorization_url'        => 'https://ssl.reddit.com/api/v1/authorize',
             'access_token_url'         => 'https://ssl.reddit.com/api/v1/access_token',
             'infos_url'                => 'https://oauth.reddit.com/api/v1/me.json',
-            
+
             'use_bearer_authorization' => true,
             'use_commas_in_scope'      => true,
             'csrf'                     => true,

--- a/OAuth/ResourceOwner/SalesforceResourceOwner.php
+++ b/OAuth/ResourceOwner/SalesforceResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Salesforce Resource Owner
@@ -61,7 +61,7 @@ class SalesforceResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/SensioConnectResourceOwner.php
+++ b/OAuth/ResourceOwner/SensioConnectResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * SensioConnectResourceOwner
@@ -40,7 +40,7 @@ class SensioConnectResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/SinaWeiboResourceOwner.php
+++ b/OAuth/ResourceOwner/SinaWeiboResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SinaWeiboResourceOwner extends GenericOAuth2ResourceOwner
 {
@@ -49,7 +49,7 @@ class SinaWeiboResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/SoundcloudResourceOwner.php
+++ b/OAuth/ResourceOwner/SoundcloudResourceOwner.php
@@ -11,8 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * SoundcloudResourceOwner
@@ -33,7 +32,7 @@ class SoundcloudResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/StackExchangeResourceOwner.php
+++ b/OAuth/ResourceOwner/StackExchangeResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * StackExchangeResourceOwner
@@ -33,7 +33,7 @@ class StackExchangeResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/StereomoodResourceOwner.php
+++ b/OAuth/ResourceOwner/StereomoodResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * StereomoodResourceOwner
@@ -42,7 +42,7 @@ class StereomoodResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwner.php
+++ b/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * ThirtySevenSignalsResourceOwner (37signals)
@@ -50,7 +50,7 @@ class ThirtySevenSignalsResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/ToshlResourceOwner.php
+++ b/OAuth/ResourceOwner/ToshlResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\Response;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * ToshlResourceOwner
@@ -50,7 +50,7 @@ class ToshlResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/TrelloResourceOwner.php
+++ b/OAuth/ResourceOwner/TrelloResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * TrelloResourceOwner
@@ -34,7 +34,7 @@ class TrelloResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/TwitchResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitchResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterfacee;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * TwitchResourceOwner
@@ -52,7 +52,7 @@ class TwitchResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/TwitterResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitterResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * TwitterResourceOwner
@@ -33,7 +33,7 @@ class TwitterResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 
@@ -43,8 +43,8 @@ class TwitterResourceOwner extends GenericOAuth1ResourceOwner
             'access_token_url'  => 'https://api.twitter.com/oauth/access_token',
             'infos_url'         => 'https://api.twitter.com/1.1/account/verify_credentials.json',
         ));
-        
-        $resolver->setOptional(array(
+
+        $resolver->setDefined(array(
             'x_auth_access_type',
         ));
         $resolver->setAllowedValues(array(

--- a/OAuth/ResourceOwner/VkontakteResourceOwner.php
+++ b/OAuth/ResourceOwner/VkontakteResourceOwner.php
@@ -12,15 +12,15 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * VkontakteResourceOwner
  *
  * @author Adrov Igor <nucleartux@gmail.com>
  * @author Vladislav Vlastovskiy <me@vlastv.ru>
- * @author Alexander Latushkin <alex@skazo4neg.ru> 
+ * @author Alexander Latushkin <alex@skazo4neg.ru>
  */
 class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
 {
@@ -59,14 +59,14 @@ class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
             $content['email'] = $accessToken['email'];
             $response->setResponse($content);
         }
-        
+
         return $response;
     }
 
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/WindowsLiveResourceOwner.php
+++ b/OAuth/ResourceOwner/WindowsLiveResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * WindowsLiveResourceOwner
@@ -33,7 +33,7 @@ class WindowsLiveResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/WordpressResourceOwner.php
+++ b/OAuth/ResourceOwner/WordpressResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * WordpressResourceOwner
@@ -34,7 +34,7 @@ class WordpressResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/XingResourceOwner.php
+++ b/OAuth/ResourceOwner/XingResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * XingResourceOwner
@@ -34,7 +34,7 @@ class XingResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/YahooResourceOwner.php
+++ b/OAuth/ResourceOwner/YahooResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * YahooResourceOwner
@@ -55,7 +55,7 @@ class YahooResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/OAuth/ResourceOwner/YandexResourceOwner.php
+++ b/OAuth/ResourceOwner/YandexResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * YandexResourceOwner
@@ -42,7 +42,7 @@ class YandexResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -106,7 +106,7 @@
 
         <service id="hwi_oauth.security.oauth_utils" class="%hwi_oauth.security.oauth_utils.class%">
             <argument type="service" id="security.http_utils" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.authorization_checker" />
             <argument>%hwi_oauth.connect%</argument>
         </service>
 

--- a/Resources/config/routing/connect.xml
+++ b/Resources/config/routing/connect.xml
@@ -4,11 +4,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="hwi_oauth_connect_service" pattern="/service/{service}">
+    <route id="hwi_oauth_connect_service" path="/service/{service}">
         <default key="_controller">HWIOAuthBundle:Connect:connectService</default>
     </route>
 
-    <route id="hwi_oauth_connect_registration" pattern="/registration/{key}">
+    <route id="hwi_oauth_connect_registration" path="/registration/{key}">
         <default key="_controller">HWIOAuthBundle:Connect:registration</default>
     </route>
 </routes>

--- a/Resources/config/routing/login.xml
+++ b/Resources/config/routing/login.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="hwi_oauth_connect" pattern="/">
+    <route id="hwi_oauth_connect" path="/">
         <default key="_controller">HWIOAuthBundle:Connect:connect</default>
     </route>
 </routes>

--- a/Resources/config/routing/redirect.xml
+++ b/Resources/config/routing/redirect.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="hwi_oauth_service_redirect" pattern="/{service}">
+    <route id="hwi_oauth_service_redirect" path="/{service}">
         <default key="_controller">HWIOAuthBundle:Connect:redirectToService</default>
     </route>
 </routes>

--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -14,7 +14,7 @@ namespace HWI\Bundle\OAuthBundle\Security;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 
 /**
@@ -46,19 +46,19 @@ class OAuthUtils
     protected $ownerMap;
 
     /**
-     * @var SecurityContextInterface
+     * @var AuthorizationCheckerInterface
      */
-    protected $securityContext;
+    protected $authorizationChecker;
 
     /**
-     * @param HttpUtils                $httpUtils
-     * @param SecurityContextInterface $securityContext
-     * @param boolean                  $connect
+     * @param HttpUtils                     $httpUtils
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     * @param boolean                       $connect
      */
-    public function __construct(HttpUtils $httpUtils, SecurityContextInterface $securityContext, $connect)
+    public function __construct(HttpUtils $httpUtils, AuthorizationCheckerInterface $authorizationChecker, $connect)
     {
         $this->httpUtils       = $httpUtils;
-        $this->securityContext = $securityContext;
+        $this->authorizationChecker = $authorizationChecker;
         $this->connect         = $connect;
     }
 
@@ -92,7 +92,7 @@ class OAuthUtils
     {
         $resourceOwner = $this->getResourceOwner($name);
         if (null === $redirectUrl) {
-            if (!$this->connect || !$this->securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
+            if (!$this->connect || !$this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
                 $redirectUrl = $this->httpUtils->generateUri($request, $this->ownerMap->getResourceOwnerCheckPath($name));
             } else {
                 $redirectUrl = $this->getServiceAuthUrl($request, $resourceOwner);

--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -51,7 +51,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
      */
     public function testGetInvalidOptionThrowsException()
     {

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -67,7 +67,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
      */
     public function testInvalidOptionThrowsException()
     {

--- a/Tests/Security/OAuthUtilsTest.php
+++ b/Tests/Security/OAuthUtilsTest.php
@@ -23,7 +23,7 @@ class OAuthUtilsTest extends \PHPUnit_Framework_TestCase
         $request  = $this->getRequest($url);
         $redirect = 'https://api.instagram.com/oauth/authorize?redirect='.rawurlencode($url);
 
-        $utils = new OAuthUtils($this->getHttpUtils($url), $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface'), true);
+        $utils = new OAuthUtils($this->getHttpUtils($url), $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'), true);
         $utils->setResourceOwnerMap($this->getMap($url, $redirect, false, true));
 
         $this->assertEquals(
@@ -182,7 +182,7 @@ class OAuthUtilsTest extends \PHPUnit_Framework_TestCase
 
     private function getSecurity($hasUser)
     {
-        $mock = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $mock = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         $mock
             ->expects($this->once())
             ->method('isGranted')

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
     "require": {
         "php":                          ">=5.3.3",
         "symfony/framework-bundle":     "~2.3",
-        "symfony/security-bundle":      "~2.1",
+        "symfony/security-bundle":      "~2.6",
         "symfony/options-resolver":     "~2.1",
         "kriswallsmith/buzz":           "~0.7",
         "symfony/yaml": "~2.3"


### PR DESCRIPTION
This is breaking BC patch, which makes this bundle compatible with symfony 2.6+ changes. Symfony 2.7 triggers error for using any deprecations, so I changed them all. 

I think we should start a new branch before. Also fixed test for #720 and changed minimal FoS UserBundle tested dependencies (FoS UB v1.2 is compatible only with Sf 2.0.*)