### PR TITLE
object cann't serialize/unserialize

### DIFF
--- a/OAuth/ResourceOwner/WechatResourceOwner.php
+++ b/OAuth/ResourceOwner/WechatResourceOwner.php
@@ -39,9 +39,9 @@ class WechatResourceOwner extends GenericOAuth2ResourceOwner
         ), $extraParameters);
 
         $response = $this->doGetTokenRequest($this->options['access_token_url'], $parameters);
-        $content = $this->getResponseContent($response);
+        $response = $this->getResponseContent($response);
 
-        $this->validateResponseContent($content);
+        $this->validateResponseContent($response);
 
         return $response;
     }
@@ -69,7 +69,6 @@ class WechatResourceOwner extends GenericOAuth2ResourceOwner
      */
     public function getUserInformation(array $accessToken = null, array $extraParameters = array())
     {
-        $accessToken = $this->getResponseContent($accessToken['access_token']);
         if ('snsapi_userinfo' === $this->options['scope']) {
             $openid = $accessToken['openid'];
 


### PR DESCRIPTION
if return HttpMessageInterface $response,  when ( throw new AccountNotLinkedException() ), will not be able to use it properly.