### PR TITLE
Add paths for first name and last name

### DIFF
--- a/OAuth/ResourceOwner/GoogleResourceOwner.php
+++ b/OAuth/ResourceOwner/GoogleResourceOwner.php
@@ -28,6 +28,8 @@ class GoogleResourceOwner extends GenericOAuth2ResourceOwner
         'identifier'     => 'id',
         'nickname'       => 'name',
         'realname'       => 'name',
+        'firstname'      => 'given_name',
+        'lastname'       => 'family_name',
         'email'          => 'email',
         'profilepicture' => 'picture',
     );

--- a/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
@@ -26,6 +26,8 @@ json;
         'identifier'     => 'id',
         'nickname'       => 'name',
         'realname'       => 'name',
+        'firstname'      => 'given_name',
+        'lastname'       => 'family_name',
         'email'          => 'email',
         'profilepicture' => 'picture',
     );


### PR DESCRIPTION
Google OAuth response provides both first name and last name as `given_name` and `family_name` respectively