### PR TITLE
Get back symfony/property-access 2.3 BC

### DIFF
--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -102,7 +102,9 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
 
         $property = $this->getProperty($response);
 
-        if (!$this->accessor->isWritable($user, $property)) {
+        // Symfony <2.5 BC
+        if (method_exists($this->accessor, 'isWritable') && !$this->accessor->isWritable($user, $property)
+            || !method_exists($this->accessor, 'isWritable') && !method_exists($user, 'set'.ucfirst($property))) {
             throw new \RuntimeException(sprintf("Class '%s' must have defined setter method for property: '%s'.", get_class($user), $property));
         }
 

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
 
     "require-dev": {
         "doctrine/orm":                 "~2.2",
-        "symfony/property-access":      "~2.5",
+        "symfony/property-access":      "~2.3",
         "symfony/validator":            "~2.1",
         "symfony/twig-bundle":          "~2.1"
     },


### PR DESCRIPTION
Should fix #691.

@fracsi @dincho @regularjack @dupuchba can you please confirm it?

ping @stloyd => This is for `0.3`.

