### PR TITLE
Fix deprecated OptionsResolverInterface usage

### DIFF
--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -92,7 +92,26 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
 
         // Resolve merged options
         $resolver = new OptionsResolver();
+
         $this->configureOptions($resolver);
+
+        // See Symfony\Component\Form\ResolvedFormType logic
+        $baseClasses = array(
+            'HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\AbstractResourceOwner',
+            'HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth1ResourceOwner',
+            'HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner',
+        );
+
+        $reflector = new \ReflectionMethod($this, 'configureOptions');
+        $isOldOverwritten = !in_array($reflector->getDeclaringClass()->getName(), $baseClasses, true);
+
+        $reflector = new \ReflectionMethod($this, 'setupOptions');
+        $isNewOverwritten = !in_array($reflector->getDeclaringClass()->getName(), $baseClasses, true);
+
+        if ($isOldOverwritten && !$isNewOverwritten) {
+            trigger_error('Overwriting '.__CLASS__.'::configureOptions() method is deprecated since version 0.4 and will be removed in 1.0. Overwrite '.__CLASS__.'::setupOptions() instead.', E_USER_DEPRECATED);
+        }
+
         $options = $resolver->resolve($options);
         $this->options = $options;
 
@@ -302,8 +321,20 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      * Configure the option resolver
      *
      * @param OptionsResolverInterface $resolver
+     *
+     * @deprecated since 0.4, to be removed in 1.0 overwrite setupOptions instead
      */
     protected function configureOptions(OptionsResolverInterface $resolver)
+    {
+        $this->setupOptions($resolver);
+    }
+
+    /**
+     * Configure the option resolver
+     *
+     * @param OptionsResolver $resolver
+     */
+    protected function setupOptions(OptionsResolver $resolver)
     {
         $resolver->setRequired(array(
             'client_id',

--- a/OAuth/ResourceOwner/AmazonResourceOwner.php
+++ b/OAuth/ResourceOwner/AmazonResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * AmazonResourceOwner
@@ -33,9 +33,9 @@ class AmazonResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://www.amazon.com/ap/oa',

--- a/OAuth/ResourceOwner/Auth0ResourceOwner.php
+++ b/OAuth/ResourceOwner/Auth0ResourceOwner.php
@@ -11,10 +11,9 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Buzz\Message\Response;
-use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Buzz\Message\RequestInterface as HttpRequestInterface;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Auth0ResourceOwner
@@ -51,9 +50,9 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
         $resolver->setDefaults(array(
             'authorization_url'   => '{base_url}/authorize',
             'access_token_url'    => '{base_url}/oauth/token',

--- a/OAuth/ResourceOwner/BitbucketResourceOwner.php
+++ b/OAuth/ResourceOwner/BitbucketResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * BitbucketResourceOwner
@@ -33,9 +33,9 @@ class BitbucketResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://bitbucket.org/api/1.0/oauth/authenticate',

--- a/OAuth/ResourceOwner/BitlyResourceOwner.php
+++ b/OAuth/ResourceOwner/BitlyResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * BitlyResourceOwner
@@ -33,9 +33,9 @@ class BitlyResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'use_bearer_authorization' => false,

--- a/OAuth/ResourceOwner/BoxResourceOwner.php
+++ b/OAuth/ResourceOwner/BoxResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * BoxResourceOwner
@@ -51,9 +51,9 @@ class BoxResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://www.box.com/api/oauth2/authorize',

--- a/OAuth/ResourceOwner/DailymotionResourceOwner.php
+++ b/OAuth/ResourceOwner/DailymotionResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * DailymotionResourceOwner
@@ -42,9 +42,9 @@ class DailymotionResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://api.dailymotion.com/oauth/authorize',

--- a/OAuth/ResourceOwner/DeviantartResourceOwner.php
+++ b/OAuth/ResourceOwner/DeviantartResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * DeviantartResourceOwner
@@ -32,9 +32,9 @@ class DeviantartResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://www.deviantart.com/oauth2/draft15/authorize',

--- a/OAuth/ResourceOwner/DisqusResourceOwner.php
+++ b/OAuth/ResourceOwner/DisqusResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * DisqusResourceOwner
@@ -46,9 +46,9 @@ class DisqusResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'   => 'https://disqus.com/api/oauth/2.0/authorize/',

--- a/OAuth/ResourceOwner/DropboxResourceOwner.php
+++ b/OAuth/ResourceOwner/DropboxResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * DropboxResourceOwner
@@ -33,9 +33,9 @@ class DropboxResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://www.dropbox.com/1/oauth2/authorize',

--- a/OAuth/ResourceOwner/EveOnlineResourceOwner.php
+++ b/OAuth/ResourceOwner/EveOnlineResourceOwner.php
@@ -11,8 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * EveOnlineResourceOwner
@@ -33,9 +32,9 @@ class EveOnlineResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'   => 'https://login.eveonline.com/oauth/authorize',

--- a/OAuth/ResourceOwner/EventbriteResourceOwner.php
+++ b/OAuth/ResourceOwner/EventbriteResourceOwner.php
@@ -12,8 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * EventbriteResourceOwner
@@ -45,9 +44,9 @@ class EventbriteResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'        => 'https://www.eventbrite.com/oauth/authorize',

--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -13,7 +13,7 @@ namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * FacebookResourceOwner
@@ -76,9 +76,9 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'   => 'https://www.facebook.com/dialog/oauth',

--- a/OAuth/ResourceOwner/FlickrResourceOwner.php
+++ b/OAuth/ResourceOwner/FlickrResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * FlickrResourceOwner
@@ -62,9 +62,9 @@ class FlickrResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'http://www.flickr.com/services/oauth/authorize',

--- a/OAuth/ResourceOwner/FoursquareResourceOwner.php
+++ b/OAuth/ResourceOwner/FoursquareResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\MessageInterface as HttpMessageInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * FoursquareResourceOwner
@@ -79,9 +79,9 @@ class FoursquareResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'        => 'https://foursquare.com/oauth2/authenticate',

--- a/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -15,6 +15,7 @@ use Buzz\Message\RequestInterface as HttpRequestInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
@@ -214,10 +215,20 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated since 0.4, to be removed in 1.0.
      */
     protected function configureOptions(OptionsResolverInterface $resolver)
     {
-        parent::configureOptions($resolver);
+        $this->setupOptions($resolver);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setupOptions(OptionsResolver $resolver)
+    {
+        parent::setupOptions($resolver);
 
         $resolver->setRequired(array(
             'request_token_url',

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -14,6 +14,7 @@ namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
@@ -202,10 +203,20 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated since 0.4, to be removed in 1.0.
      */
     protected function configureOptions(OptionsResolverInterface $resolver)
     {
-        parent::configureOptions($resolver);
+        $this->setupOptions($resolver);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setupOptions(OptionsResolver $resolver)
+    {
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'attr_name'                => 'access_token',

--- a/OAuth/ResourceOwner/GitHubResourceOwner.php
+++ b/OAuth/ResourceOwner/GitHubResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * GitHubResourceOwner
@@ -51,9 +51,9 @@ class GitHubResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'   => 'https://github.com/login/oauth/authorize',

--- a/OAuth/ResourceOwner/GoogleResourceOwner.php
+++ b/OAuth/ResourceOwner/GoogleResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * GoogleResourceOwner
@@ -49,9 +49,9 @@ class GoogleResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'       => 'https://accounts.google.com/o/oauth2/auth',

--- a/OAuth/ResourceOwner/HubicResourceOwner.php
+++ b/OAuth/ResourceOwner/HubicResourceOwner.php
@@ -11,8 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * HubicResourceOwner
@@ -36,9 +35,9 @@ class HubicResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://api.hubic.com/oauth/auth/',

--- a/OAuth/ResourceOwner/InstagramResourceOwner.php
+++ b/OAuth/ResourceOwner/InstagramResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * InstagramResourceOwner
@@ -33,9 +33,9 @@ class InstagramResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'         => 'https://api.instagram.com/oauth/authorize',

--- a/OAuth/ResourceOwner/JiraResourceOwner.php
+++ b/OAuth/ResourceOwner/JiraResourceOwner.php
@@ -15,7 +15,7 @@ use Buzz\Message\RequestInterface as HttpRequestInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * JiraResourceOwner
@@ -85,9 +85,9 @@ class JiraResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => '{base_url}/plugins/servlet/oauth/authorize',

--- a/OAuth/ResourceOwner/LinkedinResourceOwner.php
+++ b/OAuth/ResourceOwner/LinkedinResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * LinkedinResourceOwner
@@ -53,9 +53,9 @@ class LinkedinResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'        => 'https://www.linkedin.com/uas/oauth2/authorization',

--- a/OAuth/ResourceOwner/MailRuResourceOwner.php
+++ b/OAuth/ResourceOwner/MailRuResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * MailRuResourceOwner
@@ -64,9 +64,9 @@ class MailRuResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'   => 'https://connect.mail.ru/oauth/authorize',

--- a/OAuth/ResourceOwner/OdnoklassnikiResourceOwner.php
+++ b/OAuth/ResourceOwner/OdnoklassnikiResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * OdnoklassnikiResourceOwner
@@ -55,9 +55,9 @@ class OdnoklassnikiResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'http://www.odnoklassniki.ru/oauth/authorize',

--- a/OAuth/ResourceOwner/PaypalResourceOwner.php
+++ b/OAuth/ResourceOwner/PaypalResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * PaypalResourceOwner
@@ -33,9 +33,9 @@ class PaypalResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'sandbox'           => false,

--- a/OAuth/ResourceOwner/QQResourceOwner.php
+++ b/OAuth/ResourceOwner/QQResourceOwner.php
@@ -13,7 +13,7 @@ namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\MessageInterface as HttpMessageInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class QQResourceOwner extends GenericOAuth2ResourceOwner
@@ -76,9 +76,9 @@ class QQResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://graph.qq.com/oauth2.0/authorize?format=json',

--- a/OAuth/ResourceOwner/RedditResourceOwner.php
+++ b/OAuth/ResourceOwner/RedditResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * RedditResourceOwner
@@ -41,15 +41,15 @@ class RedditResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'        => 'https://ssl.reddit.com/api/v1/authorize',
             'access_token_url'         => 'https://ssl.reddit.com/api/v1/access_token',
             'infos_url'                => 'https://oauth.reddit.com/api/v1/me.json',
-            
+
             'use_bearer_authorization' => true,
             'use_commas_in_scope'      => true,
             'csrf'                     => true,

--- a/OAuth/ResourceOwner/SalesforceResourceOwner.php
+++ b/OAuth/ResourceOwner/SalesforceResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Salesforce Resource Owner
@@ -61,9 +61,9 @@ class SalesforceResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://login.salesforce.com/services/oauth2/authorize',

--- a/OAuth/ResourceOwner/SensioConnectResourceOwner.php
+++ b/OAuth/ResourceOwner/SensioConnectResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * SensioConnectResourceOwner
@@ -40,9 +40,9 @@ class SensioConnectResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'        => 'https://connect.sensiolabs.com/oauth/authorize',

--- a/OAuth/ResourceOwner/SinaWeiboResourceOwner.php
+++ b/OAuth/ResourceOwner/SinaWeiboResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SinaWeiboResourceOwner extends GenericOAuth2ResourceOwner
 {
@@ -49,9 +49,9 @@ class SinaWeiboResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://api.weibo.com/oauth2/authorize',

--- a/OAuth/ResourceOwner/SoundcloudResourceOwner.php
+++ b/OAuth/ResourceOwner/SoundcloudResourceOwner.php
@@ -11,8 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * SoundcloudResourceOwner
@@ -33,9 +32,9 @@ class SoundcloudResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'access_token_url'         => 'https://api.soundcloud.com/oauth2/token',

--- a/OAuth/ResourceOwner/SpotifyResourceOwner.php
+++ b/OAuth/ResourceOwner/SpotifyResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Janne Savolainen <janne.savolainen@sempre.fi>
@@ -51,9 +51,9 @@ class SpotifyResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://accounts.spotify.com/authorize',

--- a/OAuth/ResourceOwner/StackExchangeResourceOwner.php
+++ b/OAuth/ResourceOwner/StackExchangeResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * StackExchangeResourceOwner
@@ -33,9 +33,9 @@ class StackExchangeResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://stackexchange.com/oauth',

--- a/OAuth/ResourceOwner/StereomoodResourceOwner.php
+++ b/OAuth/ResourceOwner/StereomoodResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * StereomoodResourceOwner
@@ -42,9 +42,9 @@ class StereomoodResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'http://www.stereomood.com/api/oauth/authenticate',

--- a/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwner.php
+++ b/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * ThirtySevenSignalsResourceOwner (37signals)
@@ -52,9 +52,9 @@ class ThirtySevenSignalsResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://launchpad.37signals.com/authorization/new',

--- a/OAuth/ResourceOwner/ToshlResourceOwner.php
+++ b/OAuth/ResourceOwner/ToshlResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\Response;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * ToshlResourceOwner
@@ -52,9 +52,9 @@ class ToshlResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'   => 'https://toshl.com/oauth2/authorize',

--- a/OAuth/ResourceOwner/TrelloResourceOwner.php
+++ b/OAuth/ResourceOwner/TrelloResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * TrelloResourceOwner
@@ -34,9 +34,9 @@ class TrelloResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://trello.com/1/OAuthAuthorizeToken',

--- a/OAuth/ResourceOwner/TwitchResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitchResourceOwner.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Buzz\Message\RequestInterface as HttpRequestInterfacee;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * TwitchResourceOwner
@@ -52,9 +52,9 @@ class TwitchResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'        => 'https://api.twitch.tv/kraken/oauth2/authorize',

--- a/OAuth/ResourceOwner/TwitterResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitterResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * TwitterResourceOwner
@@ -33,9 +33,9 @@ class TwitterResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://api.twitter.com/oauth/authenticate',
@@ -43,7 +43,7 @@ class TwitterResourceOwner extends GenericOAuth1ResourceOwner
             'access_token_url'  => 'https://api.twitter.com/oauth/access_token',
             'infos_url'         => 'https://api.twitter.com/1.1/account/verify_credentials.json',
         ));
-        
+
         $resolver->setOptional(array(
             'x_auth_access_type',
         ));

--- a/OAuth/ResourceOwner/VkontakteResourceOwner.php
+++ b/OAuth/ResourceOwner/VkontakteResourceOwner.php
@@ -12,8 +12,8 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * VkontakteResourceOwner
@@ -68,9 +68,9 @@ class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'   => 'https://oauth.vk.com/authorize',

--- a/OAuth/ResourceOwner/WechatResourceOwner.php
+++ b/OAuth/ResourceOwner/WechatResourceOwner.php
@@ -11,10 +11,9 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Buzz\Message\MessageInterface as HttpMessageInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class WechatResourceOwner extends GenericOAuth2ResourceOwner
@@ -99,9 +98,9 @@ class WechatResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://open.weixin.qq.com/connect/oauth2/authorize',

--- a/OAuth/ResourceOwner/WindowsLiveResourceOwner.php
+++ b/OAuth/ResourceOwner/WindowsLiveResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * WindowsLiveResourceOwner
@@ -33,9 +33,9 @@ class WindowsLiveResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://login.live.com/oauth20_authorize.srf',

--- a/OAuth/ResourceOwner/WordpressResourceOwner.php
+++ b/OAuth/ResourceOwner/WordpressResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * WordpressResourceOwner
@@ -34,9 +34,9 @@ class WordpressResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://public-api.wordpress.com/oauth2/authorize',

--- a/OAuth/ResourceOwner/XingResourceOwner.php
+++ b/OAuth/ResourceOwner/XingResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * XingResourceOwner
@@ -36,9 +36,9 @@ class XingResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://api.xing.com/v1/authorize',

--- a/OAuth/ResourceOwner/YahooResourceOwner.php
+++ b/OAuth/ResourceOwner/YahooResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * YahooResourceOwner
@@ -55,9 +55,9 @@ class YahooResourceOwner extends GenericOAuth1ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://api.login.yahoo.com/oauth/v2/request_auth',

--- a/OAuth/ResourceOwner/YandexResourceOwner.php
+++ b/OAuth/ResourceOwner/YandexResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * YandexResourceOwner
@@ -42,9 +42,9 @@ class YandexResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url' => 'https://oauth.yandex.ru/authorize',

--- a/OAuth/ResourceOwner/YoutubeResourceOwner.php
+++ b/OAuth/ResourceOwner/YoutubeResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * YoutubeResourceOwner
@@ -48,9 +48,9 @@ class YoutubeResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritDoc}
      */
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function setupOptions(OptionsResolver $resolver)
     {
-        parent::configureOptions($resolver);
+        parent::setupOptions($resolver);
 
         $resolver->setDefaults(array(
             'authorization_url'       => 'https://accounts.google.com/o/oauth2/auth',

--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -51,7 +51,7 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
      */
     public function testGetInvalidOptionThrowsException()
     {

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -67,7 +67,7 @@ json;
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
      */
     public function testInvalidOptionThrowsException()
     {


### PR DESCRIPTION
This is an extracted part of #773.

BC is kept on following classes:
- `AbstractResourceOwner`
-  `GenericOAuth1ResourceOwner`
-  `GenericOAuth2ResourceOwner`

I mark deprecation from `0.4` to be removed on `1.0`. Checks on `trigger_error` are set to prevent users as the same method as Symfony's `ResolvedFormType`.

@stloyd @stof, waiting for your review, thanks. :-)
