### PR TITLE
Lock 0.3 version to Symfony <2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Installation
 All the installation instructions are located in the documentation, check it for specific
 version:
 
-* [__0.3__](https://github.com/hwi/HWIOAuthBundle/blob/master/Resources/doc/1-setting_up_the_bundle.md) with support for Symfony `>=2.1`
+* [__0.3__](https://github.com/hwi/HWIOAuthBundle/blob/master/Resources/doc/1-setting_up_the_bundle.md) with support for Symfony `>=2.1,<2.7`
 * [__0.2__](https://github.com/hwi/HWIOAuthBundle/blob/0.2/Resources/doc/1-setting_up_the_bundle.md) with support for Symfony `>=2.0,<2.2`
 
 Documentation
@@ -56,7 +56,7 @@ Documentation
 The bulk of the documentation is stored in the `Resources/doc/index.md`
 file in this bundle. Read the documentation for version:
 
-* [__0.3__](https://github.com/hwi/HWIOAuthBundle/blob/master/Resources/doc/index.md) with support for Symfony `>=2.1`
+* [__0.3__](https://github.com/hwi/HWIOAuthBundle/blob/master/Resources/doc/index.md) with support for Symfony `>=2.1,<2.7`
 * [__0.2__](https://github.com/hwi/HWIOAuthBundle/blob/0.2/Resources/doc/index.md) with support for Symfony `>=2.0,<2.2`
 
 License

--- a/composer.json
+++ b/composer.json
@@ -69,17 +69,17 @@
 
     "require": {
         "php":                          ">=5.3.3",
-        "symfony/framework-bundle":     "~2.1",
-        "symfony/security-bundle":      "~2.1",
-        "symfony/options-resolver":     "~2.1",
+        "symfony/framework-bundle":     "~2.1,<2.7",
+        "symfony/security-bundle":      "~2.1,<2.7",
+        "symfony/options-resolver":     "~2.1,<2.7",
         "kriswallsmith/buzz":           "~0.7"
     },
 
     "require-dev": {
         "doctrine/orm":                 "~2.2",
-        "symfony/property-access":      "~2.5",
-        "symfony/validator":            "~2.1",
-        "symfony/twig-bundle":          "~2.1"
+        "symfony/property-access":      "~2.5,<2.7",
+        "symfony/validator":            "~2.1,<2.7",
+        "symfony/twig-bundle":          "~2.1,<2.7"
     },
 
     "suggest": {


### PR DESCRIPTION
Because we want to close 0.3 updates since #747, `composer.json` deps should be lock on Symfony <2.7 in order to avoid new issues from users still using 0.3 branch with a 2.7 version of Symfony.

`README.md` is also updated.

@stloyd We need a tag for this. Should be the last! :-P