### PR TITLE
Add Evernote resource owner

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -79,6 +79,7 @@ class Configuration implements ConfigurationInterface
             'bitbucket',
             'discogs',
             'dropbox',
+            'evernote',
             'flickr',
             'jira',
             'stereomood',

--- a/OAuth/ResourceOwner/EvernoteResourceOwner.php
+++ b/OAuth/ResourceOwner/EvernoteResourceOwner.php
@@ -17,7 +17,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Buzz\Message\RequestInterface;
 use Buzz\Message\MessageInterface;
 
-use Evernote\Client as EvernoteClient;
+use Evernote\AdvancedClient as EvernoteClient;
 
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
@@ -44,7 +44,7 @@ class EvernoteResourceOwner extends GenericOAuth1ResourceOwner
     /** {@inheritDoc} */
     public function configure()
     {
-        if (!class_exists('Evernote\\Client')) {
+        if (!class_exists('Evernote\\AdvancedClient')) {
             throw new \RuntimeException('Install evernote\'s php sdk to use the Evernote resource owner');
         }
 
@@ -56,8 +56,8 @@ class EvernoteResourceOwner extends GenericOAuth1ResourceOwner
     /** {@inheritDoc} */
     public function getUserInformation(array $accessToken, array $extraParameters = [])
     {
-        $client = new EvernoteClient($accessToken['oauth_token'], $this->options['sandbox']);
-        $user = $client->getUser();
+        $client = new EvernoteClient(null, $this->options['sandbox']);
+        $user = $client->getUserStore()->getUser($accessToken['oauth_token']);
 
         $response = $this->getUserResponse();
         $response->setResponse((array) $user);

--- a/OAuth/ResourceOwner/EvernoteResourceOwner.php
+++ b/OAuth/ResourceOwner/EvernoteResourceOwner.php
@@ -69,6 +69,12 @@ class EvernoteResourceOwner extends GenericOAuth1ResourceOwner
     }
 
     /** {@inheritDoc} */
+    public function revokeToken($token)
+    {
+        $this->getUserStore()->revokeLongSession($token);
+    }
+
+    /** {@inheritDoc} */
     protected function configureOptions(OptionsResolverInterface $resolver)
     {
         parent::configureOptions($resolver);

--- a/OAuth/ResourceOwner/EvernoteResourceOwner.php
+++ b/OAuth/ResourceOwner/EvernoteResourceOwner.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+use Buzz\Message\RequestInterface;
+use Buzz\Message\MessageInterface;
+
+use Evernote\Client as EvernoteClient;
+
+use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth1ResourceOwner;
+
+/**
+ * Evernote resource owner
+ *
+ * The Evernote resource SDK MUST be installed to use this resource owner
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+class EvernoteResourceOwner extends GenericOAuth1ResourceOwner
+{
+    /** {@inheritDoc} */
+    protected $paths = array(
+        'identifier'     => 'id',
+        'nickname'       => 'username',
+        'realname'       => 'name',
+        'email'          => 'email',
+        'profilepicture' => null
+    );
+
+    /** {@inheritDoc} */
+    public function configure()
+    {
+        if (!class_exists('Evernote\\Client')) {
+            throw new \RuntimeException('Install evernote\'s php sdk to use the Evernote resource owner');
+        }
+
+        $this->options['request_token_url'] = sprintf($this->options['request_token_url'], $this->options['sandbox'] ? 'sandbox' : 'www');
+        $this->options['authorization_url'] = sprintf($this->options['authorization_url'], $this->options['sandbox'] ? 'sandbox' : 'www');
+        $this->options['access_token_url'] = sprintf($this->options['access_token_url'], $this->options['sandbox'] ? 'sandbox' : 'www');
+    }
+
+    /** {@inheritDoc} */
+    public function getUserInformation(array $accessToken, array $extraParameters = [])
+    {
+        $client = new EvernoteClient($accessToken['oauth_token'], $this->options['sandbox']);
+        $user = $client->getUser();
+
+        $response = $this->getUserResponse();
+        $response->setResponse((array) $user);
+        $response->setResourceOwner($this);
+        $response->setOAuthToken(new OAuthToken($accessToken));
+
+        return $response;
+    }
+
+    /** {@inheritDoc} */
+    protected function configureOptions(OptionsResolverInterface $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults(array(
+            'sandbox' => true,
+            'infos_url' => null,
+            'request_token_url' => 'https://%s.evernote.com/oauth',
+            'authorization_url' => 'https://%s.evernote.com/OAuth.action',
+            'access_token_url' => 'https://%s.evernote.com/oauth'
+        ));
+    }
+}
+

--- a/OAuth/ResourceOwner/EvernoteResourceOwner.php
+++ b/OAuth/ResourceOwner/EvernoteResourceOwner.php
@@ -41,6 +41,8 @@ class EvernoteResourceOwner extends GenericOAuth1ResourceOwner
         'profilepicture' => null
     );
 
+    private $userStore;
+
     /** {@inheritDoc} */
     public function configure()
     {
@@ -56,8 +58,7 @@ class EvernoteResourceOwner extends GenericOAuth1ResourceOwner
     /** {@inheritDoc} */
     public function getUserInformation(array $accessToken, array $extraParameters = [])
     {
-        $client = new EvernoteClient(null, $this->options['sandbox']);
-        $user = $client->getUserStore()->getUser($accessToken['oauth_token']);
+        $user = $this->getUserStore()->getUser($accessToken['oauth_token']);
 
         $response = $this->getUserResponse();
         $response->setResponse((array) $user);
@@ -79,6 +80,16 @@ class EvernoteResourceOwner extends GenericOAuth1ResourceOwner
             'authorization_url' => 'https://%s.evernote.com/OAuth.action',
             'access_token_url' => 'https://%s.evernote.com/oauth'
         ));
+    }
+
+    private function getUserStore()
+    {
+        if (null === $this->userStore) {
+            $client = new EvernoteClient(null, $this->options['sandbox']);
+            $this->userStore = $client->getUserStore();
+        }
+
+        return $this->userStore;
     }
 }
 

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -31,6 +31,7 @@
         <parameter key="hwi_oauth.resource_owner.dropbox.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\DropboxResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.eve_online.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\EveOnlineResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.eventbrite.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\EventbriteResourceOwner</parameter>
+        <parameter key="hwi_oauth.resource_owner.evernote.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\EvernoteResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.facebook.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\FacebookResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.fiware.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\FiwareResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.flickr.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\FlickrResourceOwner</parameter>

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "dropbox",
         "eventbrite",
         "eve online",
+        "evernote",
         "facebook",
         "fiware",
         "flickr",
@@ -112,10 +113,11 @@
     },
 
     "suggest": {
-        "doctrine/doctrine-bundle":     "to use Doctrine user provider",
-        "friendsofsymfony/user-bundle": "to connect FOSUB with this bundle",
-        "symfony/property-access":      "to use FOSUB integration with this bundle",
-        "symfony/twig-bundle":          "to use the Twig hwi_oauth_* functions"
+        "doctrine/doctrine-bundle":        "to use Doctrine user provider",
+        "friendsofsymfony/user-bundle":    "to connect FOSUB with this bundle",
+        "symfony/property-access":         "to use FOSUB integration with this bundle",
+        "symfony/twig-bundle":             "to use the Twig hwi_oauth_* functions",
+        "evernote/evernote-cloud-sdk-php": "to use the Evernote resource owner"
     },
 
     "autoload": {


### PR DESCRIPTION
Added a Evernote resource owner. The thing is, they are not using REST apis, so after the oauth_token is obtained, we have to use the client from their SDK as it is using a thrift client...

Hence the (hard) dependency on their sdk. I'm not a huge fan of this, but this is the simplest way I found in order to fetch the user informations, as the resource owners must have those to continue. 

I didn't add tests for now, as because of the hard coupling with their client, it is pretty much hard to do so... Maybe use a sort of cache in a property and then overriding it through `Reflection` could do the trick ? I'm open for advices
