### PR TITLE
Replace OptionsResolverInterface by OptionsResolver on Bitbucket2ResourceOwner

### DIFF
--- a/OAuth/ResourceOwner/Bitbucket2ResourceOwner.php
+++ b/OAuth/ResourceOwner/Bitbucket2ResourceOwner.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Bitbucket2ResourceOwner
@@ -35,7 +35,7 @@ class Bitbucket2ResourceOwner extends GenericOAuth2ResourceOwner
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function configureOptions(OptionsResolverInterface $resolver)
+	protected function configureOptions(OptionsResolver $resolver)
 	{
 		parent::configureOptions($resolver);
 


### PR DESCRIPTION
OptionsResolverInterface is deprecated from Symfony 2.6 and removed from
symfony 3