### PR TITLE
Fix linkedin error 'Unsupported POST target {/v1/people/'.

### DIFF
--- a/OAuth/ResourceOwner/LinkedinResourceOwner.php
+++ b/OAuth/ResourceOwner/LinkedinResourceOwner.php
@@ -47,7 +47,12 @@ class LinkedinResourceOwner extends GenericOAuth2ResourceOwner
     protected function doGetUserInformationRequest($url, array $parameters = array())
     {
         // LinkedIn uses different variable as they still support OAuth1.0a
-        return parent::doGetUserInformationRequest(str_replace('access_token', 'oauth2_access_token', $url), $parameters);
+        return $this->httpRequest(
+            str_replace('access_token', 'oauth2_access_token', $url),
+            http_build_query($parameters, '', '&'),
+            array(),
+            HttpRequestInterface::METHOD_GET
+        );
     }
 
     /**


### PR DESCRIPTION
LinkedIn don't support POST method to /v1/people anymore, see
http://stackoverflow.com/questions/12263202/linkedin-api-using-raw-php

Docs https://developer.linkedin.com/docs/oauth2 says nothing about POST method.

This PR should fix #809 issue.