### PR TITLE
BitBucket OAuth2 implementation 

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -33,6 +33,7 @@ class Configuration implements ConfigurationInterface
             'amazon',
             'auth0',
             'azure',
+			'bitbucket2',
             'bitly',
             'box',
             'bufferapp',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -33,7 +33,7 @@ class Configuration implements ConfigurationInterface
             'amazon',
             'auth0',
             'azure',
-			'bitbucket2',
+            'bitbucket2',
             'bitly',
             'box',
             'bufferapp',

--- a/OAuth/ResourceOwner/Bitbucket2ResourceOwner.php
+++ b/OAuth/ResourceOwner/Bitbucket2ResourceOwner.php
@@ -1,8 +1,23 @@
 <?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
+/**
+ * Bitbucket2ResourceOwner
+ *
+ * @author David Sanchez <david38sanchez@gmail.com>
+ */
 class Bitbucket2ResourceOwner extends GenericOAuth2ResourceOwner
 {
 

--- a/OAuth/ResourceOwner/Bitbucket2ResourceOwner.php
+++ b/OAuth/ResourceOwner/Bitbucket2ResourceOwner.php
@@ -1,0 +1,57 @@
+<?php
+namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
+
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class Bitbucket2ResourceOwner extends GenericOAuth2ResourceOwner
+{
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected $paths = array(
+		'identifier'     => 'uuid',
+		'nickname'       => 'username',
+		'email'          => 'email',
+		'realname'       => 'display_name',
+		'profilepicture' => 'links.avatar.href',
+	);
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configureOptions(OptionsResolverInterface $resolver)
+	{
+		parent::configureOptions($resolver);
+
+		$resolver->setDefaults(array(
+			'authorization_url' => 'https://bitbucket.org/site/oauth2/authorize',
+			'access_token_url'  => 'https://bitbucket.org/site/oauth2/access_token',
+			'infos_url'         => 'https://api.bitbucket.org/2.0/user',
+			'emails_url'		=> 'https://api.bitbucket.org/2.0/user/emails'
+		));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getUserInformation(array $accessToken, array $extraParameters = array())
+	{
+		$response = parent::getUserInformation($accessToken, $extraParameters);
+		$responseData = $response->getResponse();
+
+		// fetch the email addresses linked to the account
+		if (empty($responseData['email'])) {
+			$content = $this->httpRequest($this->normalizeUrl($this->options['emails_url']), null, array('Authorization: Bearer '.$accessToken['access_token']));
+			foreach ($this->getResponseContent($content)['values'] as $email) {
+				// we only need the primary email address
+				if (true === $email['is_primary']) {
+					$responseData['email'] = $email['email'];
+				}
+			}
+			$response->setResponse($responseData);
+		}
+
+		return $response;
+	}
+}

--- a/OAuth/ResourceOwner/BitbucketResourceOwner.php
+++ b/OAuth/ResourceOwner/BitbucketResourceOwner.php
@@ -42,6 +42,36 @@ class BitbucketResourceOwner extends GenericOAuth1ResourceOwner
             'request_token_url' => 'https://bitbucket.org/api/1.0/oauth/request_token',
             'access_token_url'  => 'https://bitbucket.org/api/1.0/oauth/access_token',
             'infos_url'         => 'https://bitbucket.org/api/1.0/user',
+			'emails_url'		=> 'https://bitbucket.org/api/1.0/users/%s/emails'
         ));
     }
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getUserInformation(array $accessToken, array $extraParameters = array())
+	{
+		$response = parent::getUserInformation($accessToken, $extraParameters);
+
+		$responseData = $response->getResponse();
+
+		if (empty($responseData['email'])) {
+			// fetch the email addresses linked to the account
+			$content = $this->httpRequest($this->normalizeUrl(
+				sprintf($this->options['emails_url'], $responseData['username'])
+			), null, array('Authorization: Bearer '.$accessToken['access_token']));
+
+			foreach ($this->getResponseContent($content) as $email) {
+				if (!empty($email['primary'])) {
+					// we only need the primary email address
+					$responseData['email'] = $email['email'];
+					break;
+				}
+			}
+
+			$response->setResponse($responseData);
+		}
+
+		return $response;
+	}
 }

--- a/OAuth/ResourceOwner/BitbucketResourceOwner.php
+++ b/OAuth/ResourceOwner/BitbucketResourceOwner.php
@@ -42,36 +42,6 @@ class BitbucketResourceOwner extends GenericOAuth1ResourceOwner
             'request_token_url' => 'https://bitbucket.org/api/1.0/oauth/request_token',
             'access_token_url'  => 'https://bitbucket.org/api/1.0/oauth/access_token',
             'infos_url'         => 'https://bitbucket.org/api/1.0/user',
-			'emails_url'		=> 'https://bitbucket.org/api/1.0/users/%s/emails'
         ));
     }
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function getUserInformation(array $accessToken, array $extraParameters = array())
-	{
-		$response = parent::getUserInformation($accessToken, $extraParameters);
-
-		$responseData = $response->getResponse();
-
-		if (empty($responseData['email'])) {
-			// fetch the email addresses linked to the account
-			$content = $this->httpRequest($this->normalizeUrl(
-				sprintf($this->options['emails_url'], $responseData['username'])
-			), null, array('Authorization: Bearer '.$accessToken['access_token']));
-
-			foreach ($this->getResponseContent($content) as $email) {
-				if (!empty($email['primary'])) {
-					// we only need the primary email address
-					$responseData['email'] = $email['email'];
-					break;
-				}
-			}
-
-			$response->setResponse($responseData);
-		}
-
-		return $response;
-	}
 }

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -20,6 +20,7 @@
         <parameter key="hwi_oauth.resource_owner.auth0.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\Auth0ResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.azure.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\AzureResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.bitbucket.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\BitbucketResourceOwner</parameter>
+        <parameter key="hwi_oauth.resource_owner.bitbucket2.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\Bitbucket2ResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.bitly.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\BitlyResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.box.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\BoxResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.bufferapp.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\BufferAppResourceOwner</parameter>


### PR DESCRIPTION
Add new provider (class) to use BitBucket OAuth2 provider implementation.
This provider is able to get email address (OAuth1 provider is not able to actually).

To use it you will need to specify ```bitbucket2```