### PR TITLE
Prevent routing error message

### DIFF
--- a/Resources/doc/1-setting_up_the_bundle.md
+++ b/Resources/doc/1-setting_up_the_bundle.md
@@ -31,6 +31,10 @@ Import the `redirect.xml` and `login.xml` routing files in your own routing file
 hwi_oauth_redirect:
     resource: "@HWIOAuthBundle/Resources/config/routing/redirect.xml"
     prefix:   /connect
+    
+hwi_oauth_connect:
+    resource: "@HWIOAuthBundle/Resources/config/routing/connect.xml"
+    prefix:   /connect
 
 hwi_oauth_login:
     resource: "@HWIOAuthBundle/Resources/config/routing/login.xml"


### PR DESCRIPTION
Prevent routing error message :
Unable to generate a URL for the named route "hwi_oauth_connect_service" as such route does not exist.