### PR TITLE
[0.4] Remove testing support for Symfony 3 in version 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,9 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=2.8.*
     - php: 5.6
-      env: SYMFONY_VERSION="3.0.x-dev as 2.8"
-    - php: 5.6
       env: FOSUSERBUNDLE_VERSION=1.3.*
     - php: 5.6
       env: FOSUSERBUNDLE_VERSION=2.0.*@dev
-  allow_failures:
-    - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+## 0.4.1 (201x-xx-xx)
+* Fixed: Remove usage of deprecated Twig function `form_enctype` & replace with usage of `form_start`/`form_end`
+* Fixed: Mark as not fully compatible with Symfony `~3.0`
 
 ## 0.4.0 (2015-12-04)
 * [BC break] Added `UserResponseInterface#getFirstName()` method, also a new default path `firstname`

--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
         "symfony/twig-bundle":          "~2.3",
         "symfony/phpunit-bridge":       "~2.7",
         "friendsofsymfony/user-bundle": "~1.3|~2.0",
-        "phpunit/phpunit":              "~4.8"
+        "phpunit/phpunit":              "~4.8|~5.0"
     },
 
     "suggest": {


### PR DESCRIPTION
To match discussion around PRs/issues, i.e.: #808.

We go to mark version `0.5` (current master) as compatible with Symfony 3.