### PR TITLE
Remove authenticated=true

### DIFF
--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -129,7 +129,7 @@ class OAuthUtils
     public function getServiceAuthUrl(Request $request, ResourceOwnerInterface $resourceOwner)
     {
         if ($resourceOwner->getOption('auth_with_one_url')) {
-            return $this->httpUtils->generateUri($request, $this->getResourceOwnerCheckPath($resourceOwner->getName())).'?authenticated=true';
+            return $this->httpUtils->generateUri($request, $this->getResourceOwnerCheckPath($resourceOwner->getName()));
         }
 
         $request->attributes->set('service', $resourceOwner->getName());


### PR DESCRIPTION
Like @xaben said in https://github.com/hwi/HWIOAuthBundle/issues/607

The option "auth_with_one_url" is set to true, but appending `?authenticated=true` essentially breaks the whole point in this option as the URL is different.

For example:
Soundcloud accept only one redirect url; Adding `authenticated=true` to the url when the user is authenticated make this url invalid because it is different from the unauthenticated version.
