### PR TITLE
Change Discogs URL from http to https

### DIFF
--- a/OAuth/ResourceOwner/DiscogsResourceOwner.php
+++ b/OAuth/ResourceOwner/DiscogsResourceOwner.php
@@ -22,10 +22,10 @@ class DiscogsResourceOwner extends GenericOAuth1ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
-            'authorization_url' => 'http://www.discogs.com/oauth/authorize',
-            'request_token_url' => 'http://api.discogs.com/oauth/request_token',
-            'access_token_url'  => 'http://api.discogs.com/oauth/access_token',
-            'infos_url'         => 'http://api.discogs.com/oauth/identity',
+            'authorization_url' => 'https://www.discogs.com/oauth/authorize',
+            'request_token_url' => 'https://api.discogs.com/oauth/request_token',
+            'access_token_url'  => 'https://api.discogs.com/oauth/access_token',
+            'infos_url'         => 'https://api.discogs.com/oauth/identity',
         ));
     }
 } 


### PR DESCRIPTION
According to this API announcement 25 days ago https://www.discogs.com/forum/thread/347984#7056344
API must use https instead of http, or oAuth will not work

Fix #992 