### PR TITLE
Fix deprecated usages (SF 2.6/2.7/2.8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION="3.0.x-dev as 2.8"
     - php: 5.6
-      env: FOSUSERBUNDLE_VERSION=1.2.*
-    - php: 5.6
       env: FOSUSERBUNDLE_VERSION=1.3.*
     - php: 5.6
       env: FOSUSERBUNDLE_VERSION=2.0.*@dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,53 @@
 language: php
 
 php:
-  - 5.3.3
   - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - hhvm
- 
-matrix:
-    allow_failures:
-        - php: hhvm
 
 env:
-  - SYMFONY_VERSION='2.3.*' FOSUSERBUNDLE_VERSION='~1.2'
-  - SYMFONY_VERSION='2.4.*' FOSUSERBUNDLE_VERSION='~1.2'
-  - SYMFONY_VERSION='2.3.*' FOSUSERBUNDLE_VERSION='2.0.*@dev'
-  - SYMFONY_VERSION='2.4.*' FOSUSERBUNDLE_VERSION='2.0.*@dev'
+  global:
+    - PATH="$HOME/.composer/vendor/bin:$PATH"
+
+sudo: false
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.3
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: SYMFONY_VERSION=2.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*@dev
+    - php: 5.6
+      env: SYMFONY_VERSION="3.0.x-dev as 2.8"
+    - php: 5.6
+      env: FOSUSERBUNDLE_VERSION=1.2.*
+    - php: 5.6
+      env: FOSUSERBUNDLE_VERSION=1.3.*
+    - php: 5.6
+      env: FOSUSERBUNDLE_VERSION=2.0.*@dev
+  allow_failures:
+    - php: hhvm
+    - env: SYMFONY_VERSION=2.8.*@dev
+    - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 before_script:
-    - composer require --no-update symfony/symfony=${SYMFONY_VERSION}
-    - composer require --no-update friendsofsymfony/user-bundle=${FOSUSERBUNDLE_VERSION}
-    - composer install --prefer-source
+  - composer selfupdate
+  - composer global require phpunit/phpunit --no-update
+  - composer global update --prefer-dist --no-interaction
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - if [ "$FOSUSERBUNDLE_VERSION" != "" ]; then composer require "friendsofsymfony/user-bundle:${FOSUSERBUNDLE_VERSION}" --no-update; fi;
+  - travis_wait composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
+
+script: phpunit

--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -14,7 +14,7 @@ namespace HWI\Bundle\OAuthBundle\Controller;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,7 +32,7 @@ use Symfony\Component\Security\Http\SecurityEvents;
  *
  * @author Alexander <iam.asm89@gmail.com>
  */
-class ConnectController extends ContainerAware
+class ConnectController extends Controller
 {
     /**
      * Action that handles the login 'form'. If connecting is enabled the
@@ -45,7 +45,7 @@ class ConnectController extends ContainerAware
     public function connectAction(Request $request)
     {
         $connect = $this->container->getParameter('hwi_oauth.connect');
-        $hasUser = $this->container->get('security.context')->isGranted('IS_AUTHENTICATED_REMEMBERED');
+        $hasUser = $this->isGranted('IS_AUTHENTICATED_REMEMBERED');
 
         $error = $this->getErrorForRequest($request);
 
@@ -91,7 +91,7 @@ class ConnectController extends ContainerAware
             throw new NotFoundHttpException();
         }
 
-        $hasUser = $this->container->get('security.context')->isGranted('IS_AUTHENTICATED_REMEMBERED');
+        $hasUser = $this->isGranted('IS_AUTHENTICATED_REMEMBERED');
         if ($hasUser) {
             throw new AccessDeniedException('Cannot connect already registered account.');
         }
@@ -160,7 +160,7 @@ class ConnectController extends ContainerAware
             throw new NotFoundHttpException();
         }
 
-        $hasUser = $this->container->get('security.context')->isGranted('IS_AUTHENTICATED_REMEMBERED');
+        $hasUser = $this->isGranted('IS_AUTHENTICATED_REMEMBERED');
         if (!$hasUser) {
             throw new AccessDeniedException('Cannot connect an account.');
         }

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -70,6 +70,13 @@ class HWIOAuthExtension extends Extension
 
         $oauthUtils = $container->getDefinition('hwi_oauth.security.oauth_utils');
         $oauthUtils->addMethodCall('setResourceOwnerMap', array(new Reference('hwi_oauth.resource_ownermap.'.$config['firewall_name'])));
+        // Symfony <2.6 BC
+        // Go back to basic xml config after
+        if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
+            $oauthUtils->replaceArgument(1, new Reference('security.authorization_checker'));
+        } else {
+            $oauthUtils->replaceArgument(1, new Reference('security.context'));
+        }
 
         if (isset($config['fosub'])) {
             $container

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -22,7 +22,6 @@ use HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -327,7 +326,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
             'auth_with_one_url'   => false,
         ));
 
-        if (version_compare(Kernel::VERSION, '2.6', '>=')) {
+        if (method_exists($resolver, 'setDefined')) {
             $resolver->setAllowedValues('csrf', array(true, false));
         } else {
             $resolver->setAllowedValues(array(

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -22,6 +22,7 @@ use HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -326,8 +327,12 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
             'auth_with_one_url'   => false,
         ));
 
-        $resolver->setAllowedValues(array(
-            'csrf' => array(true, false),
-        ));
+        if (version_compare(Kernel::VERSION, '2.6', '>=')) {
+            $resolver->setAllowedValues('csrf', array(true, false));
+        } else {
+            $resolver->setAllowedValues(array(
+                'csrf' => array(true, false),
+            ));
+        }
     }
 }

--- a/OAuth/ResourceOwner/Auth0ResourceOwner.php
+++ b/OAuth/ResourceOwner/Auth0ResourceOwner.php
@@ -11,10 +11,9 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Buzz\Message\Response;
+use Buzz\Message\RequestInterface as HttpRequestInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Buzz\Message\RequestInterface as HttpRequestInterface;
 
 /**
  * Auth0ResourceOwner

--- a/OAuth/ResourceOwner/Auth0ResourceOwner.php
+++ b/OAuth/ResourceOwner/Auth0ResourceOwner.php
@@ -68,10 +68,19 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
             return str_replace('{base_url}', $options['base_url'], $value);
         };
 
-        $resolver->setNormalizers(array(
-            'authorization_url' => $normalizer,
-            'access_token_url'  => $normalizer,
-            'infos_url'         => $normalizer,
-        ));
+        // Symfony <2.6 BC
+        if (method_exists($resolver, 'setNormalizer')) {
+            $resolver
+                ->setNormalizer('authorization_url', $normalizer)
+                ->setNormalizer('access_token_url', $normalizer)
+                ->setNormalizer('infos_url', $normalizer)
+            ;
+        } else {
+            $resolver->setNormalizers(array(
+                'authorization_url' => $normalizer,
+                'access_token_url'  => $normalizer,
+                'infos_url'         => $normalizer,
+            ));
+        }
     }
 }

--- a/OAuth/ResourceOwner/DailymotionResourceOwner.php
+++ b/OAuth/ResourceOwner/DailymotionResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * DailymotionResourceOwner
@@ -55,7 +54,7 @@ class DailymotionResourceOwner extends GenericOAuth2ResourceOwner
             'display'           => null,
         ));
 
-        if (version_compare(Kernel::VERSION, '2.6', '>=')) {
+        if (method_exists($resolver, 'setDefined')) {
             // @link http://www.dailymotion.com/doc/api/authentication.html#dialog-form-factors
             $resolver->setAllowedValues('display', array('page', 'popup', 'mobile', null));
         } else {

--- a/OAuth/ResourceOwner/DailymotionResourceOwner.php
+++ b/OAuth/ResourceOwner/DailymotionResourceOwner.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * DailymotionResourceOwner
@@ -54,9 +55,13 @@ class DailymotionResourceOwner extends GenericOAuth2ResourceOwner
             'display'           => null,
         ));
 
-        $resolver->setAllowedValues(array(
+        if (version_compare(Kernel::VERSION, '2.6', '>=')) {
             // @link http://www.dailymotion.com/doc/api/authentication.html#dialog-form-factors
-            'display' => array('page', 'popup', 'mobile', null),
-        ));
+            $resolver->setAllowedValues('display', array('page', 'popup', 'mobile', null));
+        } else {
+            $resolver->setAllowedValues(array(
+                'display' => array('page', 'popup', 'mobile', null),
+            ));
+        }
     }
 }

--- a/OAuth/ResourceOwner/EveOnlineResourceOwner.php
+++ b/OAuth/ResourceOwner/EveOnlineResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**

--- a/OAuth/ResourceOwner/EventbriteResourceOwner.php
+++ b/OAuth/ResourceOwner/EventbriteResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**

--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -14,7 +14,6 @@ namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 use Buzz\Message\RequestInterface as HttpRequestInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * FacebookResourceOwner
@@ -103,14 +102,15 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
         ));
 
         // Symfony <2.6 BC
-        if (method_exists($resolver, 'setNormalizer')) {
+        if (method_exists($resolver, 'setDefined')) {
             $resolver
                 ->setAllowedValues('display', array('page', 'popup', 'touch', null)) // @link https://developers.facebook.com/docs/reference/dialogs/#display
                 ->setAllowedValues('auth_type', array('rerequest', null)) // @link https://developers.facebook.com/docs/reference/javascript/FB.login/
             ;
         } else {
             $resolver->setAllowedValues(array(
-                'display' => array('page', 'popup', 'touch', null),
+                'display'   => array('page', 'popup', 'touch', null),
+                'auth_type' => array('rerequest', null),
             ));
         }
     }

--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -14,6 +14,7 @@ namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 use Buzz\Message\RequestInterface as HttpRequestInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * FacebookResourceOwner
@@ -101,9 +102,16 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
             'auth_type'           => null,
         ));
 
-        $resolver->setAllowedValues(array(
-            'display' => array('page', 'popup', 'touch', null), // @link https://developers.facebook.com/docs/reference/dialogs/#display
-            'auth_type' => array('rerequest', null), // @link https://developers.facebook.com/docs/reference/javascript/FB.login/
-        ));
+        // Symfony <2.6 BC
+        if (method_exists($resolver, 'setNormalizer')) {
+            $resolver
+                ->setAllowedValues('display', array('page', 'popup', 'touch', null)) // @link https://developers.facebook.com/docs/reference/dialogs/#display
+                ->setAllowedValues('auth_type', array('rerequest', null)) // @link https://developers.facebook.com/docs/reference/javascript/FB.login/
+            ;
+        } else {
+            $resolver->setAllowedValues(array(
+                'display' => array('page', 'popup', 'touch', null),
+            ));
+        }
     }
 }

--- a/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -16,6 +16,7 @@ use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
@@ -228,8 +229,12 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
             'signature_method' => 'HMAC-SHA1',
         ));
 
-        $resolver->setAllowedValues(array(
-            'signature_method' => array('HMAC-SHA1', 'RSA-SHA1', 'PLAINTEXT'),
-        ));
+        if (version_compare(Kernel::VERSION, '2.6', '>=')) {
+            $resolver->setAllowedValues('signature_method', array('HMAC-SHA1', 'RSA-SHA1', 'PLAINTEXT'));
+        } else {
+            $resolver->setAllowedValues(array(
+                'signature_method' => array('HMAC-SHA1', 'RSA-SHA1', 'PLAINTEXT'),
+            ));
+        }
     }
 }

--- a/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -16,7 +16,6 @@ use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
@@ -229,7 +228,7 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
             'signature_method' => 'HMAC-SHA1',
         ));
 
-        if (version_compare(Kernel::VERSION, '2.6', '>=')) {
+        if (method_exists($resolver, 'setDefined')) {
             $resolver->setAllowedValues('signature_method', array('HMAC-SHA1', 'RSA-SHA1', 'PLAINTEXT'));
         } else {
             $resolver->setAllowedValues(array(

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -213,9 +213,14 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
             'use_bearer_authorization' => true,
         ));
 
-        $resolver->setOptional(array(
-            'revoke_token_url',
-        ));
+        // Symfony <2.6 BC
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->setDefined('revoke_token_url');
+        } else {
+            $resolver->setOptional(array(
+                'revoke_token_url',
+            ));
+        }
 
         $resolver->setNormalizers(array(
             // Unfortunately some resource owners break the spec by using commas instead

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -222,20 +222,27 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
             ));
         }
 
-        $resolver->setNormalizers(array(
-            // Unfortunately some resource owners break the spec by using commas instead
-            // of spaces to separate scopes (Disqus, Facebook, Github, Vkontante)
-            'scope' => function (Options $options, $value) {
-                if (!$value) {
-                    return null;
-                }
+        // Unfortunately some resource owners break the spec by using commas instead
+        // of spaces to separate scopes (Disqus, Facebook, Github, Vkontante)
+        $scopeNormalizer = function (Options $options, $value) {
+            if (!$value) {
+                return null;
+            }
 
-                if (!$options['use_commas_in_scope']) {
-                    return $value;
-                }
+            if (!$options['use_commas_in_scope']) {
+                return $value;
+            }
 
-                return str_replace(',', ' ', $value);
-            },
-        ));
+            return str_replace(',', ' ', $value);
+        };
+
+        // Symfony <2.6 BC
+        if (method_exists($resolver, 'setNormalizer')) {
+            $resolver->setNormalizer('scope', $scopeNormalizer);
+        } else {
+            $resolver->setNormalizers(array(
+                'scope' => $scopeNormalizer,
+            ));
+        }
     }
 }

--- a/OAuth/ResourceOwner/GoogleResourceOwner.php
+++ b/OAuth/ResourceOwner/GoogleResourceOwner.php
@@ -11,6 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -71,15 +72,25 @@ class GoogleResourceOwner extends GenericOAuth2ResourceOwner
             'request_visible_actions' => null,
         ));
 
-        $resolver->setAllowedValues(array(
-            // @link https://developers.google.com/accounts/docs/OAuth2WebServer#offline
-            'access_type'     => array('online', 'offline', null),
-            // sometimes we need to force for approval prompt (e.g. when we lost refresh token)
-            'approval_prompt' => array('force', 'auto', null),
-            // @link https://developers.google.com/accounts/docs/OAuth2Login#authenticationuriparameters
-            'display'         => array('page', 'popup', 'touch', 'wap', null),
-            'login_hint'      => array('email address', 'sub', null),
-            'prompt'          => array('consent', 'select_account', null),
-        ));
+        if (version_compare(Kernel::VERSION, '2.6', '>=')) {
+            $resolver
+                // @link https://developers.google.com/accounts/docs/OAuth2WebServer#offline
+                ->setAllowedValues('access_type', array('online', 'offline', null))
+                // sometimes we need to force for approval prompt (e.g. when we lost refresh token)
+                ->setAllowedValues('approval_prompt', array('force', 'auto', null))
+                // @link https://developers.google.com/accounts/docs/OAuth2Login#authenticationuriparameters
+                ->setAllowedValues('display', array('page', 'popup', 'touch', 'wap', null))
+                ->setAllowedValues('login_hint', array('email address', 'sub', null))
+                ->setAllowedValues('prompt', array('consent', 'select_account', null))
+            ;
+        } else {
+            $resolver->setAllowedValues(array(
+                'access_type'     => array('online', 'offline', null),
+                'approval_prompt' => array('force', 'auto', null),
+                'display'         => array('page', 'popup', 'touch', 'wap', null),
+                'login_hint'      => array('email address', 'sub', null),
+                'prompt'          => array('consent', 'select_account', null),
+            ));
+        }
     }
 }

--- a/OAuth/ResourceOwner/GoogleResourceOwner.php
+++ b/OAuth/ResourceOwner/GoogleResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -72,7 +71,7 @@ class GoogleResourceOwner extends GenericOAuth2ResourceOwner
             'request_visible_actions' => null,
         ));
 
-        if (version_compare(Kernel::VERSION, '2.6', '>=')) {
+        if (method_exists($resolver, 'setDefined')) {
             $resolver
                 // @link https://developers.google.com/accounts/docs/OAuth2WebServer#offline
                 ->setAllowedValues('access_type', array('online', 'offline', null))

--- a/OAuth/ResourceOwner/HubicResourceOwner.php
+++ b/OAuth/ResourceOwner/HubicResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**

--- a/OAuth/ResourceOwner/JiraResourceOwner.php
+++ b/OAuth/ResourceOwner/JiraResourceOwner.php
@@ -109,12 +109,23 @@ class JiraResourceOwner extends GenericOAuth1ResourceOwner
             return str_replace('{base_url}', $options['base_url'], $value);
         };
 
-        $resolver->setNormalizers(array(
-            'authorization_url' => $normalizer,
-            'request_token_url' => $normalizer,
-            'access_token_url'  => $normalizer,
-            'infos_session_url' => $normalizer,
-            'infos_url'         => $normalizer,
-        ));
+        // Symfony <2.6 BC
+        if (method_exists($resolver, 'setNormalizer')) {
+            $resolver
+                ->setNormalizer('authorization_url', $normalizer)
+                ->setNormalizer('request_token_url', $normalizer)
+                ->setNormalizer('access_token_url', $normalizer)
+                ->setNormalizer('infos_session_url', $normalizer)
+                ->setNormalizer('infos_url', $normalizer)
+            ;
+        } else {
+            $resolver->setNormalizers(array(
+                'authorization_url' => $normalizer,
+                'request_token_url' => $normalizer,
+                'access_token_url'  => $normalizer,
+                'infos_session_url' => $normalizer,
+                'infos_url'         => $normalizer,
+            ));
+        }
     }
 }

--- a/OAuth/ResourceOwner/PaypalResourceOwner.php
+++ b/OAuth/ResourceOwner/PaypalResourceOwner.php
@@ -45,9 +45,14 @@ class PaypalResourceOwner extends GenericOAuth2ResourceOwner
             'infos_url'         => 'https://api.paypal.com/v1/identity/openidconnect/userinfo/?schema=openid',
         ));
 
-        $resolver->addAllowedTypes(array(
-            'sandbox' => 'bool',
-        ));
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->addAllowedTypes('sandbox', 'bool');
+        } else {
+            $resolver->addAllowedTypes(array(
+                'sandbox' => 'bool',
+            ));
+        }
+
 
         $sandboxTransformation = function (Options $options, $value) {
             if (!$options['sandbox']) {

--- a/OAuth/ResourceOwner/PaypalResourceOwner.php
+++ b/OAuth/ResourceOwner/PaypalResourceOwner.php
@@ -57,10 +57,19 @@ class PaypalResourceOwner extends GenericOAuth2ResourceOwner
             return preg_replace('~\.paypal\.~', '.sandbox.paypal.', $value, 1);
         };
 
-        $resolver->setNormalizers(array(
-            'authorization_url' => $sandboxTransformation,
-            'access_token_url'  => $sandboxTransformation,
-            'infos_url'         => $sandboxTransformation,
-        ));
+        // Symfony <2.6 BC
+        if (method_exists($resolver, 'setNormalizer')) {
+            $resolver
+                ->setNormalizer('authorization_url', $sandboxTransformation)
+                ->setNormalizer('access_token_url', $sandboxTransformation)
+                ->setNormalizer('infos_url', $sandboxTransformation)
+            ;
+        } else {
+            $resolver->setNormalizers(array(
+                'authorization_url' => $sandboxTransformation,
+                'access_token_url'  => $sandboxTransformation,
+                'infos_url'         => $sandboxTransformation,
+            ));
+        }
     }
 }

--- a/OAuth/ResourceOwner/SoundcloudResourceOwner.php
+++ b/OAuth/ResourceOwner/SoundcloudResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**

--- a/OAuth/ResourceOwner/TwitterResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitterResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -54,7 +53,7 @@ class TwitterResourceOwner extends GenericOAuth1ResourceOwner
             ));
         }
 
-        if (version_compare(Kernel::VERSION, '2.6', '>=')) {
+        if (method_exists($resolver, 'setDefined')) {
             // @link https://dev.twitter.com/oauth/reference/post/oauth/request_token
             $resolver->setAllowedValues('x_auth_access_type', array('read', 'write'));
         } else {

--- a/OAuth/ResourceOwner/TwitterResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitterResourceOwner.php
@@ -11,6 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -43,13 +44,18 @@ class TwitterResourceOwner extends GenericOAuth1ResourceOwner
             'access_token_url'  => 'https://api.twitter.com/oauth/access_token',
             'infos_url'         => 'https://api.twitter.com/1.1/account/verify_credentials.json',
         ));
-        
+
         $resolver->setOptional(array(
             'x_auth_access_type',
         ));
-        $resolver->setAllowedValues(array(
+
+        if (version_compare(Kernel::VERSION, '2.6', '>=')) {
             // @link https://dev.twitter.com/oauth/reference/post/oauth/request_token
-            'x_auth_access_type' => array('read', 'write'),
-        ));
+            $resolver->setAllowedValues('x_auth_access_type', array('read', 'write'));
+        } else {
+            $resolver->setAllowedValues(array(
+                'x_auth_access_type' => array('read', 'write'),
+            ));
+        }
     }
 }

--- a/OAuth/ResourceOwner/TwitterResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitterResourceOwner.php
@@ -45,9 +45,14 @@ class TwitterResourceOwner extends GenericOAuth1ResourceOwner
             'infos_url'         => 'https://api.twitter.com/1.1/account/verify_credentials.json',
         ));
 
-        $resolver->setOptional(array(
-            'x_auth_access_type',
-        ));
+        // Symfony <2.6 BC
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->setDefined('x_auth_access_type');
+        } else {
+            $resolver->setOptional(array(
+                'x_auth_access_type',
+            ));
+        }
 
         if (version_compare(Kernel::VERSION, '2.6', '>=')) {
             // @link https://dev.twitter.com/oauth/reference/post/oauth/request_token

--- a/OAuth/ResourceOwner/TwitterResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitterResourceOwner.php
@@ -47,16 +47,12 @@ class TwitterResourceOwner extends GenericOAuth1ResourceOwner
         // Symfony <2.6 BC
         if (method_exists($resolver, 'setDefined')) {
             $resolver->setDefined('x_auth_access_type');
+            // @link https://dev.twitter.com/oauth/reference/post/oauth/request_token
+            $resolver->setAllowedValues('x_auth_access_type', array('read', 'write'));
         } else {
             $resolver->setOptional(array(
                 'x_auth_access_type',
             ));
-        }
-
-        if (method_exists($resolver, 'setDefined')) {
-            // @link https://dev.twitter.com/oauth/reference/post/oauth/request_token
-            $resolver->setAllowedValues('x_auth_access_type', array('read', 'write'));
-        } else {
             $resolver->setAllowedValues(array(
                 'x_auth_access_type' => array('read', 'write'),
             ));

--- a/OAuth/ResourceOwner/VkontakteResourceOwner.php
+++ b/OAuth/ResourceOwner/VkontakteResourceOwner.php
@@ -83,14 +83,21 @@ class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
             'name_case'           => null,
         ));
 
-        $resolver->setNormalizers(array(
-            'fields' => function (Options $options, $value) {
-                if (!$value) {
-                    return null;
-                }
+        $fieldsNormalizer = function (Options $options, $value) {
+            if (!$value) {
+                return null;
+            }
 
-                return is_array($value) ? implode(',', $value) : $value;
-            },
-        ));
+            return is_array($value) ? implode(',', $value) : $value;
+        };
+
+        // Symfony <2.6 BC
+        if (method_exists($resolver, 'setNormalizer')) {
+            $resolver->setNormalizer('fields', $fieldsNormalizer);
+        } else {
+            $resolver->setNormalizers(array(
+                'fields' => $fieldsNormalizer,
+            ));
+        }
     }
 }

--- a/OAuth/ResourceOwner/YoutubeResourceOwner.php
+++ b/OAuth/ResourceOwner/YoutubeResourceOwner.php
@@ -69,15 +69,26 @@ class YoutubeResourceOwner extends GenericOAuth2ResourceOwner
             'request_visible_actions' => null,
         ));
 
-        $resolver->setAllowedValues(array(
-            // @link https://developers.google.com/accounts/docs/OAuth2WebServer#offline
-            'access_type'     => array('online', 'offline', null),
-            // sometimes we need to force for approval prompt (e.g. when we lost refresh token)
-            'approval_prompt' => array('force', 'auto', null),
-            // @link https://developers.google.com/accounts/docs/OAuth2Login#authenticationuriparameters
-            'display'         => array('page', 'popup', 'touch', 'wap', null),
-            'login_hint'      => array('email address', 'sub', null),
-            'prompt'          => array(null, 'consent', 'select_account', null),
-        ));
+        // Symfony <2.6 BC
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver
+                // @link https://developers.google.com/accounts/docs/OAuth2WebServer#offline
+                ->setAllowedValues('access_type', array('online', 'offline', null))
+                // sometimes we need to force for approval prompt (e.g. when we lost refresh token)
+                ->setAllowedValues('approval_prompt', array('force', 'auto', null))
+                // @link https://developers.google.com/accounts/docs/OAuth2Login#authenticationuriparameters
+                ->setAllowedValues('display', array('page', 'popup', 'touch', 'wap', null))
+                ->setAllowedValues('login_hint', array('email address', 'sub', null))
+                ->setAllowedValues('prompt', array(null, 'consent', 'select_account', null))
+            ;
+        } else {
+            $resolver->setAllowedValues(array(
+                'access_type'     => array('online', 'offline', null),
+                'approval_prompt' => array('force', 'auto', null),
+                'display'         => array('page', 'popup', 'touch', 'wap', null),
+                'login_hint'      => array('email address', 'sub', null),
+                'prompt'          => array(null, 'consent', 'select_account', null),
+            ));
+        }
     }
 }

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -111,7 +111,7 @@
 
         <service id="hwi_oauth.security.oauth_utils" class="%hwi_oauth.security.oauth_utils.class%">
             <argument type="service" id="security.http_utils" />
-            <argument type="service" id="security.context" />
+            <argument /> <!-- security.authorization_checker or security.context for Symfony <2.6 -->
             <argument>%hwi_oauth.connect%</argument>
         </service>
 

--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -14,6 +14,7 @@ namespace HWI\Bundle\OAuthBundle\Security;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 
@@ -47,19 +48,34 @@ class OAuthUtils
 
     /**
      * @var SecurityContextInterface
+     *
+     * @deprecated since 0.4. To be removed in 1.0. Use $authorizationChecker property instead.
      */
     protected $securityContext;
 
     /**
-     * @param HttpUtils                $httpUtils
-     * @param SecurityContextInterface $securityContext
-     * @param boolean                  $connect
+     * SecurityContextInterface for Symfony <2.6
+     * To be removed with all related logic (constructor, configs, extension)
+     *
+     * @var AuthorizationCheckerInterface|SecurityContextInterface
      */
-    public function __construct(HttpUtils $httpUtils, SecurityContextInterface $securityContext, $connect)
+    protected $authorizationChecker;
+
+    /**
+     * @param HttpUtils                                              $httpUtils
+     * @param AuthorizationCheckerInterface|SecurityContextInterface $authorizationChecker
+     * @param boolean                                                $connect
+     */
+    public function __construct(HttpUtils $httpUtils, $authorizationChecker, $connect)
     {
-        $this->httpUtils       = $httpUtils;
-        $this->securityContext = $securityContext;
-        $this->connect         = $connect;
+        if (!$authorizationChecker instanceof AuthorizationCheckerInterface && !$authorizationChecker instanceof SecurityContextInterface) {
+            throw new \InvalidArgumentException('Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        }
+
+        $this->httpUtils            = $httpUtils;
+        $this->authorizationChecker = $authorizationChecker;
+        $this->securityContext      = $this->authorizationChecker;
+        $this->connect              = $connect;
     }
 
     /**
@@ -92,7 +108,7 @@ class OAuthUtils
     {
         $resourceOwner = $this->getResourceOwner($name);
         if (null === $redirectUrl) {
-            if (!$this->connect || !$this->securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
+            if (!$this->connect || !$this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
                 $redirectUrl = $this->httpUtils->generateUri($request, $this->ownerMap->getResourceOwnerCheckPath($name));
             } else {
                 $redirectUrl = $this->getServiceAuthUrl($request, $resourceOwner);

--- a/Tests/Controller/AbstractConnectControllerTest.php
+++ b/Tests/Controller/AbstractConnectControllerTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace HWI\Bundle\OAuthBundle\Tests\Controller;
+
+use HWI\Bundle\OAuthBundle\Controller\ConnectController;
+use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
+use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse;
+use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+
+abstract class AbstractConnectControllerTest extends TestCase
+{
+    /**
+     * @var ConnectController
+     */
+    protected $controller;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $authorizationChecker;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $tokenStorage;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $securityContext;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $templating;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $router;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $resourceOwnerMap;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $resourceOwner;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $accountConnector;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $oAuthUtils;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $userChecker;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $eventDispatcher;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $formFactory;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $session;
+
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->container = new Container();
+        $this->container->setParameter('hwi_oauth.templating.engine', 'twig');
+        $this->container->setParameter('hwi_oauth.connect', true);
+        $this->container->setParameter('hwi_oauth.firewall_name', 'default');
+        $this->container->setParameter('hwi_oauth.connect.confirmation', true);
+
+        if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
+            $this->authorizationChecker = $this->getMock('\Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+            $this->container->set('security.authorization_checker', $this->authorizationChecker);
+            $this->tokenStorage = $this->getMock('\Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+            $this->container->set('security.token_storage', $this->tokenStorage);
+        } else {
+            $this->securityContext = $this->getMock('\Symfony\Component\Security\Core\SecurityContextInterface');
+            $this->container->set('security.context', $this->securityContext);
+        }
+
+        $this->templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $this->container->set('templating', $this->templating);
+
+        $this->router = $this->getMock('\Symfony\Component\Routing\RouterInterface');
+        $this->container->set('router', $this->router);
+
+        $this->resourceOwner = $this->getMock('\HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface');
+        $this->resourceOwner->expects($this->any())
+            ->method('getUserInformation')
+            ->willReturn(new CustomUserResponse())
+        ;
+        $this->resourceOwnerMap = $this->getMockBuilder('\HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap')
+            ->disableOriginalConstructor()->getMock()
+        ;
+        $this->resourceOwnerMap->expects($this->any())
+            ->method('getResourceOwnerByName')
+            ->withAnyParameters()
+            ->willReturn($this->resourceOwner);
+        $this->container->set('hwi_oauth.resource_ownermap.default', $this->resourceOwnerMap);
+
+        $this->accountConnector = $this->getMock('HWI\Bundle\OAuthBundle\Connect\AccountConnectorInterface');
+        $this->container->set('hwi_oauth.account.connector', $this->accountConnector);
+
+        $this->oAuthUtils = $this->getMockBuilder('HWI\Bundle\OAuthBundle\Security\OAuthUtils')
+            ->disableOriginalConstructor()->getMock()
+        ;
+        $this->container->set('hwi_oauth.security.oauth_utils', $this->oAuthUtils);
+
+        $this->userChecker = $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface');
+        $this->container->set('hwi_oauth.user_checker', $this->userChecker);
+
+        $this->eventDispatcher = $this->getMock('\Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->container->set('event_dispatcher', $this->eventDispatcher);
+
+        $this->formFactory = $this->getMock('\Symfony\Component\Form\FormFactoryInterface');
+        $this->container->set('form.factory', $this->formFactory);
+
+        $this->session = $this->getMock('\Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $this->request = Request::create('/');
+        $this->request->setSession($this->session);
+
+        $this->controller = new ConnectController();
+        $this->controller->setContainer($this->container);
+    }
+
+    /**
+     * @return AccountNotLinkedException
+     */
+    protected function createAccountNotLinkedException()
+    {
+        $accountNotLinked = new AccountNotLinkedException();
+        $accountNotLinked->setResourceOwnerName('facebook');
+        $token = new CustomOAuthToken();
+        $accountNotLinked->setToken($token);
+
+        return $accountNotLinked;
+    }
+
+    /**
+     * Symfony <2.6 BC. To be removed.
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getAuthorizationChecker()
+    {
+        return $this->authorizationChecker ? $this->authorizationChecker : $this->securityContext;
+    }
+
+    /**
+     * Symfony <2.6 BC. To be removed.
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getTokenStorage()
+    {
+        return $this->tokenStorage ? $this->tokenStorage : $this->securityContext;
+    }
+
+    /**
+     * Symfony <2.6 BC. To be removed.
+     *
+     * @return string
+     */
+    protected function getAuthenticationErrorKey()
+    {
+        return class_exists('Symfony\Component\Security\Core\Security')
+            ? Security::AUTHENTICATION_ERROR : SecurityContextInterface::AUTHENTICATION_ERROR;
+    }
+}

--- a/Tests/Controller/ConnectControllerConnectActionTest.php
+++ b/Tests/Controller/ConnectControllerConnectActionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace HWI\Bundle\OAuthBundle\Tests\Controller;
+
+use HWI\Bundle\OAuthBundle\Tests\Fixtures\User;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\SecurityContext;
+
+class ConnectConnectControllerConnectActionTest extends AbstractConnectControllerTest
+{
+    public function testLoginPage()
+    {
+        $this->container->setParameter('hwi_oauth.connect', true);
+
+        $this->templating->expects($this->once())
+            ->method('renderResponse')
+            ->with('HWIOAuthBundle:Connect:login.html.twig')
+        ;
+
+        $this->controller->connectAction($this->request);
+    }
+
+    public function testRegistrationRedirect()
+    {
+        $this->request->attributes = new ParameterBag(array(
+            $this->getAuthenticationErrorKey() => $this->createAccountNotLinkedException()
+        ));
+
+        $this->getAuthorizationChecker()->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willReturn(false)
+        ;
+
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with('hwi_oauth_connect_registration')
+            ->willReturn('/')
+        ;
+
+        $this->controller->connectAction($this->request);
+    }
+
+    public function testRequestError()
+    {
+        $this->request->attributes = new ParameterBag(array(
+            $this->getAuthenticationErrorKey() => new AccessDeniedException('You shall not pass the request.')
+        ));
+
+        $this->templating->expects($this->once())
+            ->method('renderResponse')
+            ->with('HWIOAuthBundle:Connect:login.html.twig', array('error' => 'You shall not pass the request.'))
+        ;
+
+        $this->controller->connectAction($this->request);
+    }
+
+    public function testSessionError()
+    {
+        $this->session->expects($this->once())
+            ->method('has')
+            ->with($this->getAuthenticationErrorKey())
+            ->willReturn(true)
+        ;
+
+        $this->session->expects($this->once())
+            ->method('get')
+            ->with($this->getAuthenticationErrorKey())
+            ->willReturn(new AccessDeniedException('You shall not pass the session.'))
+        ;
+
+        $this->templating->expects($this->once())
+            ->method('renderResponse')
+            ->with('HWIOAuthBundle:Connect:login.html.twig', array('error' => 'You shall not pass the session.'))
+        ;
+
+        $this->controller->connectAction($this->request);
+    }
+}

--- a/Tests/Controller/ConnectControllerConnectServiceActionTest.php
+++ b/Tests/Controller/ConnectControllerConnectServiceActionTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace HWI\Bundle\OAuthBundle\Tests\Controller;
+
+use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
+
+class ConnectConnectControllerConnectServiceActionTest extends AbstractConnectControllerTest
+{
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function testNotEnabled()
+    {
+        $this->container->setParameter('hwi_oauth.connect', false);
+
+        $this->controller->connectServiceAction($this->request, 'facebook');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
+     * @expectedExceptionMessage Cannot connect an account.
+     */
+    public function testAlreadyConnected()
+    {
+        $this->getAuthorizationChecker()->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willReturn(false)
+        ;
+
+        $this->controller->connectServiceAction($this->request, 'facebook');
+    }
+
+    public function testConnectConfirm()
+    {
+        $key = time();
+
+        $this->request->query->set('key', $key);
+
+        $this->getAuthorizationChecker()->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willReturn(true)
+        ;
+
+        $this->session->expects($this->once())
+            ->method('get')
+            ->with('_hwi_oauth.connect_confirmation.'.$key)
+            ->willReturn(array())
+        ;
+
+        $form = $this->getMock('\Symfony\Component\Form\FormInterface');
+        $this->formFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($form)
+        ;
+
+        $this->templating->expects($this->once())
+            ->method('renderResponse')
+            ->with('HWIOAuthBundle:Connect:connect_confirm.html.twig')
+        ;
+
+        $this->controller->connectServiceAction($this->request, 'facebook');
+    }
+
+    public function testConnectSuccess()
+    {
+        $key = time();
+
+        $this->request->query->set('key', $key);
+        $this->request->setMethod('POST');
+
+        $this->getAuthorizationChecker()->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willReturn(true)
+        ;
+
+        $this->session->expects($this->once())
+            ->method('get')
+            ->with('_hwi_oauth.connect_confirmation.'.$key)
+            ->willReturn(array())
+        ;
+
+        $form = $this->getMock('\Symfony\Component\Form\FormInterface');
+        $this->formFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($form)
+        ;
+
+        $form->expects($this->once())->method('isSubmitted')->willReturn(true);
+        $form->expects($this->once())->method('isValid')->willReturn(true);
+
+        $this->getTokenStorage()->expects($this->once())
+            ->method('getToken')
+            ->willReturn(new CustomOAuthToken())
+        ;
+
+        $this->templating->expects($this->once())
+            ->method('renderResponse')
+            ->with('HWIOAuthBundle:Connect:connect_success.html.twig')
+        ;
+
+        $this->controller->connectServiceAction($this->request, 'facebook');
+    }
+
+    public function testConnectNoConfirmation()
+    {
+        $key = time();
+
+        $this->request->query->set('key', $key);
+        $this->container->setParameter('hwi_oauth.connect.confirmation', false);
+
+        $this->getAuthorizationChecker()->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willReturn(true)
+        ;
+
+        $this->session->expects($this->once())
+            ->method('get')
+            ->with('_hwi_oauth.connect_confirmation.'.$key)
+            ->willReturn(array())
+        ;
+
+        $this->getTokenStorage()->expects($this->once())
+            ->method('getToken')
+            ->willReturn(new CustomOAuthToken())
+        ;
+
+        $this->templating->expects($this->once())
+            ->method('renderResponse')
+            ->with('HWIOAuthBundle:Connect:connect_success.html.twig')
+        ;
+
+        $this->controller->connectServiceAction($this->request, 'facebook');
+    }
+
+    public function testResourceOwnerHandle()
+    {
+        $key = time();
+
+        $this->request->query->set('key', $key);
+
+        $this->getAuthorizationChecker()->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willReturn(true)
+        ;
+
+        $this->resourceOwner->expects($this->once())
+            ->method('handles')
+            ->willReturn(true)
+        ;
+
+        $this->resourceOwner->expects($this->once())
+            ->method('getAccessToken')
+            ->willReturn(array())
+        ;
+
+        $form = $this->getMock('\Symfony\Component\Form\FormInterface');
+        $this->formFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($form)
+        ;
+
+        $this->templating->expects($this->once())
+            ->method('renderResponse')
+            ->with('HWIOAuthBundle:Connect:connect_confirm.html.twig')
+        ;
+
+        $this->controller->connectServiceAction($this->request, 'facebook');
+    }
+}

--- a/Tests/Controller/ConnectControllerRedirectToServiceActionTest.php
+++ b/Tests/Controller/ConnectControllerRedirectToServiceActionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace HWI\Bundle\OAuthBundle\Tests\Controller;
+
+
+class ConnectConnectControllerRedirectToServiceActionTest extends AbstractConnectControllerTest
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->container->setParameter('hwi_oauth.target_path_parameter', null);
+        $this->container->setParameter('hwi_oauth.use_referer', false);
+
+        $this->oAuthUtils->expects($this->any())
+            ->method('getAuthorizationUrl')
+            ->willReturn('http://domain.com/oauth/v2/auth')
+        ;
+    }
+
+    public function test()
+    {
+        $response = $this->controller->redirectToServiceAction($this->request, 'facebook');
+
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertEquals('http://domain.com/oauth/v2/auth', $response->getTargetUrl());
+    }
+
+    public function testTargetPathParameter()
+    {
+        $this->container->setParameter('hwi_oauth.target_path_parameter', 'target_path');
+        $this->request->attributes->set('target_path', '/target/path');
+
+        $this->session->expects($this->once())
+            ->method('set')
+            ->with('_security.default.target_path', '/target/path')
+        ;
+
+        $this->controller->redirectToServiceAction($this->request, 'facebook');
+    }
+
+    public function testUseReferer()
+    {
+        $this->container->setParameter('hwi_oauth.use_referer', true);
+        $this->request->headers->set('Referer', 'https://google.com');
+
+        $this->session->expects($this->once())
+            ->method('set')
+            ->with('_security.default.target_path', 'https://google.com')
+        ;
+
+        $this->controller->redirectToServiceAction($this->request, 'facebook');
+    }
+}

--- a/Tests/Controller/ConnectControllerRegistrationActionTest.php
+++ b/Tests/Controller/ConnectControllerRegistrationActionTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace HWI\Bundle\OAuthBundle\Tests\Controller;
+
+use HWI\Bundle\OAuthBundle\Tests\Fixtures\User;
+
+class ConnectConnectControllerRegistrationActionTest extends AbstractConnectControllerTest
+{
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function testNotEnabled()
+    {
+        $this->container->setParameter('hwi_oauth.connect', false);
+
+        $this->controller->registrationAction($this->request, time());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
+     * @expectedExceptionMessage Cannot connect already registered account.
+     */
+    public function testAlreadyConnected()
+    {
+        $this->getAuthorizationChecker()->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willReturn(true)
+        ;
+
+        $this->controller->registrationAction($this->request, time());
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Cannot register an account.
+     */
+    public function testCannotRegisterBadError()
+    {
+        $key = time();
+
+        $this->session->expects($this->once())
+            ->method('get')
+            ->with('_hwi_oauth.registration_error.'.$key)
+            ->willReturn(new \Exception())
+        ;
+
+        $this->controller->registrationAction($this->request, $key);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Cannot register an account.
+     */
+    public function testCannotRegisterBadKey()
+    {
+        $key = time() - 500;
+
+        $this->session->expects($this->once())
+            ->method('get')
+            ->with('_hwi_oauth.registration_error.'.$key)
+            ->willReturn($this->createAccountNotLinkedException())
+        ;
+
+        $this->controller->registrationAction($this->request, $key);
+    }
+
+    public function testFailedProcess()
+    {
+        $key = time();
+
+        $this->session->expects($this->once())
+            ->method('get')
+            ->with('_hwi_oauth.registration_error.'.$key)
+            ->willReturn($this->createAccountNotLinkedException())
+        ;
+
+        $this->makeRegistrationForm();
+
+        $registrationFormHandler = $this->getMock('\HWI\Bundle\OAuthBundle\Form\RegistrationFormHandlerInterface');
+        $registrationFormHandler->expects($this->once())
+            ->method('process')
+            ->withAnyParameters()
+            ->willReturn(false)
+        ;
+        $this->container->set('hwi_oauth.registration.form.handler', $registrationFormHandler);
+
+        $this->templating->expects($this->once())
+            ->method('renderResponse')
+            ->with('HWIOAuthBundle:Connect:registration.html.twig')
+        ;
+
+        $this->controller->registrationAction($this->request, $key);
+    }
+
+    public function test()
+    {
+        $key = time();
+
+        $this->session->expects($this->once())
+            ->method('get')
+            ->with('_hwi_oauth.registration_error.'.$key)
+            ->willReturn($this->createAccountNotLinkedException())
+        ;
+
+        $this->makeRegistrationForm();
+
+        $registrationFormHandler = $this->getMock('\HWI\Bundle\OAuthBundle\Form\RegistrationFormHandlerInterface');
+        $registrationFormHandler->expects($this->once())
+            ->method('process')
+            ->withAnyParameters()
+            ->willReturn(true)
+        ;
+        $this->container->set('hwi_oauth.registration.form.handler', $registrationFormHandler);
+
+        $this->accountConnector->expects($this->once())
+            ->method('connect')
+        ;
+
+        $this->eventDispatcher->expects($this->once())
+            ->method('dispatch')
+        ;
+
+        $this->controller->registrationAction($this->request, $key);
+    }
+
+    private function makeRegistrationForm()
+    {
+        $registrationForm = $this->getMockBuilder('\Symfony\Component\Form\Form')
+            ->disableOriginalConstructor()->getMock();
+        $registrationForm->expects($this->any())
+            ->method('getData')
+            ->willReturn(new User());
+        $registrationFormFactory = $this->getMock('\FOS\UserBundle\Form\Factory\FactoryInterface');
+        $registrationFormFactory->expects($this->any())
+            ->method('createForm')
+            ->willReturn($registrationForm)
+        ;
+        $this->container->set('hwi_oauth.registration.form.factory', $registrationFormFactory);
+        // FOSUser 1.3 BC. To be removed.
+        $this->container->set('hwi_oauth.registration.form', $registrationForm);
+
+    }
+}

--- a/Tests/Fixtures/CustomOAuthToken.php
+++ b/Tests/Fixtures/CustomOAuthToken.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace HWI\Bundle\OAuthBundle\Tests\Fixtures;
+
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+
+class CustomOAuthToken extends OAuthToken
+{
+    public function __construct()
+    {
+        parent::__construct(array(
+            'access_token'      => 'access_token_data',
+        ), array(
+            'ROLE_USER',
+        ));
+
+        $this->setUser(new User());
+    }
+}

--- a/Tests/OAuth/ResourceOwner/DailymotionResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/DailymotionResourceOwnerTest.php
@@ -39,7 +39,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\ExceptionInterface
      */
     public function testInvalidDisplayOptionValueThrowsException()
     {

--- a/Tests/OAuth/ResourceOwner/FacebookResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/FacebookResourceOwnerTest.php
@@ -71,7 +71,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\ExceptionInterface
      */
     public function testInvalidDisplayOptionValueThrowsException()
     {

--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -51,15 +51,15 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\ExceptionInterface
      */
-    public function testGetInvalidOptionThrowsException()
+    public function testUndefinedOptionThrowsException()
     {
         $this->createResourceOwner($this->resourceOwnerName, array('non_existing' => null));
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\ExceptionInterface
      */
     public function testInvalidOptionValueThrowsException()
     {

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -17,6 +17,7 @@ use Buzz\Message\RequestInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 class GenericOAuth2ResourceOwnerTest extends \PHPUnit_Framework_TestCase
 {
@@ -69,15 +70,15 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\ExceptionInterface
      */
-    public function testInvalidOptionThrowsException()
+    public function testUndefinedOptionThrowsException()
     {
         $this->createResourceOwner($this->resourceOwnerName, array('non_existing' => null));
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\ExceptionInterface
      */
     public function testInvalidOptionValueThrowsException()
     {
@@ -319,7 +320,7 @@ json;
         $this->storage->expects($this->once())
             ->method('fetch')
             ->with($resourceOwner, 'invalid_token', 'csrf_state')
-            ->will($this->throwException(new \InvalidArgumentException('No data available in storage.')));
+            ->will($this->throwException(new InvalidOptionsException('No data available in storage.')));
 
         $resourceOwner->isCsrfTokenValid('invalid_token');
     }

--- a/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
@@ -36,7 +36,7 @@ json;
     );
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\ExceptionInterface
      */
     public function testInvalidAccessTypeOptionValueThrowsException()
     {
@@ -44,7 +44,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\ExceptionInterface
      */
     public function testInvalidApprovalPromptOptionValueThrowsException()
     {

--- a/Tests/Security/OAuthUtilsTest.php
+++ b/Tests/Security/OAuthUtilsTest.php
@@ -23,7 +23,12 @@ class OAuthUtilsTest extends \PHPUnit_Framework_TestCase
         $request  = $this->getRequest($url);
         $redirect = 'https://api.instagram.com/oauth/authorize?redirect='.rawurlencode($url);
 
-        $utils = new OAuthUtils($this->getHttpUtils($url), $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface'), true);
+        if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
+            $authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        } else {
+            $authorizationChecker = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        }
+        $utils = new OAuthUtils($this->getHttpUtils($url), $authorizationChecker, true);
         $utils->setResourceOwnerMap($this->getMap($url, $redirect, false, true));
 
         $this->assertEquals(
@@ -40,7 +45,7 @@ class OAuthUtilsTest extends \PHPUnit_Framework_TestCase
         $request  = $this->getRequest($url);
         $redirect = 'https://api.instagram.com/oauth/authorize?redirect='.rawurlencode($url);
 
-        $utils = new OAuthUtils($this->getHttpUtils($url), $this->getSecurity(true), true);
+        $utils = new OAuthUtils($this->getHttpUtils($url), $this->getAutorizationChecker(true), true);
         $utils->setResourceOwnerMap($this->getMap($url, $redirect, true));
 
         $this->assertEquals(
@@ -60,7 +65,7 @@ class OAuthUtilsTest extends \PHPUnit_Framework_TestCase
         $request  = $this->getRequest($url);
         $redirect = 'https://api.instagram.com/oauth/authorize?redirect='.rawurlencode($url);
 
-        $utils = new OAuthUtils($this->getHttpUtils($url), $this->getSecurity(false), true);
+        $utils = new OAuthUtils($this->getHttpUtils($url), $this->getAutorizationChecker(false), true);
         $utils->setResourceOwnerMap($this->getMap($url, $redirect));
 
         $this->assertEquals(
@@ -180,9 +185,13 @@ class OAuthUtilsTest extends \PHPUnit_Framework_TestCase
         return new HttpUtils($urlGenerator);
     }
 
-    private function getSecurity($hasUser)
+    private function getAutorizationChecker($hasUser)
     {
-        $mock = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
+            $mock = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        } else {
+            $mock= $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        }
         $mock
             ->expects($this->once())
             ->method('isGranted')

--- a/composer.json
+++ b/composer.json
@@ -74,11 +74,11 @@
     "require": {
         "php":                          ">=5.3.3",
         "symfony/framework-bundle":     "~2.3",
-        "symfony/security-bundle":      "~2.1",
-        "symfony/options-resolver":     "~2.1",
+        "symfony/security-bundle":      "~2.3",
+        "symfony/options-resolver":     "~2.3",
         "symfony/form":                 "~2.3",
-        "kriswallsmith/buzz":           "~0.7",
-        "symfony/yaml": "~2.3"
+        "symfony/yaml":                 "~2.3",
+        "kriswallsmith/buzz":           "~0.13"
     },
 
     "conflict": {
@@ -87,9 +87,9 @@
 
     "require-dev": {
         "doctrine/orm":                 "~2.3",
-        "symfony/property-access":      "~2.5",
-        "symfony/validator":            "~2.1",
-        "symfony/twig-bundle":          "~2.1",
+        "symfony/property-access":      "~2.3",
+        "symfony/validator":            "~2.3",
+        "symfony/twig-bundle":          "~2.3",
         "symfony/phpunit-bridge":       "~2.7",
         "friendsofsymfony/user-bundle": "~1.3|~2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
         "symfony/framework-bundle":     "~2.3",
         "symfony/security-bundle":      "~2.1",
         "symfony/options-resolver":     "~2.1",
+        "symfony/form":                 "~2.3",
         "kriswallsmith/buzz":           "~0.7",
         "symfony/yaml": "~2.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,8 @@
         "doctrine/orm":                 "~2.3",
         "symfony/property-access":      "~2.5",
         "symfony/validator":            "~2.1",
-        "symfony/twig-bundle":          "~2.1"
+        "symfony/twig-bundle":          "~2.1",
+        "symfony/phpunit-bridge":       "~2.7"
     },
 
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,8 @@
         "symfony/property-access":      "~2.5",
         "symfony/validator":            "~2.1",
         "symfony/twig-bundle":          "~2.1",
-        "symfony/phpunit-bridge":       "~2.7"
+        "symfony/phpunit-bridge":       "~2.7",
+        "friendsofsymfony/user-bundle": "~1.3|~2.0"
     },
 
     "suggest": {
@@ -107,6 +108,9 @@
     },
 
     "target-dir": "HWI/Bundle/OAuthBundle",
+
+    "minimum-stability": "dev",
+    "prefer-stable": true,
 
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This PR is a remake of #730.

All BC will be kept for Symfony 2.3+.

What is done here:

 * `symfony/phpunit-bridge` package install to get more proper deprecation notices
 * Updated Travis configuration
 * Drop FOSUserBundle 1.2 support (Only for symfony <2.3)
 * Add missing `symfony/form` package
 * Fix deprecated `SecurityContextInterface` usage
 * Fix deprecated `OptionsResolverInterface` usage
 * Fix deprecated `OptionsResolver::setAllowedValues` arguments usage
 * Fix deprecated `OptionsResolver::setOptional` method usage
 * Fix deprecated `OptionsResolver::setNormalizers` method usage
 * Fix deprecated `OptionsResolver::addAllowedTypes` method usage
 * Fix new `UndefinedOptionsException` thrown error
 * Improves `ConnectController` with `Controller` extends (`$this->render`, `$this->redirect`...)
 * Tests for `ConnectController`
 * Remove deprecated usages on `ConnectController`

Todo:
 
* Add `friendsofsymfony/user-bundle` as a dev requirement.
* Remove ugly `goto` case from `ConnectController`

The list will be updated as long as I'm working on it. Will remove `[WIP]` tag when it will be finished.