### PR TITLE
Symfony 3 compatibility fix to Fiware Resource Owner.

### DIFF
--- a/OAuth/ResourceOwner/FiwareResourceOwner.php
+++ b/OAuth/ResourceOwner/FiwareResourceOwner.php
@@ -104,11 +104,19 @@ class FiwareResourceOwner extends GenericOAuth2ResourceOwner
             return str_replace('{base_url}', $options['base_url'], $value);
         };
 
-        $resolver->setNormalizers(array(
-            'authorization_url' => $normalizer,
-            'access_token_url'  => $normalizer,
-            'revoke_token_url'  => $normalizer,
-            'infos_url'         => $normalizer,
-        ));
+        // Symfony <2.6 BC
+        if (method_exists($resolver, 'setNormalizer')) {
+            $resolver->setNormalizer('authorization_url', $normalizer);
+            $resolver->setNormalizer('access_token_url', $normalizer);
+            $resolver->setNormalizer('revoke_token_url', $normalizer);
+            $resolver->setNormalizer('infos_url', $normalizer);
+        } else {
+            $resolver->setNormalizers(array(
+                'authorization_url' => $normalizer,
+                'access_token_url'  => $normalizer,
+                'revoke_token_url'  => $normalizer,
+                'infos_url'         => $normalizer,
+            ));
+        }
     }
 }


### PR DESCRIPTION
OptionsResolver setNormalizers has been removed in Symfony 3.0. Added compatibility fix to Fiware Resource Owner to make it compatible with Symfony 3.