### PR TITLE
Fixed forced post method

### DIFF
--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -177,7 +177,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
      */
     protected function doGetUserInformationRequest($url, array $parameters = array())
     {
-        return $this->httpRequest($url, http_build_query($parameters, '', '&'));
+        return $this->httpRequest($url, !empty($parameters) ? http_build_query($parameters, '', '&') : null);
     }
 
     /**


### PR DESCRIPTION
This commit https://github.com/hwi/HWIOAuthBundle/commit/b37a2c8f63ccaee45a4b3069f38fb4832f8dbecc introduced an issue with some providers.

Because of the second parameter, a POST method is always used, and that causes issues with LinkedIn which requires a GET method for instance.

I'm not sure whether or not this fix is naive, I'll let you be the judge of that ;-)

This is an alternative fix to https://github.com/hwi/HWIOAuthBundle/issues/809