### PR TITLE
Replaced routing deprecated arguments

### DIFF
--- a/Resources/config/routing/connect.xml
+++ b/Resources/config/routing/connect.xml
@@ -4,11 +4,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="hwi_oauth_connect_service" pattern="/service/{service}">
+    <route id="hwi_oauth_connect_service" path="/service/{service}">
         <default key="_controller">HWIOAuthBundle:Connect:connectService</default>
     </route>
 
-    <route id="hwi_oauth_connect_registration" pattern="/registration/{key}">
+    <route id="hwi_oauth_connect_registration" path="/registration/{key}">
         <default key="_controller">HWIOAuthBundle:Connect:registration</default>
     </route>
 </routes>

--- a/Resources/config/routing/login.xml
+++ b/Resources/config/routing/login.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="hwi_oauth_connect" pattern="/">
+    <route id="hwi_oauth_connect" path="/">
         <default key="_controller">HWIOAuthBundle:Connect:connect</default>
     </route>
 </routes>

--- a/Resources/config/routing/redirect.xml
+++ b/Resources/config/routing/redirect.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="hwi_oauth_service_redirect" pattern="/{service}">
+    <route id="hwi_oauth_service_redirect" path="/{service}">
         <default key="_controller">HWIOAuthBundle:Connect:redirectToService</default>
     </route>
 </routes>

--- a/Resources/doc/3-configuring_the_security_layer.md
+++ b/Resources/doc/3-configuring_the_security_layer.md
@@ -48,16 +48,16 @@ The paths configured at the `resource_owners` section should be defined in your 
 ```yaml
 # app/config/routing.yml
 facebook_login:
-    pattern: /login/check-facebook
+    path: /login/check-facebook
 
 google_login:
-    pattern: /login/check-google
+    path: /login/check-google
 
 custom_login:
-    pattern: /login/check-custom
+    path: /login/check-custom
 
 github_login:
-    pattern: /login/check-github
+    path: /login/check-github
 ```
 
 ## That was it!

--- a/Resources/doc/bonus/facebook-connect.md
+++ b/Resources/doc/bonus/facebook-connect.md
@@ -35,7 +35,7 @@ hwi_oauth_redirect:
     prefix:   /demo/secured/connect
 
 facebook_login:
-    pattern: /demo/secured/login_facebook
+    path: /demo/secured/login_facebook
 ```
 
 ### Configuration of the Security Layer

--- a/Resources/doc/internals/reference_configuration.md
+++ b/Resources/doc/internals/reference_configuration.md
@@ -138,16 +138,16 @@ hwi_oauth_redirect:
     prefix:   /connect
 
 facebook_login:
-    pattern: /login/check-facebook
+    path: /login/check-facebook
 
 google_login:
-    pattern: /login/check-google
+    path: /login/check-google
 
 custom_login:
-    pattern: /login/check-custom
+    path: /login/check-custom
 
 github_login:
-    pattern: /login/check-github
+    path: /login/check-github
 ```
 
 [Return to the index.](../index.md)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Replaces arguments which are deprecated from Symfony 2.2:

Before:
```xml
<route id="hwi_oauth_connect_registration" pattern="/registration/{key}">
    <default key="_controller">HWIOAuthBundle:Connect:registration</default>
</route>
```

After:
```xml
<route id="hwi_oauth_connect_registration" path="/registration/{key}">
    <default key="_controller">HWIOAuthBundle:Connect:registration</default>
</route>
```