### PR TITLE
[DOCS] Fixed missing column annotation on the 'facebook_access_token' property.

### DIFF
--- a/Resources/doc/4-integrating_fosub.md
+++ b/Resources/doc/4-integrating_fosub.md
@@ -34,6 +34,9 @@ class User extends FOSUBUser
      */
     private $facebookId;
 
+    /**
+     * @ORM\Column(name="facebook_access_token", type="string", length=255, nullable=true)
+     */     
     private $facebookAccessToken;
 
     /**


### PR DESCRIPTION
Fixed missing column annotation on the 'facebook_access_token' property.