### PR TITLE
Use ContainerAwareInterface in resource map

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -24,15 +24,12 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AccountStatusException;
 use Symfony\Component\Security\Core\Security;
-use Symfony\Component\Security\Core\SecurityContext;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 
 /**
- * ConnectController.
- *
  * @author Alexander <iam.asm89@gmail.com>
  */
 class ConnectController extends Controller

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -72,7 +72,7 @@ class HWIOAuthExtension extends Extension
         // setup services for all configured resource owners
         $resourceOwners = array();
         foreach ($config['resource_owners'] as $name => $options) {
-            $resourceOwners[] = $name;
+            $resourceOwners[$name] = $name;
             $this->createResourceOwnerService($container, $name, $options);
         }
         $container->setParameter('hwi_oauth.resource_owners', $resourceOwners);
@@ -122,7 +122,7 @@ class HWIOAuthExtension extends Extension
             }
 
             foreach ($config['connect'] as $key => $serviceId) {
-                if ('confirmation' == $key) {
+                if ('confirmation' === $key) {
                     $container->setParameter('hwi_oauth.connect.confirmation', $config['connect']['confirmation']);
 
                     continue;

--- a/Security/Http/ResourceOwnerMap.php
+++ b/Security/Http/ResourceOwnerMap.php
@@ -13,6 +13,8 @@ namespace HWI\Bundle\OAuthBundle\Security\Http;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Http\HttpUtils;
 
@@ -22,7 +24,7 @@ use Symfony\Component\Security\Http\HttpUtils;
  *
  * @author Alexander <iam.asm89@gmail.com>
  */
-class ResourceOwnerMap extends ContainerAware
+class ResourceOwnerMap implements ContainerAwareInterface
 {
     /**
      * @var HttpUtils
@@ -40,6 +42,11 @@ class ResourceOwnerMap extends ContainerAware
     protected $possibleResourceOwners;
 
     /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
      * Constructor.
      *
      * @param HttpUtils $httpUtils              HttpUtils
@@ -53,12 +60,24 @@ class ResourceOwnerMap extends ContainerAware
         $this->resourceOwners         = $resourceOwners;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Check that resource owner with given name exists.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
     public function hasResourceOwnerByName($name)
     {
-        return
-            isset($this->resourceOwners[$name])
-            && in_array($name, $this->possibleResourceOwners)
-        ;
+        return isset($this->resourceOwners[$name], $this->possibleResourceOwners[$name]);
     }
 
     /**
@@ -74,9 +93,7 @@ class ResourceOwnerMap extends ContainerAware
             return null;
         }
 
-        $service = $this->container->get('hwi_oauth.resource_owner.'.$name);
-
-        return $service;
+        return $this->container->get('hwi_oauth.resource_owner.'.$name);
     }
 
     /**

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -242,7 +242,7 @@ class HWIOAuthExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertParameter(array('secured_area'), 'hwi_oauth.firewall_names');
         $this->assertParameter(null, 'hwi_oauth.target_path_parameter');
         $this->assertParameter(false, 'hwi_oauth.use_referer');
-        $this->assertParameter(array('any_name', 'some_service'), 'hwi_oauth.resource_owners');
+        $this->assertParameter(array('any_name' => 'any_name', 'some_service' => 'some_service'), 'hwi_oauth.resource_owners');
 
         $this->assertNotHasDefinition('hwi_oauth.user.provider.fosub_bridge');
 


### PR DESCRIPTION
Use `isset()` instead of `in_array()` to check existence of resource owner.

Replaces #907.