### PR TITLE
after FB oauth cancellation. Fatal error was occuring, bug has been fixed. hwi/HWIOAuthBundle#796

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -183,6 +183,10 @@ class ConnectController extends ContainerAware
             $accessToken = $session->get('_hwi_oauth.connect_confirmation.'.$key);
         }
 
+        if (!is_array($accessToken)) {
+            return $this->container->get('templating')->renderResponse('HWIOAuthBundle:Connect:connect_fail.html.' . $this->getTemplatingEngine());
+        }
+
         $userInformation = $resourceOwner->getUserInformation($accessToken);
 
         // Show confirmation page?

--- a/Resources/translations/HWIOAuthBundle.en.yml
+++ b/Resources/translations/HWIOAuthBundle.en.yml
@@ -1,6 +1,7 @@
 header:
     connecting: Connecting
     success: Successfully connected the account '%name%'!
+    fail: Couldn't connected the account
     register: Register with the account '%name%'
     registration_success: Successfully registered and connected the account '%username%'!
 

--- a/Resources/translations/HWIOAuthBundle.tr.yml
+++ b/Resources/translations/HWIOAuthBundle.tr.yml
@@ -1,6 +1,7 @@
 header:
     connecting: "Bağlan"
     success: "Başarı ile '%name%' hesabına bağlanıldı!"
+    fail: "Hesaba bağlanılamadı!"
     register: "'%name%' üyeliğim ile kayıt ol"
     registration_success: "'%username%' başarı ile kayıt oldunuz ve bağlandınız!"
 

--- a/Resources/views/Connect/connect_fail.html.twig
+++ b/Resources/views/Connect/connect_fail.html.twig
@@ -1,0 +1,5 @@
+{% extends 'HWIOAuthBundle::layout.html.twig' %}
+
+{% block hwi_oauth_content %}
+    <h3>{{ 'header.fail'|trans({}, 'HWIOAuthBundle') }}</h3>
+{% endblock hwi_oauth_content %}


### PR DESCRIPTION
Translations are missing except Turkish and English.