### PR TITLE
Add getter for oAuthToken

### DIFF
--- a/OAuth/Response/AbstractUserResponse.php
+++ b/OAuth/Response/AbstractUserResponse.php
@@ -96,6 +96,14 @@ abstract class AbstractUserResponse implements UserResponseInterface
     /**
      * {@inheritdoc}
      */
+    public function getOAuthToken()
+    {
+        return $this->oAuthToken;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getResponse()
     {
         return $this->response;

--- a/OAuth/Response/UserResponseInterface.php
+++ b/OAuth/Response/UserResponseInterface.php
@@ -109,4 +109,11 @@ interface UserResponseInterface extends ResponseInterface
      * @param OAuthToken $token
      */
     public function setOAuthToken(OAuthToken $token);
+
+    /**
+     * Get the raw token data from the request.
+     *
+     * @return OAuthToken
+     */
+    public function getOAuthToken();
 }


### PR DESCRIPTION
When connecting to Google one want to get access to the raw token which is in the OAuthToken, to be able to verify it.
I didn't find a way to do that in `OAuthAwareUserProviderInterface::loadUserByOAuthUserResponse(UserResponseInterface $response)`, thus adding a getter.