### PR TITLE
update to facebook api v2.7

### DIFF
--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -103,10 +103,10 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
-            'authorization_url'   => 'https://www.facebook.com/v2.3/dialog/oauth',
-            'access_token_url'    => 'https://graph.facebook.com/v2.3/oauth/access_token',
-            'revoke_token_url'    => 'https://graph.facebook.com/v2.3/me/permissions',
-            'infos_url'           => 'https://graph.facebook.com/v2.3/me',
+            'authorization_url'   => 'https://www.facebook.com/v2.7/dialog/oauth',
+            'access_token_url'    => 'https://graph.facebook.com/v2.7/oauth/access_token',
+            'revoke_token_url'    => 'https://graph.facebook.com/v2.7/me/permissions',
+            'infos_url'           => 'https://graph.facebook.com/v2.7/me?fields=first_name,last_name,name,email',
             'use_commas_in_scope' => true,
             'display'             => null,
             'auth_type'           => null,


### PR DESCRIPTION
New apps on facebook can _only_ use the newest api. 

So now, the bundle does not work for app younger than eg a year.