### PR TITLE
Resolved deprecated messages

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -197,7 +197,7 @@ class ConnectController extends Controller
 
         // Handle the form
         /** @var $form FormInterface */
-        $form = $this->createForm('form');
+        $form = $this->createForm('Symfony\Component\Form\Extension\Core\Type\FormType');
 
         $form->handleRequest($request);
 

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -108,11 +108,8 @@ class HWIOAuthExtension extends Extension
                 // setup fosub bridge services
                 $container->setAlias('hwi_oauth.account.connector', 'hwi_oauth.user.provider.fosub_bridge');
 
-                $container
-                    ->setDefinition('hwi_oauth.registration.form.handler.fosub_bridge', new DefinitionDecorator('hwi_oauth.registration.form.handler.fosub_bridge.def'))
-                    ->addArgument($config['fosub']['username_iterations'])
-                    ->setScope('request')
-                ;
+                $definition = $container->setDefinition('hwi_oauth.registration.form.handler.fosub_bridge', new DefinitionDecorator('hwi_oauth.registration.form.handler.fosub_bridge.def'));
+                $definition->addArgument($config['fosub']['username_iterations']);
 
                 $container->setAlias('hwi_oauth.registration.form.handler', 'hwi_oauth.registration.form.handler.fosub_bridge');
 
@@ -120,6 +117,9 @@ class HWIOAuthExtension extends Extension
                 if (interface_exists('FOS\UserBundle\Form\Factory\FactoryInterface')) {
                     $container->setAlias('hwi_oauth.registration.form.factory', 'fos_user.registration.form.factory');
                 } else {
+                    // FOSUser 1.3 BC. To be removed.
+                    $definition->setScope('request');
+
                     $container->setAlias('hwi_oauth.registration.form', 'fos_user.registration.form');
                 }
             }

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -71,7 +71,7 @@ class HWIOAuthExtension extends Extension
 
         // set failed auth path
         $container->setParameter('hwi_oauth.failed_auth_path', $config['failed_auth_path']);
-        
+
         // setup services for all configured resource owners
         $resourceOwners = array();
         foreach ($config['resource_owners'] as $name => $options) {


### PR DESCRIPTION
Accessing type "form" by its string name is deprecated since version 2.8 and will be removed in 3.0. Use the fully-qualified type class name "Symfony\Component\Form\Extension\Core\Type\FormType" instead.