### PR TITLE
Fixed FOSUBUserProvider refreshUser

### DIFF
--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -139,7 +139,7 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
             throw new UsernameNotFoundException(sprintf('User with ID "%d" could not be reloaded.', $userId));
         }
 
-        return $reloadedUser;
+        return $user;
     }
 
     /**


### PR DESCRIPTION
In this class $reloadedUser is used, which is not defined. It should be $user.