### PR TITLE
Allow null or '', (or other empty value) for content. fixes #809

### DIFF
--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -220,7 +220,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
     protected function httpRequest($url, $content = null, $headers = array(), $method = null)
     {
         if (null === $method) {
-            $method = null === $content ? HttpRequestInterface::METHOD_GET : HttpRequestInterface::METHOD_POST;
+            $method = empty($content) ? HttpRequestInterface::METHOD_GET : HttpRequestInterface::METHOD_POST;
         }
 
         $request  = new HttpRequest($method, $url);


### PR DESCRIPTION
Without the check for a generic empty value, the data may be POSTed, 
when a simple GET was required - and there was no body content.