### PR TITLE
Auth0 SDK Client headers spec compliant

### DIFF
--- a/OAuth/ResourceOwner/Auth0ResourceOwner.php
+++ b/OAuth/ResourceOwner/Auth0ResourceOwner.php
@@ -55,7 +55,7 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function doGetUserInformationRequest($url, array $parameters = array());
+    protected function doGetUserInformationRequest($url, array $parameters = array())
     {
 
         $headers = $this->getRequestHeaders();

--- a/OAuth/ResourceOwner/Auth0ResourceOwner.php
+++ b/OAuth/ResourceOwner/Auth0ResourceOwner.php
@@ -34,11 +34,24 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
         'profilepicture' => 'picture',
     );
 
+    protected function getAuthClient() {
+        return base64_encode(json_encode(array(
+
+                'name' => 'HWIOAuthBundle', 
+                'version' => 'unknown',
+
+                'environment' => array(
+                    'name' => 'PHP', 
+                    'version' => phpversion()
+                )
+
+            )));
+    }
+
     protected function getRequestHeaders($extends = array()) {
 
         return array_merge($extends, array(
-            'User-Agent' => 'PHP/' . phpversion(),
-            'Auth0-Client' => 'PHP/HWIOAuthBundle',
+            'Auth0-Client' => $this->getAuthClient()
         ));
     }
     /**
@@ -71,7 +84,7 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults(array(
-            'authorization_url'   => '{base_url}/authorize',
+            'authorization_url'   => '{base_url}/authorize?auth0Client=' . $this->getAuthClient(),
             'access_token_url'    => '{base_url}/oauth/token',
             'infos_url'           => '{base_url}/userinfo',
         ));

--- a/OAuth/ResourceOwner/Auth0ResourceOwner.php
+++ b/OAuth/ResourceOwner/Auth0ResourceOwner.php
@@ -34,32 +34,11 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
         'profilepicture' => 'picture',
     );
 
-    protected function getAuthClient() {
-        return base64_encode(json_encode(array(
-
-                'name' => 'HWIOAuthBundle', 
-                'version' => 'unknown',
-
-                'environment' => array(
-                    'name' => 'PHP', 
-                    'version' => phpversion()
-                )
-
-            )));
-    }
-
-    protected function getRequestHeaders($extends = array()) {
-
-        return array_merge($extends, array(
-            'Auth0-Client' => $this->getAuthClient()
-        ));
-    }
     /**
      * {@inheritDoc}
      */
     protected function doGetTokenRequest($url, array $parameters = array())
     {
-
         $headers = $this->getRequestHeaders(array('Content-Type' => 'application/x-www-form-urlencoded'));
 
         return $this->httpRequest($url, http_build_query($parameters, '', '&'), $headers, HttpRequestInterface::METHOD_POST);
@@ -70,12 +49,10 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
      */
     protected function doGetUserInformationRequest($url, array $parameters = array())
     {
-
         $headers = $this->getRequestHeaders();
 
         return $this->httpRequest($url, http_build_query($parameters, '', '&'), $headers);
     }
-
 
     /**
      * {@inheritDoc}
@@ -83,10 +60,18 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
     protected function configureOptions(OptionsResolverInterface $resolver)
     {
         parent::configureOptions($resolver);
+
+        $auth0CLient = base64_encode(json_encode(array(
+            'name' => 'HWIOAuthBundle', 
+            'version' => 'unknown',
+            'environment' => array('name' => 'PHP', 'version' => phpversion())
+        )));
+
         $resolver->setDefaults(array(
-            'authorization_url'   => '{base_url}/authorize?auth0Client=' . $this->getAuthClient(),
+            'authorization_url'   => '{base_url}/authorize?auth0Client=' . $auth0CLient,
             'access_token_url'    => '{base_url}/oauth/token',
             'infos_url'           => '{base_url}/userinfo',
+            'auth0_client'        => $auth0CLient
         ));
 
         $resolver->setRequired(array(
@@ -102,5 +87,16 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
             'access_token_url'  => $normalizer,
             'infos_url'         => $normalizer,
         ));
+    }
+
+    private function getRequestHeaders($extends = array()) 
+    {
+        $headers = array();
+        
+        if (!empty($this->options['auth0_client'])) {
+            $headers = array('Auth0-Client' => $this->options['auth0_client']);
+        }
+
+        return array_merge($extends, $headers);
     }
 }

--- a/OAuth/ResourceOwner/Auth0ResourceOwner.php
+++ b/OAuth/ResourceOwner/Auth0ResourceOwner.php
@@ -34,17 +34,33 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
         'profilepicture' => 'picture',
     );
 
+    protected function getRequestHeaders($extends = array()) {
+
+        return array_merge($extends, array(
+            'User-Agent' => 'PHP/' . phpversion(),
+            'Auth0-Client' => 'PHP/HWIOAuthBundle',
+        ));
+    }
     /**
      * {@inheritDoc}
      */
     protected function doGetTokenRequest($url, array $parameters = array())
     {
 
-        $headers = array(
-            'Content-Type' => 'application/x-www-form-urlencoded'
-        );
+        $headers = $this->getRequestHeaders(array('Content-Type' => 'application/x-www-form-urlencoded'));
 
         return $this->httpRequest($url, http_build_query($parameters, '', '&'), $headers, HttpRequestInterface::METHOD_POST);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function doGetUserInformationRequest($url, array $parameters = array());
+    {
+
+        $headers = $this->getRequestHeaders();
+
+        return $this->httpRequest($url, http_build_query($parameters, '', '&'), $headers);
     }
 
 


### PR DESCRIPTION
Hi,

We are adding in all our SDK's a couple of headers to allow us to find errors on our clients integration and/or deprecated versions.

This PR targets to add this headers for the requests to the Auth0 API.

Also, it would be very helpful to add the HWIOAuthBundle version in the header but seems that doesn't exists some constant with this info, right?

thanks
