### PR TITLE
Incorrect schema for infos_url parameter

### DIFF
--- a/Resources/doc/internals/response_object_and_paths.md
+++ b/Resources/doc/internals/response_object_and_paths.md
@@ -58,7 +58,7 @@ hwi_oauth:
            client_id:     <client_id>
            client_secret: <client_secret>
            scope:         r_fullprofile
-           infos_url:     "http://api.linkedin.com/v1/people/~:(id,formatted-name,recommendations-received)"
+           infos_url:     "https://api.linkedin.com/v1/people/~:(id,formatted-name,recommendations-received)"
 ```
 
 Again the details can be accessed in i.e. `loadUserByOAuthUserResponse(UserResponseInterface $response)`:


### PR DESCRIPTION
I was at the edge of madness when I discovered the problem: we have to call LI using https, not http.