### PR TITLE
Ensure request is never null

### DIFF
--- a/Templating/Helper/OAuthHelper.php
+++ b/Templating/Helper/OAuthHelper.php
@@ -38,6 +38,7 @@ class OAuthHelper extends Helper
     public function __construct(OAuthUtils $oauthUtils)
     {
         $this->oauthUtils = $oauthUtils;
+        $this->request = new Request();
     }
 
     /**
@@ -48,7 +49,9 @@ class OAuthHelper extends Helper
         if ($request instanceof Request) {
             $this->request = $request;
         } elseif ($request instanceof RequestStack) {
-            $this->request = $request->getMasterRequest();
+            if ($masterRequest = $request->getMasterRequest()) {
+                $this->request = $masterRequest;
+            }
         }
     }
 


### PR DESCRIPTION
fixes #975 

because getLoginUrl does not allow null as request it would
currently fail with empty cache directory.

