### PR TITLE
Fire event after connecting an account in order to save AccessToken, RefreshToken and Expires at

### DIFF
--- a/HWIOAuthEvents.php
+++ b/HWIOAuthEvents.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace HWI\Bundle\OAuthBundle;
+
+final class HWIOAuthEvents {
+    /**
+     * Fired after the account of an authenticated user was connected with a remote service
+     */
+    const HWIOAUTH_CONNECTED = 'hwioauth.connected';
+}


### PR DESCRIPTION
There is a way to save these tokens after registration by listening to security.authentication.success as described [here](https://github.com/hwi/HWIOAuthBundle/issues/127#issuecomment-8885067)

In order to do the same after connecting an existent user account a new custom event is fired from ConnectController->connectServiceAction(). The processing of the event can be done as below (to be added into the documentation ?!):

``` php
public function handle(AuthenticationEvent $event)
    {
        $authToken = $event->getAuthenticationToken();
        $user = $authToken->getUser();
        $resourceOwner = $authToken->getResourceOwnerName();

        if ($user instanceof UserInterface) {
            if ($authToken instanceof OAuthToken) {
                $serviceAccessTokenSetter = 'set' . ucfirst($resourceOwner) . 'AccessToken';
                if ( method_exists($user, $serviceAccessTokenSetter)){
                    $user->$serviceAccessTokenSetter($authToken->getAccessToken());
                }
                $serviceAccessTokenSetter = 'set' . ucfirst($resourceOwner) . 'RefreshToken';
                if ( method_exists($user, $serviceAccessTokenSetter)){
                    $user->$serviceAccessTokenSetter($authToken->getRefreshToken());
                }
                $serviceAccessTokenSetter = 'set' . ucfirst($resourceOwner) . 'AccessTokenExpiresAt';
                if ( method_exists($user, $serviceAccessTokenSetter)){
                    $user->$serviceAccessTokenSetter($authToken->getExpiresAt());
                }
            }
            // do an update of user object with tokens here
            $this->userManager->updateUser($user);
        }
    }
```
