### PR TITLE
Added checkPreAuth to authenticateUser method in ConnectController fo…

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -344,6 +344,7 @@ class ConnectController extends Controller
     protected function authenticateUser(Request $request, UserInterface $user, $resourceOwnerName, $accessToken, $fakeLogin = true)
     {
         try {
+            $this->container->get('hwi_oauth.user_checker')->checkPreAuth($user);
             $this->container->get('hwi_oauth.user_checker')->checkPostAuth($user);
         } catch (AccountStatusException $e) {
             // Don't authenticate locked, disabled or expired users


### PR DESCRIPTION
Our application uses HWIOAuthBundle for registering users using social applications API and for normal (form) registration and managing users we use FOSUserBundle. We need for our application confirmed email address and we need it even with social API registration, because we show our users a form, where they can change their email after connecting with Facebook for example, so all users are not enabled after they register until they confirm their email address. But HWIOAuthBundle is logging in users immediately after registration without checking user state.