### PR TITLE
Add first and last names on OAuth responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## 0.4.0 (2015-??-??)
+* Added `UserResponseInterface#getFirstName()` method, also a new default path `firstname`
+  was added, this path holds the first name of user
+* Added `UserResponseInterface#getLastName()` method, also a new default path `lastname`
+  was added, this path holds the last name of user
+
 ## 0.3.8 (2015-05-04)
 * Fix: Compatibility issues with Symfony 2.6+,
 * Fix: Deprecated graph URLs fir `FacebookResourceOwner`
@@ -81,7 +87,7 @@ Changelog
 * [BC break] `AbstractResourceOwner::__construct()` now requires `RequestDataStorageInterface`
   instance as last argument
 * Fix: Yandex resource owner using invalid parameter when requesting user data
-* Fix: To prevent unusual content headers response from resource owners should 
+* Fix: To prevent unusual content headers response from resource owners should
   be first threaten as json and only in case of failure threaten as query text
 * Fix: Instagram resource owner is not able to receive user data more than once
 * Added ability to disable confirmation page when connecting accounts

--- a/OAuth/ResourceOwner/EventbriteResourceOwner.php
+++ b/OAuth/ResourceOwner/EventbriteResourceOwner.php
@@ -28,6 +28,8 @@ class EventbriteResourceOwner extends GenericOAuth2ResourceOwner
     protected $paths = array(
         'identifier' => 'user.user_id',
         'nickname'   => 'user.first_name',
+        'firstname'  => 'user.first_name',
+        'lastname'   => 'user.last_name',
         'realname'   => array('user.first_name', 'user.last_name'),
         'email'      => 'email',
     );

--- a/OAuth/ResourceOwner/FoursquareResourceOwner.php
+++ b/OAuth/ResourceOwner/FoursquareResourceOwner.php
@@ -26,6 +26,8 @@ class FoursquareResourceOwner extends GenericOAuth2ResourceOwner
      */
     protected $paths = array(
         'identifier'     => 'response.user.id',
+        'firstname'      => 'response.user.firstName',
+        'lastname'       => 'response.user.lastName',
         'nickname'       => 'response.user.firstName',
         'realname'       => array('response.user.firstName', 'response.user.lastName'),
         'email'          => 'response.user.contact.email',
@@ -89,8 +91,6 @@ class FoursquareResourceOwner extends GenericOAuth2ResourceOwner
             // @link https://developer.foursquare.com/overview/versioning
             'version'                  => '20121206',
 
-            'use_bearer_authorization' => false,
-            
             'use_bearer_authorization' => false,
         ));
     }

--- a/OAuth/ResourceOwner/HubicResourceOwner.php
+++ b/OAuth/ResourceOwner/HubicResourceOwner.php
@@ -27,6 +27,8 @@ class HubicResourceOwner extends GenericOAuth2ResourceOwner
     protected $paths = array(
         'identifier' => 'email',
         'nickname'   => 'email',
+        'firstname'  => 'firstname',
+        'lastname'   => 'lastname',
         'realname'   => 'firstname',
         'email'      => 'email',
     );

--- a/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwner.php
+++ b/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwner.php
@@ -27,6 +27,8 @@ class ThirtySevenSignalsResourceOwner extends GenericOAuth2ResourceOwner
     protected $paths = array(
         'identifier' => 'identity.id',
         'nickname'   => 'identity.email_address',
+        'firstname'  => 'identity.first_name',
+        'lastname'   => 'identity.last_name',
         'realname'   => array('identity.last_name', 'identity.first_name'),
         'email'      => 'identity.email_address',
     );

--- a/OAuth/ResourceOwner/ToshlResourceOwner.php
+++ b/OAuth/ResourceOwner/ToshlResourceOwner.php
@@ -27,6 +27,8 @@ class ToshlResourceOwner extends GenericOAuth2ResourceOwner
     protected $paths = array(
         'identifier'     => 'id',
         'nickname'       => 'email',
+        'firstname'      => 'first_name',
+        'lastname'       => 'last_name',
         'realname'       => array('first_name', 'last_name'),
         'email'          => 'email',
     );

--- a/OAuth/ResourceOwner/VkontakteResourceOwner.php
+++ b/OAuth/ResourceOwner/VkontakteResourceOwner.php
@@ -20,7 +20,7 @@ use Symfony\Component\OptionsResolver\Options;
  *
  * @author Adrov Igor <nucleartux@gmail.com>
  * @author Vladislav Vlastovskiy <me@vlastv.ru>
- * @author Alexander Latushkin <alex@skazo4neg.ru> 
+ * @author Alexander Latushkin <alex@skazo4neg.ru>
  */
 class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
 {
@@ -31,6 +31,8 @@ class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
         'identifier' => 'response.0.uid',
         'nickname'   => 'response.0.nickname',
         'profilepicture' => 'response.0.photo_50',
+        'firstname'  => 'response.0.first_name',
+        'lastname'   => 'response.0.last_name',
         'realname'   => array('response.0.last_name', 'response.0.first_name'),
         'email' => 'email'
     );
@@ -59,7 +61,7 @@ class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
             $content['email'] = $accessToken['email'];
             $response->setResponse($content);
         }
-        
+
         return $response;
     }
 

--- a/OAuth/ResourceOwner/XingResourceOwner.php
+++ b/OAuth/ResourceOwner/XingResourceOwner.php
@@ -26,6 +26,8 @@ class XingResourceOwner extends GenericOAuth1ResourceOwner
     protected $paths = array(
         'identifier'     => 'users.0.id',
         'nickname'       => 'users.0.display_name',
+        'firstname'      => 'users.0.first_name',
+        'lastname'       => 'users.0.last_name',
         'realname'       => array('users.0.first_name', 'users.0.last_name'),
         'profilepicture' => 'users.0.photo_urls.large',
         'email'          => 'users.0.active_email',

--- a/OAuth/Response/PathUserResponse.php
+++ b/OAuth/Response/PathUserResponse.php
@@ -26,6 +26,8 @@ class PathUserResponse extends AbstractUserResponse
     protected $paths = array(
         'identifier'     => null,
         'nickname'       => null,
+        'firstname'      => null,
+        'lastname'       => null,
         'realname'       => null,
         'email'          => null,
         'profilepicture' => null,
@@ -45,6 +47,22 @@ class PathUserResponse extends AbstractUserResponse
     public function getNickname()
     {
         return $this->getValueForPath('nickname');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFirstName()
+    {
+        return $this->getValueForPath('firstname');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastName()
+    {
+        return $this->getValueForPath('lastname');
     }
 
     /**

--- a/OAuth/Response/SensioConnectUserResponse.php
+++ b/OAuth/Response/SensioConnectUserResponse.php
@@ -55,6 +55,22 @@ class SensioConnectUserResponse extends AbstractUserResponse
     /**
      * {@inheritdoc}
      */
+    public function getFirstName()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastName()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getRealName()
     {
         return $this->getNodeValue('./foaf:name', $this->response);

--- a/OAuth/Response/UserResponseInterface.php
+++ b/OAuth/Response/UserResponseInterface.php
@@ -41,6 +41,20 @@ interface UserResponseInterface extends ResponseInterface
     public function getNickname();
 
     /**
+     * Get the first name of user.
+     *
+     * @return null|string
+     */
+    public function getFirstName();
+
+    /**
+     * Get the last name of user.
+     *
+     * @return null|string
+     */
+    public function getLastName();
+
+    /**
      * Get the real name of user.
      *
      * @return null|string
@@ -77,7 +91,7 @@ interface UserResponseInterface extends ResponseInterface
 
     /**
      * Get oauth token secret used for the request.
-     * 
+     *
      * @return null|string
      */
     public function getTokenSecret();

--- a/Tests/Fixtures/CustomUserResponse.php
+++ b/Tests/Fixtures/CustomUserResponse.php
@@ -30,6 +30,16 @@ class CustomUserResponse extends AbstractUserResponse
         return 'foo';
     }
 
+    public function getFirstName()
+    {
+        return 'foo';
+    }
+
+    public function getLastName()
+    {
+        return 'BAR';
+    }
+
     public function getRealName()
     {
         return 'foo';

--- a/Tests/OAuth/ResourceOwner/EventbriteResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/EventbriteResourceOwnerTest.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\EventbriteResourceOwner;
+use HWI\Bundle\OAuthBundle\OAuth\Response\AbstractUserResponse;
 
 class EventbriteResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
@@ -28,9 +29,24 @@ json;
     protected $paths = array(
         'identifier' => 'user.user_id',
         'nickname'   => 'user.first_name',
+        'firstname'  => 'user.first_name',
+        'lastname'   => 'user.last_name',
         'realname'   => array('user.first_name', 'user.last_name'),
         'email'      => 'email',
     );
+
+    public function testGetUserInformationFirstAndLastName()
+    {
+        $this->mockBuzz($this->userResponse, 'application/json; charset=utf-8');
+
+        /**
+         * @var $userResponse AbstractUserResponse
+         */
+        $userResponse = $this->resourceOwner->getUserInformation(array('access_token' => 'token'));
+
+        $this->assertEquals('bar', $userResponse->getFirstName());
+        $this->assertEquals('foo', $userResponse->getLastName());
+    }
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {

--- a/Tests/OAuth/ResourceOwner/FoursquareResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/FoursquareResourceOwnerTest.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\FoursquareResourceOwner;
+use HWI\Bundle\OAuthBundle\OAuth\Response\AbstractUserResponse;
 
 class FoursquareResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
@@ -29,9 +30,24 @@ json;
 
     protected $paths = array(
         'identifier' => 'response.user.id',
+        'firstname'  => 'response.user.firstName',
+        'lastname'   => 'response.user.lastName',
         'nickname'   => 'response.user.firstName',
         'realname'   => array('response.user.firstName', 'response.user.lastName'),
     );
+
+    public function testGetUserInformationFirstAndLastName()
+    {
+        $this->mockBuzz($this->userResponse, 'application/json; charset=utf-8');
+
+        /**
+         * @var $userResponse AbstractUserResponse
+         */
+        $userResponse = $this->resourceOwner->getUserInformation(array('access_token' => 'token'));
+
+        $this->assertEquals('bar', $userResponse->getFirstName());
+        $this->assertEquals('foo', $userResponse->getLastName());
+    }
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {

--- a/Tests/OAuth/ResourceOwner/HubicResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/HubicResourceOwnerTest.php
@@ -12,16 +12,32 @@
 namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\HubicResourceOwner;
+use HWI\Bundle\OAuthBundle\OAuth\Response\AbstractUserResponse;
 
 class HubicResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
-    protected $userResponse = '{ "email": "1", "firstname": "bar", "activated": true , "creationDate": "2013-12-31T19:09:42+01:00", "language": "fr", "status": "ok", "offer": "25g", "lastname": "Test" }';
+    protected $userResponse = '{ "email": "1", "firstname": "bar", "activated": true , "creationDate": "2013-12-31T19:09:42+01:00", "language": "fr", "status": "ok", "offer": "25g", "lastname": "foo" }';
     protected $paths = array(
         'identifier' => 'email',
         'nickname'   => 'firstname',
+        'firstname'  => 'firstname',
+        'lastname'   => 'lastname',
         'realname'   => 'firstname',
         'email'      => 'email',
     );
+
+    public function testGetUserInformationFirstAndLastName()
+    {
+        $this->mockBuzz($this->userResponse, 'application/json; charset=utf-8');
+
+        /**
+         * @var $userResponse AbstractUserResponse
+         */
+        $userResponse = $this->resourceOwner->getUserInformation(array('access_token' => 'token'));
+
+        $this->assertEquals('bar', $userResponse->getFirstName());
+        $this->assertEquals('foo', $userResponse->getLastName());
+    }
 
     public function testGetAuthorizationUrl()
     {

--- a/Tests/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwnerTest.php
@@ -27,6 +27,8 @@ json;
     protected $paths = array(
         'identifier' => 'identity.id',
         'nickname'   => 'identity.email_address',
+        'firstname'  => 'identity.first_name',
+        'lastname'   => 'identity.last_name',
         'realname'   => array('identity.last_name', 'identity.first_name'),
         'email'      => 'identity.email_address',
     );

--- a/Tests/OAuth/ResourceOwner/ToshlResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/ToshlResourceOwnerTest.php
@@ -28,6 +28,8 @@ json;
     protected $paths = array(
         'identifier'     => 'id',
         'nickname'       => 'email',
+        'firstname'      => 'first_name',
+        'lastname'       => 'last_name',
         'realname'       => array('first_name', 'last_name'),
         'email'          => 'email',
     );
@@ -64,6 +66,8 @@ json;
         $this->assertEquals('1', $userResponse->getUsername());
         $this->assertEquals('example@website.com', $userResponse->getNickname());
         $this->assertEquals('token', $userResponse->getAccessToken());
+        $this->assertEquals('John', $userResponse->getFirstName());
+        $this->assertEquals('Smith', $userResponse->getLastName());
         $this->assertNull($userResponse->getRefreshToken());
         $this->assertNull($userResponse->getExpiresIn());
     }

--- a/Tests/OAuth/ResourceOwner/XingResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/XingResourceOwnerTest.php
@@ -34,6 +34,8 @@ json;
     protected $paths = array(
         'identifier'     => 'users.0.id',
         'nickname'       => 'users.0.display_name',
+        'firstname'      => 'users.0.first_name',
+        'lastname'       => 'users.0.last_name',
         'realname'       => array('users.0.first_name', 'users.0.last_name'),
         'profilepicture' => 'users.0.photo_urls.large',
         'email'          => 'users.0.active_email',
@@ -48,6 +50,8 @@ json;
 
         $this->assertEquals('42', $userResponse->getUsername());
         $this->assertEquals('foo bar', $userResponse->getNickname());
+        $this->assertEquals('Foo', $userResponse->getFirstName());
+        $this->assertEquals('Bar', $userResponse->getLastName());
         $this->assertEquals('Foo Bar', $userResponse->getRealName());
         $this->assertEquals('foobar@example.com', $userResponse->getEmail());
         $this->assertEquals('https://x2.xingassets.com/img/n/nobody_m.140x185.jpg', $userResponse->getProfilePicture());

--- a/Tests/OAuth/Response/PathUserResponseTest.php
+++ b/Tests/OAuth/Response/PathUserResponseTest.php
@@ -62,6 +62,8 @@ class PathUserResponseTest extends \PHPUnit_Framework_TestCase
         $paths = array(
             'identifier'     => null,
             'nickname'       => null,
+            'firstname'      => null,
+            'lastname'       => null,
             'realname'       => null,
             'email'          => null,
             'profilepicture' => null,
@@ -75,6 +77,8 @@ class PathUserResponseTest extends \PHPUnit_Framework_TestCase
         $paths = array(
             'identifier'     => null,
             'nickname'       => null,
+            'firstname'      => null,
+            'lastname'       => null,
             'realname'       => null,
             'email'          => null,
             'profilepicture' => null,


### PR DESCRIPTION
Many providers has first name and last name fields that could be very interesting to get separately on our applications.

This PR adds `getFirstName` and `getLastName` on `UserResponseInterface` and his children classes.

Concerned resource owners are also updated.