### PR TITLE
correct wrong preg_replace

### DIFF
--- a/OAuth/ResourceOwner/SalesforceResourceOwner.php
+++ b/OAuth/ResourceOwner/SalesforceResourceOwner.php
@@ -83,7 +83,7 @@ class SalesforceResourceOwner extends GenericOAuth2ResourceOwner
                 return $value;
             }
 
-            return preg_replace('~\.login\.~', '.test.', $value, 1);
+            return preg_replace('~login\.~', 'test.', $value, 1);
         };
 
         // Symfony <2.6 BC


### PR DESCRIPTION
Proposed change corrects a bug that avoids to transform "https://login.salesforce.com/" in "https://test.salesforce.com/"