### PR TITLE
the bitly v3 user info does not support bearer tokens

### DIFF
--- a/OAuth/ResourceOwner/BitlyResourceOwner.php
+++ b/OAuth/ResourceOwner/BitlyResourceOwner.php
@@ -38,6 +38,7 @@ class BitlyResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
+            'use_bearer_authorization' => false,
             'authorization_url' => 'https://bitly.com/oauth/authorize',
             'access_token_url'  => 'https://api-ssl.bitly.com/oauth/access_token',
             'infos_url'         => 'https://api-ssl.bitly.com/v3/user/info?format=json',


### PR DESCRIPTION
curl -H 'Authorization: Bearer 12345' 'https://api-ssl.bitly.com/v3/user/info?format=json'
{"status_code": 500, "data": null, "status_txt": "MISSING_ARG_ACCESS_TOKEN"}