### PR TITLE
migration to Facebook Graph API v2.1

### DIFF
--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -103,10 +103,10 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
-            'authorization_url'   => 'https://www.facebook.com/v2.0/dialog/oauth',
-            'access_token_url'    => 'https://graph.facebook.com/v2.0/oauth/access_token',
-            'revoke_token_url'    => 'https://graph.facebook.com/v2.0/me/permissions',
-            'infos_url'           => 'https://graph.facebook.com/v2.0/me',
+            'authorization_url'   => 'https://www.facebook.com/v2.1/dialog/oauth',
+            'access_token_url'    => 'https://graph.facebook.com/v2.1/oauth/access_token',
+            'revoke_token_url'    => 'https://graph.facebook.com/v2.1/me/permissions',
+            'infos_url'           => 'https://graph.facebook.com/v2.1/me',
 
             'use_commas_in_scope' => true,
 


### PR DESCRIPTION
Graph API v2.0 will reach the end of the 2-year deprecation window on Monday, August 8, 2016