### PR TITLE
Add resource owner for Spotify

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -54,6 +54,7 @@ class Configuration implements ConfigurationInterface
             'salesforce',
             'sensio_connect',
             'sina_weibo',
+            'spotify',
             'soundcloud',
             'stack_exchange',
             'toshl',

--- a/OAuth/ResourceOwner/SpotifyResourceOwner.php
+++ b/OAuth/ResourceOwner/SpotifyResourceOwner.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
+
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * @author Janne Savolainen <janne.savolainen@sempre.fi>
+ */
+class SpotifyResourceOwner extends GenericOAuth2ResourceOwner
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $paths = array(
+        'identifier'     => 'id',
+        'nickname'       => 'id',
+        'realname'       => 'display_name',
+        'email'          => 'email'
+    );
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getUserInformation(array $accessToken = null, array $extraParameters = array())
+    {
+        $url = $this->normalizeUrl($this->options['infos_url'], array(
+            'access_token' => $accessToken['access_token']
+        ));
+
+        $content = $this->doGetUserInformationRequest($url)->getContent();
+
+        $response = $this->getUserResponse();
+        $response->setResponse($content);
+        $response->setResourceOwner($this);
+        $response->setOAuthToken(new OAuthToken($accessToken));
+
+        return $response;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function configureOptions(OptionsResolverInterface $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults(array(
+            'authorization_url' => 'https://accounts.spotify.com/authorize',
+            'access_token_url'  => 'https://accounts.spotify.com/api/token',
+            'infos_url'         => 'https://api.spotify.com/v1/me'
+        ));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This bundle contains support for 20+ different providers:
 * Salesforce,
 * Sensio Connect,
 * Sina Weibo
+* Spotify
 * Soundcloud
 * Stack Exchange,
 * Stereomood,

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -43,6 +43,7 @@
         <parameter key="hwi_oauth.resource_owner.salesforce.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SalesforceResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sensio_connect.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SensioConnectResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.sina_weibo.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SinaWeiboResourceOwner</parameter>
+        <parameter key="hwi_oauth.resource_owner.spotify.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SpotifyResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.soundcloud.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SoundcloudResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.stack_exchange.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\StackExchangeResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.stereomood.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\StereomoodResourceOwner</parameter>

--- a/Resources/doc/2-configuring_resource_owners.md
+++ b/Resources/doc/2-configuring_resource_owners.md
@@ -61,6 +61,7 @@ hwi_oauth:
 - [Salesforce](resource_owners/salesforce.md)
 - [SensioLabs Connect](resource_owners/sensio_connect.md)
 - [Sina Weibo](resource_owners/sina_weibo.md)
+- [Spotify](resource_owners/spotify.md)
 - [Soundcloud](resource_owners/soundcloud.md)
 - [Stack Exchange](resource_owners/stack_exchange.md)
 - [Stereomood](resource_owners/stereomood.md)

--- a/Resources/doc/resource_owners/spotify.md
+++ b/Resources/doc/resource_owners/spotify.md
@@ -1,0 +1,24 @@
+Step 2x: Setup Spotify
+=====================
+First you will have to register your application on Spotify. Check out the
+documentation for more information: [authorization guide](https://developer.spotify.com/web-api/authorization-guide/).
+
+Next configure a resource owner of type `spotify` with appropriate
+`client_id`, `client_secret`.
+
+```yaml
+# app/config/config.yml
+
+hwi_oauth:
+    resource_owners:
+        any_name:
+            type:                spotify
+            client_id:           <client_id>
+            client_secret:       <client_secret>
+```
+
+When you're done. Continue by configuring the security layer or go back to
+setup more resource owners.
+
+- [Step 2: Configuring resource owners (Facebook, GitHub, Google, Windows Live and others](../2-configuring_resource_owners.md)
+- [Step 3: Configuring the security layer](../3-configuring_the_security_layer.md).

--- a/Tests/OAuth/ResourceOwner/SpotifyResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/SpotifyResourceOwnerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\SpotifyResourceOwner;
+
+/**
+ * @author Janne Savolainen <janne.savolainen@sempre.fi>
+ */
+class SpotifyResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
+{
+    protected $userResponse = <<<json
+{
+  "birthdate": "1937-06-01",
+  "country": "SE",
+  "display_name": "JM Wizzler",
+  "email": "email@example.com",
+  "external_urls": {
+    "spotify": "https://open.spotify.com/user/wizzler"
+  },
+  "followers" : {
+    "href" : null,
+    "total" : 3829
+  },
+  "href": "https://api.spotify.com/v1/users/wizzler",
+  "id": "wizzler",
+  "images": [
+    {
+      "height": null,
+      "url": "https://fbcdn-profile-a.akamaihd.net/hprofile-ak-frc3/t1.0-1/1970403_10152215092574354_1798272330_n.jpg",
+      "width": null
+    }
+  ],
+  "product": "premium",
+  "type": "user", 
+  "uri": "spotify:user:wizzler"
+}
+json;
+    protected $paths = array(
+        'identifier'     => 'id',
+        'nickname'       => 'id',
+        'realname'       => 'display_name',
+        'email'          => 'email'
+    );
+
+    protected function setUpResourceOwner($name, $httpUtils, array $options)
+    {
+        return new SpotifyResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+    }
+
+    public function testGetUserInformation()
+    {
+        $this->mockBuzz($this->userResponse);
+
+        /**
+         * @var $userResponse \HWI\Bundle\OAuthBundle\OAuth\Response\AbstractUserResponse
+         */
+        $userResponse = $this->resourceOwner->getUserInformation(array('access_token' => 'token'));
+
+        $this->assertEquals('wizzler', $userResponse->getUsername());
+        $this->assertEquals('wizzler', $userResponse->getNickname());
+        $this->assertEquals('token', $userResponse->getAccessToken());
+        $this->assertNull($userResponse->getRefreshToken());
+        $this->assertNull($userResponse->getExpiresIn());
+    }
+
+    public function testCustomResponseClass()
+    {
+        $class         = '\HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse';
+        $resourceOwner = $this->createResourceOwner('oauth2', array('user_response_class' => $class));
+
+        $this->mockBuzz();
+
+        /**
+         * @var $userResponse \HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse
+         */
+        $userResponse = $resourceOwner->getUserInformation(array('access_token' => 'token')); 
+
+        $this->assertInstanceOf($class, $userResponse);
+        $this->assertEquals('foo666', $userResponse->getUsername());
+        $this->assertEquals('foo', $userResponse->getNickname());
+        $this->assertEquals('token', $userResponse->getAccessToken());
+        $this->assertNull($userResponse->getRefreshToken());
+        $this->assertNull($userResponse->getExpiresIn());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "stack exchange",
         "stereomood",
         "sina weibo",
+        "spotify",
         "trello",
         "twitch",
         "twitter",


### PR DESCRIPTION
Adds a new ```ResourceOwner``` for Spotify following OAuth2 integration from [authorization guide] (https://developer.spotify.com/web-api/authorization-guide)