### PR TITLE
Prepopulation of registration form doesn't require POST again

### DIFF
--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -84,11 +84,12 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
             return $processed;
         }
 
-        if ($request->isMethod('POST')) {
-            $user = $this->userManager->createUser();
-            $user->setEnabled(true);
+        $user = $this->userManager->createUser();
+        $user->setEnabled(true);
 
-            $form->setData($this->setUserInformation($user, $userInformation));
+        $form->setData($this->setUserInformation($user, $userInformation));
+
+        if ($request->isMethod('POST')) {
             $form->handleRequest($request);
 
             return $form->isValid();

--- a/Tests/Form/FOSUBRegistrationFormHandlerTest.php
+++ b/Tests/Form/FOSUBRegistrationFormHandlerTest.php
@@ -22,7 +22,7 @@ class FOSUBRegistrationFormHandlerTest extends \PHPUnit_Framework_TestCase
 
         $response = $this->getMockBuilder('HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface')->getMock();
 
-        $handler = new FOSUBRegistrationFormHandler($this->getUserManager(false), $this->getMailer());
+        $handler = new FOSUBRegistrationFormHandler($this->getUserManager(), $this->getMailer());
 
         $this->assertFalse($handler->process(Request::create('/'), $formMock, $response));
     }
@@ -55,24 +55,21 @@ class FOSUBRegistrationFormHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($handler->process(Request::create('/', 'POST'), $formMock, $this->getResponse()));
     }
 
-    private function getUserManager($createUser = true)
+    private function getUserManager()
     {
         $mock = $this->getMockBuilder('FOS\UserBundle\Model\UserManagerInterface')->getMock();
+        $userMock = $this->getMockBuilder('FOS\UserBundle\Model\UserInterface')->getMock();
+        $userMock
+            ->expects($this->once())
+            ->method('setEnabled')
+            ->with(true)
+        ;
 
-        if ($createUser) {
-            $userMock = $this->getMockBuilder('FOS\UserBundle\Model\UserInterface')->getMock();
-            $userMock
-                ->expects($this->once())
-                ->method('setEnabled')
-                ->with(true)
-            ;
-
-            $mock
-                ->expects($this->once())
-                ->method('createUser')
-                ->willReturn($userMock)
-            ;
-        }
+        $mock
+            ->expects($this->once())
+            ->method('createUser')
+            ->willReturn($userMock)
+        ;
 
         return $mock;
     }


### PR DESCRIPTION
This commit caused a BC break - https://github.com/hwi/HWIOAuthBundle/commit/78322998a5400ea00f03f148f38e3a052e97f84a#diff-da386dfe4045fc61ae795f4546b9a247

This fix makes the registration form prepopulated with the user data obtained byh OAuth again.