### PR TITLE
Pass the service name to the success view as well

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -215,6 +215,7 @@ class ConnectController extends ContainerAware
 
                 return $this->container->get('templating')->renderResponse('HWIOAuthBundle:Connect:connect_success.html.' . $this->getTemplatingEngine(), array(
                     'userInformation' => $userInformation,
+                    'service' => $service,
                 ));
             }
         }


### PR DESCRIPTION
I needed to access the service in the connection-success view (after I'd overridden it). Seems useful?