### PR TITLE
Checking authentication for 'remembered me' login user

### DIFF
--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -108,7 +108,7 @@ class OAuthUtils
     {
         $resourceOwner = $this->getResourceOwner($name);
         if (null === $redirectUrl) {
-            if (!$this->connect || !$this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
+            if (!$this->connect || !$this->authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY')) {
                 $redirectUrl = $this->httpUtils->generateUri($request, $this->ownerMap->getResourceOwnerCheckPath($name));
             } else {
                 $redirectUrl = $this->getServiceAuthUrl($request, $resourceOwner);

--- a/Tests/Security/OAuthUtilsTest.php
+++ b/Tests/Security/OAuthUtilsTest.php
@@ -195,7 +195,7 @@ class OAuthUtilsTest extends \PHPUnit_Framework_TestCase
         $mock
             ->expects($this->once())
             ->method('isGranted')
-            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->with('IS_AUTHENTICATED_FULLY')
             ->will($this->returnValue($hasUser));
 
         return $mock;


### PR DESCRIPTION
There are sometimes situations where user should fully log in, for example preventing editing user profile when is logged in from 'remember me' cookie. By forcing him to log in I was getting always the connect view even if remembered me account was connected to the same oauth account. This PR fixes this issue performing check by the oauth on remebered me user authenticating him fully.
