### PR TITLE
Oauth auth exception

### DIFF
--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -20,6 +20,7 @@ use HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
+use HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -155,11 +156,11 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      *               along with any other parameters returned from the authentication
      *               provider.
      *
-     * @throws AuthenticationException If an OAuth error occurred or no access token is found
+     * @throws OAuthAuthenticationException If an OAuth error occurred or no access token is found
      */
     public function refreshAccessToken($refreshToken, array $extraParameters = array())
     {
-        throw new AuthenticationException('OAuth error: "Method unsupported."');
+        throw new OAuthAuthenticationException('OAuth error: "Method unsupported."', null, $this->getName());
     }
 
     /**
@@ -169,11 +170,11 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      *
      * @return Boolean Returns True if the revocation was successful, otherwise False.
      *
-     * @throws AuthenticationException If an OAuth error occurred
+     * @throws OAuthAuthenticationException If an OAuth error occurred
      */
     public function revokeToken($token)
     {
-        throw new AuthenticationException('OAuth error: "Method unsupported."');
+        throw new OAuthAuthenticationException('OAuth error: "Method unsupported."', null, $this->getName());
     }
 
     /**

--- a/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -13,6 +13,7 @@ namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -102,11 +103,11 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
         $response = $this->getResponseContent($response);
 
         if (isset($response['oauth_problem'])) {
-            throw new AuthenticationException(sprintf('OAuth error: "%s"', $response['oauth_problem']));
+            throw new OAuthAuthenticationException(sprintf('OAuth error: "%s"', $response['oauth_problem']), $redirectUri, $this->getName());
         }
 
         if (!isset($response['oauth_token']) || !isset($response['oauth_token_secret'])) {
-            throw new AuthenticationException('Not a valid request token.');
+            throw new OAuthAuthenticationException('Not a valid request token.', $redirectUri, $this->getName());
         }
 
         return $response;
@@ -160,15 +161,15 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
         $response = $this->getResponseContent($apiResponse);
 
         if (isset($response['oauth_problem'])) {
-            throw new AuthenticationException(sprintf('OAuth error: "%s"', $response['oauth_problem']));
+            throw new OAuthAuthenticationException(sprintf('OAuth error: "%s"', $response['oauth_problem']), $redirectUri, $this->getName());
         }
 
         if (isset($response['oauth_callback_confirmed']) && ($response['oauth_callback_confirmed'] != 'true')) {
-            throw new AuthenticationException('Defined OAuth callback was not confirmed.');
+            throw new OAuthAuthenticationException('Defined OAuth callback was not confirmed.', $redirectUri, $this->getName());
         }
 
         if (!isset($response['oauth_token']) || !isset($response['oauth_token_secret'])) {
-            throw new AuthenticationException('Not a valid request token.');
+            throw new OAuthAuthenticationException('Not a valid request token.', $redirectUri, $this->getName());
         }
 
         $response['timestamp'] = $timestamp;

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -80,7 +81,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
      *               along with any other parameters returned from the authentication
      *               provider.
      *
-     * @throws AuthenticationException If an OAuth error occurred or no access token is found
+     * @throws OAuthAuthenticationException If an OAuth error occurred or no access token is found
      */
     public function getAccessToken(Request $request, $redirectUri, array $extraParameters = array())
     {
@@ -95,7 +96,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
         $response = $this->doGetTokenRequest($this->options['access_token_url'], $parameters);
         $response = $this->getResponseContent($response);
 
-        $this->validateResponseContent($response);
+        $this->validateResponseContent($response, $redirectUri);
 
         return $response;
     }
@@ -115,7 +116,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
         $response = $this->doGetTokenRequest($this->options['access_token_url'], $parameters);
         $response = $this->getResponseContent($response);
 
-        $this->validateResponseContent($response);
+        $this->validateResponseContent($response, null);
 
         return $response;
     }
@@ -126,7 +127,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
     public function revokeToken($token)
     {
         if (!isset($this->options['revoke_token_url'])) {
-            throw new AuthenticationException('OAuth error: "Method unsupported."');
+            throw new OAuthAuthenticationException('OAuth error: "Method unsupported."', null, $this->getName());
         }
 
         $parameters = array(
@@ -183,20 +184,20 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
     /**
      * @param mixed $response the 'parsed' content based on the response headers
      *
-     * @throws AuthenticationException If an OAuth error occurred or no access token is found
+     * @throws OAuthAuthenticationException If an OAuth error occurred or no access token is found
      */
-    protected function validateResponseContent($response)
+    protected function validateResponseContent($response, $redirectUri)
     {
         if (isset($response['error_description'])) {
-            throw new AuthenticationException(sprintf('OAuth error: "%s"', $response['error_description']));
+            throw new OAuthAuthenticationException(sprintf('OAuth error: "%s"', $response['error_description']), $redirectUri, $this->getName());
         }
 
         if (isset($response['error'])) {
-            throw new AuthenticationException(sprintf('OAuth error: "%s"', isset($response['error']['message']) ? $response['error']['message'] : $response['error']));
+            throw new OAuthAuthenticationException(sprintf('OAuth error: "%s"', isset($response['error']['message']) ? $response['error']['message'] : $response['error']), $redirectUri, $this->getName());
         }
 
         if (!isset($response['access_token'])) {
-            throw new AuthenticationException('Not a valid access token.');
+            throw new OAuthAuthenticationException('Not a valid access token.', $redirectUri, $this->getName());
         }
     }
 

--- a/Security/Core/Exception/OAuthAuthenticationException.php
+++ b/Security/Core/Exception/OAuthAuthenticationException.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Security\Core\Exception;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Represents an oauth authentication exception, with more details
+ * such as the redirectURI or the resource owner's name if available
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+class OAuthAuthenticationException extends AuthenticationException
+{
+    /**
+     * @var string
+     */
+    private $redirectUri;
+
+    /**
+     * @var string
+     */
+    private $resourceOwnerName;
+
+    public function __construct($message, $redirectUri, $resourceOwner)
+    {
+        parent::__construct($message);
+
+        if ($resourceOwner instanceof ResourceOwnerInterface) {
+            $resourceOwner = $resourceOwner->getName();
+        }
+
+        $this->redirectUri = $redirectUri;
+        $this->resourceOwnerName = $resourceOwner;
+    }
+
+    /**
+     * Get the redirect uri the request was supposed to redirect to
+     *
+     * @return string
+     */
+    public function getRedirectUri()
+    {
+        return $this->redirectUri;
+    }
+
+    /**
+     * Get the resource name that triggered this exception
+     *
+     * @return string
+     */
+    public function getResourceOwnerName()
+    {
+        return $this->resourceOwnerName;
+    }
+}
+

--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -95,7 +95,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testGetAuthorizationUrlFailedResponseContainOnlyOAuthToken()
     {
@@ -108,7 +108,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testGetAuthorizationUrlFailedResponseContainOAuthProblem()
     {
@@ -121,7 +121,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testGetAuthorizationUrlFailedResponseContainCallbackNotConfirmed()
     {
@@ -134,7 +134,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testGetAuthorizationUrlFailedResponseNotContainOAuthTokenOrSecret()
     {
@@ -198,7 +198,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testGetAccessTokenFailedResponse()
     {
@@ -217,7 +217,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testGetAccessTokenErrorResponse()
     {
@@ -236,7 +236,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testRefreshAccessToken()
     {
@@ -244,7 +244,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testRevokeToken()
     {

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -202,7 +202,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testGetAccessTokenFailedResponse()
     {
@@ -213,7 +213,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testGetAccessTokenErrorResponse()
     {
@@ -233,7 +233,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testRefreshAccessTokenInvalid()
     {
@@ -243,7 +243,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testRefreshAccessTokenError()
     {
@@ -253,7 +253,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAuthenticationException
      */
     public function testRevokeToken()
     {


### PR DESCRIPTION
When a OAuth request fails, we can still want to redirect the user to another place rather than leave the default symfony's failure handler redirect to the `failure_path` with the specified `redirect_uri` parameter.

A user should be able to implement its own failure handler with some parameters into the exception to be able to do whatever he wants to do (redirect, know which resource owner failed, ...), and the `OAuthAuthentication` exception object can allow him to have more information (such as the redirect uri parameter when available, or the resource owner's name)