### PR TITLE
Catch InvalidArgumentException from storage

### DIFF
--- a/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -74,9 +74,14 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
      */
     public function getAccessToken(Request $request, $redirectUri, array $extraParameters = array())
     {
-        if (null === $requestToken = $this->storage->fetch($this, $request->query->get('oauth_token'))) {
-            throw new \RuntimeException('No request token found in the storage.');
+        try {
+            if (null === $requestToken = $this->storage->fetch($this, $request->query->get('oauth_token'))) {
+                throw new \RuntimeException('No request token found in the storage.');
+            }
+        } catch (\InvalidArgumentException $e) {
+            throw new AuthenticationException('Given token is not valid.');
         }
+
 
         $parameters = array_merge(array(
             'oauth_consumer_key'     => $this->options['client_id'],

--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -238,6 +238,26 @@ class GenericOAuth1ResourceOwnerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
      */
+    public function testGetAccessTokenInvalidArgumentException()
+    {
+        $this->storage->expects($this->once())
+            ->method('fetch')
+            ->will($this->throwException(new \InvalidArgumentException));
+
+        $this->buzzClient->expects($this->never())
+            ->method('send');
+
+        $this->storage->expects($this->never())
+            ->method('save');
+
+        $request = new Request(array('oauth_token' => 'token', 'oauth_verifier' => 'code'));
+
+        $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     */
     public function testRefreshAccessToken()
     {
         $this->resourceOwner->refreshAccessToken('token');


### PR DESCRIPTION
As it's done into `GenericOAuth2ResourceOwner` (https://github.com/hwi/HWIOAuthBundle/blob/master/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php#L160-L164), `InvalidArgumentException` thrown by the storage should be catched and transformed into `AuthenticationException`.