### PR TITLE
pass new accessToken to the authenticateUser method

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -220,7 +220,7 @@ class ConnectController extends Controller
 
             if ($currentToken instanceof OAuthToken) {
                 // Update user token with new details
-                $this->authenticateUser($request, $currentUser, $service, $currentToken->getRawToken(), false);
+                $this->authenticateUser($request, $currentUser, $service, $accessToken, false);
             }
 
             if ($targetPath = $this->getTargetPath($session)) {

--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -220,7 +220,12 @@ class ConnectController extends Controller
 
             if ($currentToken instanceof OAuthToken) {
                 // Update user token with new details
-                $this->authenticateUser($request, $currentUser, $service, $accessToken, false);
+                $newToken =
+                    is_array($accessToken) &&
+                    (isset($accessToken['access_token']) || isset($accessToken['oauth_token'])) ?
+                        $accessToken : $currentToken->getRawToken();
+
+                $this->authenticateUser($request, $currentUser, $service, $newToken, false);
             }
 
             if ($targetPath = $this->getTargetPath($session)) {


### PR DESCRIPTION
if user has already authenticated by OAuthToken and is connecting to a new OAuth account we need to pass the new access token to authenticateUser method. Another case after page reload we have old access token and new resource owner name in OAuthToken.