### PR TITLE
Bumped Facebook Resource Owner version to use API v2.3

### DIFF
--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -103,13 +103,11 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
-            'authorization_url'   => 'https://www.facebook.com/v2.0/dialog/oauth',
-            'access_token_url'    => 'https://graph.facebook.com/v2.0/oauth/access_token',
-            'revoke_token_url'    => 'https://graph.facebook.com/v2.0/me/permissions',
-            'infos_url'           => 'https://graph.facebook.com/v2.0/me',
-
+            'authorization_url'   => 'https://www.facebook.com/v2.3/dialog/oauth',
+            'access_token_url'    => 'https://graph.facebook.com/v2.3/oauth/access_token',
+            'revoke_token_url'    => 'https://graph.facebook.com/v2.3/me/permissions',
+            'infos_url'           => 'https://graph.facebook.com/v2.3/me',
             'use_commas_in_scope' => true,
-
             'display'             => null,
             'auth_type'           => null,
             'appsecret_proof'     => false,


### PR DESCRIPTION
Facebook Graph API on version `v2.0` will be closed on 8th August. This pull request bumps API version to `v2.3`. 
I know that there is `v2.6` already available, but since `v2.4` amount of data returned by `/me` is greatly reduced to only:
- name
- user id

So refactoring to use `>=v2.4` would be more time consuming. Treat this Pull Request as a hotfix.