### PR TITLE
Upgraded endpoints for Facebook graph API v2.2

### DIFF
--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -81,10 +81,10 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
-            'authorization_url'   => 'https://www.facebook.com/dialog/oauth',
-            'access_token_url'    => 'https://graph.facebook.com/oauth/access_token',
-            'revoke_token_url'    => 'https://graph.facebook.com/me/permissions',
-            'infos_url'           => 'https://graph.facebook.com/me',
+            'authorization_url'   => 'https://www.facebook.com/v2.2/dialog/oauth',
+            'access_token_url'    => 'https://graph.facebook.com/v2.2/oauth/access_token',
+            'revoke_token_url'    => 'https://graph.facebook.com/v2.2/me/permissions',
+            'infos_url'           => 'https://graph.facebook.com/v2.2/me',
 
             'use_commas_in_scope' => true,
 


### PR DESCRIPTION
Updated URLs for Graph API v2.2. All API calls need to be updated to v2.x by April 30, 2015.