### PR TITLE
Request with incorrect method

### DIFF
--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -177,7 +177,11 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
      */
     protected function doGetUserInformationRequest($url, array $parameters = array())
     {
-        return $this->httpRequest($url, http_build_query($parameters, '', '&'));
+        $params = http_build_query($parameters, '', '&');
+        if (empty($params)) {
+          $params = null;
+        }
+        return $this->httpRequest($url, $params);
     }
 
     /**


### PR DESCRIPTION
if there is no param, pass null. 
Fixes instagram for example.