### PR TITLE
Backport 2.6 compat to 0.3 + we need a tag

### DIFF
--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -93,7 +93,7 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
 
         $resolver->setAllowedValues(array(
             // @link https://developers.facebook.com/docs/reference/dialogs/#display
-            'display' => array('page', 'popup', 'touch'),
+            'display' => array('page', 'popup', 'touch', null),
         ));
     }
 }

--- a/OAuth/ResourceOwner/GoogleResourceOwner.php
+++ b/OAuth/ResourceOwner/GoogleResourceOwner.php
@@ -73,13 +73,13 @@ class GoogleResourceOwner extends GenericOAuth2ResourceOwner
 
         $resolver->setAllowedValues(array(
             // @link https://developers.google.com/accounts/docs/OAuth2WebServer#offline
-            'access_type'     => array('online', 'offline'),
+            'access_type'     => array('online', 'offline', null),
             // sometimes we need to force for approval prompt (e.g. when we lost refresh token)
-            'approval_prompt' => array('force', 'auto'),
+            'approval_prompt' => array('force', 'auto', null),
             // @link https://developers.google.com/accounts/docs/OAuth2Login#authenticationuriparameters
-            'display'         => array('page', 'popup', 'touch', 'wap'),
-            'login_hint'      => array('email address', 'sub'),
-            'prompt'          => array(null, 'consent', 'select_account'),
+            'display'         => array('page', 'popup', 'touch', 'wap', null),
+            'login_hint'      => array('email address', 'sub', null),
+            'prompt'          => array(null, 'consent', 'select_account', null),
         ));
     }
 }

--- a/OAuth/ResourceOwner/GoogleResourceOwner.php
+++ b/OAuth/ResourceOwner/GoogleResourceOwner.php
@@ -79,7 +79,7 @@ class GoogleResourceOwner extends GenericOAuth2ResourceOwner
             // @link https://developers.google.com/accounts/docs/OAuth2Login#authenticationuriparameters
             'display'         => array('page', 'popup', 'touch', 'wap', null),
             'login_hint'      => array('email address', 'sub', null),
-            'prompt'          => array(null, 'consent', 'select_account', null),
+            'prompt'          => array('consent', 'select_account', null),
         ));
     }
 }

--- a/Tests/OAuth/ResourceOwner/DailymotionResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/DailymotionResourceOwnerTest.php
@@ -39,7 +39,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
      */
     public function testInvalidDisplayOptionValueThrowsException()
     {

--- a/Tests/OAuth/ResourceOwner/FacebookResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/FacebookResourceOwnerTest.php
@@ -51,7 +51,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
      */
     public function testInvalidDisplayOptionValueThrowsException()
     {

--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -51,7 +51,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
      */
     public function testGetInvalidOptionThrowsException()
     {
@@ -59,7 +59,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
      */
     public function testInvalidOptionValueThrowsException()
     {

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -65,7 +65,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
      */
     public function testInvalidOptionThrowsException()
     {
@@ -73,7 +73,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
      */
     public function testInvalidOptionValueThrowsException()
     {

--- a/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
@@ -36,7 +36,7 @@ json;
     );
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
      */
     public function testInvalidAccessTypeOptionValueThrowsException()
     {
@@ -44,7 +44,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
      */
     public function testInvalidApprovalPromptOptionValueThrowsException()
     {


### PR DESCRIPTION
Hi guys!

This is a cherry-pick of sha: 9186f9299d291f113d3f1bb63067349cb6d6ff81, which was applied to the master branch only. The issue is that we need a new 0.3 tag, so I'm backporting this for that reason.

This will be the *only* commit that's on the `0.3` branch, so tagging it should be easy.

But, master has a lot of commits - @stloyd what's the plan for the `0.4` release?

Thanks!

