### PR TITLE
Fixed Fiware UserInformation request with active token

### DIFF
--- a/OAuth/ResourceOwner/FiwareResourceOwner.php
+++ b/OAuth/ResourceOwner/FiwareResourceOwner.php
@@ -11,6 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -59,6 +60,26 @@ class FiwareResourceOwner extends GenericOAuth2ResourceOwner
         $this->validateResponseContent($responseContent);
 
         return $responseContent;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getUserInformation(array $accessToken, array $extraParameters = array())
+    {
+        if ($this->options['use_bearer_authorization']) {
+            $content = $this->httpRequest($this->normalizeUrl($this->options['infos_url'], array('access_token' => $accessToken['access_token'])), null, array('Authorization: Bearer'));
+        } else {
+            $content = $this->doGetUserInformationRequest($this->normalizeUrl($this->options['infos_url'], array($this->options['attr_name'] => $accessToken['access_token'])));
+        }
+
+        $response = $this->getUserResponse();
+        $response->setResponse($content->getContent());
+
+        $response->setResourceOwner($this);
+        $response->setOAuthToken(new OAuthToken($accessToken));
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
After authorization when calling user API, system response with "authorization token not found". So I added array with access_token as a second parameter in http request method and now problem is solved. User data was fetched successfully.