### PR TITLE
Configurable redirect when connecting accounts failed

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -183,6 +183,11 @@ class ConnectController extends Controller
             $accessToken = $session->get('_hwi_oauth.connect_confirmation.'.$key);
         }
 
+        // Redirect to the login path if the token is empty (Eg. User cancelled auth)
+        if (null === $accessToken) {
+            return $this->redirectToRoute($this->container->getParameter('hwi_oauth.failed_auth_path'));
+        }
+        
         $userInformation = $resourceOwner->getUserInformation($accessToken);
 
         // Show confirmation page?

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -142,6 +142,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('target_path_parameter')->defaultNull()->end()
                 ->booleanNode('use_referer')->defaultFalse()->end()
                 ->scalarNode('templating_engine')->defaultValue('twig')->end()
+                ->scalarNode('failed_auth_path')->defaultValue('hwi_oauth_connect')->end()
             ->end()
         ;
 

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -69,6 +69,9 @@ class HWIOAuthExtension extends Extension
         // set use referer parameter
         $container->setParameter('hwi_oauth.use_referer', $config['use_referer']);
 
+        // set failed auth path
+        $container->setParameter('hwi_oauth.failed_auth_path', $config['failed_auth_path']);
+        
         // setup services for all configured resource owners
         $resourceOwners = array();
         foreach ($config['resource_owners'] as $name => $options) {

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -242,6 +242,7 @@ class HWIOAuthExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertParameter(array('secured_area'), 'hwi_oauth.firewall_names');
         $this->assertParameter(null, 'hwi_oauth.target_path_parameter');
         $this->assertParameter(false, 'hwi_oauth.use_referer');
+        $this->assertParameter('hwi_oauth_connect', 'hwi_oauth.failed_auth_path');
         $this->assertParameter(array('any_name' => 'any_name', 'some_service' => 'some_service'), 'hwi_oauth.resource_owners');
 
         $this->assertNotHasDefinition('hwi_oauth.user.provider.fosub_bridge');


### PR DESCRIPTION
i. e. if user denies authentication via resource owner.

Replaces #724. Fixes #363.