### PR TITLE
Update EntityUserProvider.php

### DIFF
--- a/Security/Core/User/EntityUserProvider.php
+++ b/Security/Core/User/EntityUserProvider.php
@@ -92,7 +92,7 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
         }
 
         $username = $response->getUsername();
-        if (null === $user = $this->repository->findOneBy(array($this->properties[$resourceOwnerName] => $username))) {
+        if ($username === null || null === $user = $this->repository->findOneBy(array($this->properties[$resourceOwnerName] => $username))) {
             throw new UsernameNotFoundException(sprintf("User '%s' not found.", $username));
         }
 


### PR DESCRIPTION
If $response->getUsername() returns null, and it did, the findOneBy will return the first record with a matching NULL id... Which would suck, and it did.