### PR TITLE
Added FOSUserBundle like events

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -11,10 +11,15 @@
 
 namespace HWI\Bundle\OAuthBundle\Controller;
 
+use HWI\Bundle\OAuthBundle\Event\FilterUserResponseEvent;
+use HWI\Bundle\OAuthBundle\Event\FormEvent;
+use HWI\Bundle\OAuthBundle\Event\GetResponseUserEvent;
+use HWI\Bundle\OAuthBundle\HWIOAuthEvents;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -124,23 +129,41 @@ class ConnectController extends Controller
 
         $formHandler = $this->container->get('hwi_oauth.registration.form.handler');
         if ($formHandler->process($request, $form, $userInformation)) {
+            $event = new FormEvent($form, $request);
+            $this->dispatch(HWIOAuthEvents::REGISTRATION_SUCCESS, $event);
+
             $this->container->get('hwi_oauth.account.connector')->connect($form->getData(), $userInformation);
 
             // Authenticate the user
             $this->authenticateUser($request, $form->getData(), $error->getResourceOwnerName(), $error->getRawToken());
 
-            if ($targetPath = $this->getTargetPath($session)) {
-                return $this->redirect($targetPath);
+            if (!$response = $event->getResponse()) {
+                $targetPath = $this->getTargetPath($session);
+                $response = $targetPath
+                    ? $this->redirect($targetPath)
+                    : $this->render(
+                        'HWIOAuthBundle:Connect:registration_success.html.' . $this->getTemplatingEngine(),
+                        array('userInformation' => $userInformation)
+                    )
+                ;
             }
 
-            return $this->render('HWIOAuthBundle:Connect:registration_success.html.'.$this->getTemplatingEngine(), array(
-                'userInformation' => $userInformation,
-            ));
+            $event = new FilterUserResponseEvent($form->getData(), $request, $response);
+            $this->dispatch(HWIOAuthEvents::REGISTRATION_COMPLETED, $event);
+
+            return $response;
         }
 
         // reset the error in the session
         $key = time();
         $session->set('_hwi_oauth.registration_error.'.$key, $error);
+
+        $event = new GetResponseUserEvent($form->getData(), $request);
+        $this->dispatch(HWIOAuthEvents::REGISTRATION_INITIALIZE, $event);
+
+        if ($response = $event->getResponse()) {
+            return $response;
+        }
 
         return $this->render('HWIOAuthBundle:Connect:registration.html.'.$this->getTemplatingEngine(), array(
             'key' => $key,
@@ -198,6 +221,9 @@ class ConnectController extends Controller
         }
 
         $userInformation = $resourceOwner->getUserInformation($accessToken);
+        /** @var $currentToken OAuthToken */
+        $currentToken = $this->getToken();
+        $currentUser = $currentToken->getUser();
 
         // Show confirmation page?
         if (!$this->container->getParameter('hwi_oauth.connect.confirmation')) {
@@ -215,9 +241,8 @@ class ConnectController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             show_confirmation_page:
 
-            /** @var $currentToken OAuthToken */
-            $currentToken = $this->getToken();
-            $currentUser = $currentToken->getUser();
+            $event = new GetResponseUserEvent($currentUser, $request);
+            $this->dispatch(HWIOAuthEvents::CONNECT_CONFIRMED, $event);
 
             $this->container->get('hwi_oauth.account.connector')->connect($currentUser, $userInformation);
 
@@ -231,14 +256,31 @@ class ConnectController extends Controller
                 $this->authenticateUser($request, $currentUser, $service, $newToken, false);
             }
 
-            if ($targetPath = $this->getTargetPath($session)) {
-                return $this->redirect($targetPath);
+            if (!$response = $event->getResponse()) {
+                $targetPath = $this->getTargetPath($session);
+                $response = $targetPath
+                    ? $this->redirect($targetPath)
+                    : $this->render(
+                        'HWIOAuthBundle:Connect:connect_success.html.' . $this->getTemplatingEngine(),
+                        array(
+                            'userInformation' => $userInformation,
+                            'service' => $service,
+                        )
+                    )
+                ;
             }
 
-            return $this->render('HWIOAuthBundle:Connect:connect_success.html.' . $this->getTemplatingEngine(), array(
-                'userInformation' => $userInformation,
-                'service' => $service,
-            ));
+            $event = new FilterUserResponseEvent($currentUser, $request, $response);
+            $this->dispatch(HWIOAuthEvents::CONNECT_COMPLETED, $event);
+
+            return $response;
+        }
+
+        $event = new GetResponseUserEvent($currentUser, $request);
+        $this->dispatch(HWIOAuthEvents::CONNECT_INITIALIZE, $event);
+
+        if ($response = $event->getResponse()) {
+            return $response;
         }
 
         return $this->render('HWIOAuthBundle:Connect:connect_confirm.html.' . $this->getTemplatingEngine(), array(
@@ -452,6 +494,16 @@ class ConnectController extends Controller
         }
 
         return $this->get('security.context')->setToken($token);
+    }
+
+    /**
+     * @param string $eventName
+     * @param Event|null $event
+     * @return Event
+     */
+    private function dispatch($eventName, Event $event = null)
+    {
+        return $this->container->get('event_dispatcher')->dispatch($eventName, $event);
     }
 
     /**

--- a/Event/FilterUserResponseEvent.php
+++ b/Event/FilterUserResponseEvent.php
@@ -1,0 +1,25 @@
+<?php
+namespace HWI\Bundle\OAuthBundle\Event;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class FilterUserResponseEvent extends UserEvent
+{
+    private $response;
+
+    public function __construct(UserInterface $user, Request $request, Response $response)
+    {
+        parent::__construct($user, $request);
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/Event/FormEvent.php
+++ b/Event/FormEvent.php
@@ -1,0 +1,52 @@
+<?php
+namespace HWI\Bundle\OAuthBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class FormEvent extends Event
+{
+    private $form;
+    private $request;
+    private $response;
+
+    public function __construct(FormInterface $form, Request $request)
+    {
+        $this->form = $form;
+        $this->request = $request;
+    }
+
+    /**
+     * @return FormInterface
+     */
+    public function getForm()
+    {
+        return $this->form;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/Event/GetResponseUserEvent.php
+++ b/Event/GetResponseUserEvent.php
@@ -1,0 +1,25 @@
+<?php
+namespace HWI\Bundle\OAuthBundle\Event;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class GetResponseUserEvent extends UserEvent
+{
+    private $response;
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/Event/UserEvent.php
+++ b/Event/UserEvent.php
@@ -1,0 +1,34 @@
+<?php
+namespace HWI\Bundle\OAuthBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class UserEvent extends Event
+{
+    private $user;
+    private $request;
+
+    public function __construct(UserInterface $user, Request $request)
+    {
+        $this->user = $user;
+        $this->request = $request;
+    }
+
+    /**
+     * @return UserInterface
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+}

--- a/HWIOAuthEvents.php
+++ b/HWIOAuthEvents.php
@@ -1,0 +1,17 @@
+<?php
+namespace HWI\Bundle\OAuthBundle;
+
+final class HWIOAuthEvents
+{
+    const REGISTRATION_INITIALIZE = 'hwi_oauth.registration.initialize';
+
+    const REGISTRATION_SUCCESS = 'hwi_oauth.registration.success';
+
+    const REGISTRATION_COMPLETED = 'hwi_oauth.registration.completed';
+
+    const CONNECT_INITIALIZE = 'hwi_oauth.connect.initialize';
+
+    const CONNECT_CONFIRMED = 'hwi_oauth.connect.confirmed';
+
+    const CONNECT_COMPLETED = 'hwi_oauth.connect.completed';
+}

--- a/Tests/Controller/ConnectControllerConnectServiceActionTest.php
+++ b/Tests/Controller/ConnectControllerConnectServiceActionTest.php
@@ -2,7 +2,9 @@
 
 namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 
+use HWI\Bundle\OAuthBundle\HWIOAuthEvents;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
+use Symfony\Component\HttpFoundation\Response;
 
 class ConnectControllerConnectServiceActionTest extends AbstractConnectControllerTest
 {
@@ -49,12 +51,23 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->willReturn(array())
         ;
 
+        $this->getTokenStorage()->expects($this->once())
+            ->method('getToken')
+            ->willReturn(new CustomOAuthToken())
+        ;
+
         $form = $this->getMockBuilder('\Symfony\Component\Form\FormInterface')
             ->disableOriginalConstructor()
             ->getMock();
         $this->formFactory->expects($this->once())
             ->method('create')
             ->willReturn($form)
+        ;
+
+        $this->eventDispatcher->expects($this->once())->method('dispatch');
+        $this->eventDispatcher->expects($this->at(0))
+            ->method('dispatch')
+            ->with(HWIOAuthEvents::CONNECT_INITIALIZE)
         ;
 
         $this->templating->expects($this->once())
@@ -100,12 +113,24 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->willReturn(new CustomOAuthToken())
         ;
 
+        $this->eventDispatcher->expects($this->exactly(2))->method('dispatch');
+        $this->eventDispatcher->expects($this->at(0))
+            ->method('dispatch')
+            ->with(HWIOAuthEvents::CONNECT_CONFIRMED)
+        ;
+        $this->eventDispatcher->expects($this->at(1))
+            ->method('dispatch')
+            ->with(HWIOAuthEvents::CONNECT_COMPLETED)
+        ;
+
+        $response = new Response();
         $this->templating->expects($this->once())
             ->method('renderResponse')
             ->with('HWIOAuthBundle:Connect:connect_success.html.twig')
+            ->willReturn($response)
         ;
 
-        $this->controller->connectServiceAction($this->request, 'facebook');
+        $this->assertSame($response, $this->controller->connectServiceAction($this->request, 'facebook'));
     }
 
     public function testConnectNoConfirmation()
@@ -132,12 +157,24 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->willReturn(new CustomOAuthToken())
         ;
 
+        $this->eventDispatcher->expects($this->exactly(2))->method('dispatch');
+        $this->eventDispatcher->expects($this->at(0))
+            ->method('dispatch')
+            ->with(HWIOAuthEvents::CONNECT_CONFIRMED)
+        ;
+        $this->eventDispatcher->expects($this->at(1))
+            ->method('dispatch')
+            ->with(HWIOAuthEvents::CONNECT_COMPLETED)
+        ;
+
+        $response = new Response();
         $this->templating->expects($this->once())
             ->method('renderResponse')
             ->with('HWIOAuthBundle:Connect:connect_success.html.twig')
+            ->willReturn($response)
         ;
 
-        $this->controller->connectServiceAction($this->request, 'facebook');
+        $this->assertSame($response, $this->controller->connectServiceAction($this->request, 'facebook'));
     }
 
     public function testResourceOwnerHandle()
@@ -160,6 +197,11 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
         $this->resourceOwner->expects($this->once())
             ->method('getAccessToken')
             ->willReturn(array())
+        ;
+
+        $this->getTokenStorage()->expects($this->once())
+            ->method('getToken')
+            ->willReturn(new CustomOAuthToken())
         ;
 
         $form = $this->getMockBuilder('\Symfony\Component\Form\FormInterface')

--- a/Tests/Controller/ConnectControllerRegistrationActionTest.php
+++ b/Tests/Controller/ConnectControllerRegistrationActionTest.php
@@ -2,7 +2,10 @@
 
 namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 
+use HWI\Bundle\OAuthBundle\HWIOAuthEvents;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\User;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\SecurityEvents;
 
 class ConnectControllerRegistrationActionTest extends AbstractConnectControllerTest
 {
@@ -87,6 +90,12 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
         ;
         $this->container->set('hwi_oauth.registration.form.handler', $registrationFormHandler);
 
+        $this->eventDispatcher->expects($this->once())->method('dispatch');
+        $this->eventDispatcher->expects($this->at(0))
+            ->method('dispatch')
+            ->with(HWIOAuthEvents::REGISTRATION_INITIALIZE)
+        ;
+
         $this->templating->expects($this->once())
             ->method('renderResponse')
             ->with('HWIOAuthBundle:Connect:registration.html.twig')
@@ -107,9 +116,7 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
 
         $this->makeRegistrationForm();
 
-        $registrationFormHandler = $this->getMockBuilder('\HWI\Bundle\OAuthBundle\Form\RegistrationFormHandlerInterface')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $registrationFormHandler = $this->getMockBuilder('HWI\Bundle\OAuthBundle\Form\RegistrationFormHandlerInterface')->getMock();
         $registrationFormHandler->expects($this->once())
             ->method('process')
             ->withAnyParameters()
@@ -121,11 +128,30 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
             ->method('connect')
         ;
 
-        $this->eventDispatcher->expects($this->once())
+        $this->eventDispatcher->expects($this->exactly(3))->method('dispatch');
+        $this->eventDispatcher->expects($this->at(0))
             ->method('dispatch')
+            ->with(HWIOAuthEvents::REGISTRATION_SUCCESS)
         ;
 
-        $this->controller->registrationAction($this->request, $key);
+        $this->eventDispatcher->expects($this->at(1))
+            ->method('dispatch')
+            ->with(SecurityEvents::INTERACTIVE_LOGIN)
+        ;
+
+        $this->eventDispatcher->expects($this->at(2))
+            ->method('dispatch')
+            ->with(HWIOAuthEvents::REGISTRATION_COMPLETED)
+        ;
+
+        $response = new Response();
+        $this->templating->expects($this->once())
+            ->method('renderResponse')
+            ->with('HWIOAuthBundle:Connect:registration_success.html.twig')
+            ->willReturn($response)
+        ;
+
+        $this->assertSame($response, $this->controller->registrationAction($this->request, $key));
     }
 
     private function makeRegistrationForm()


### PR DESCRIPTION
This PR is almost the same as https://github.com/hwi/HWIOAuthBundle/pull/945
I just renamed HWIOAuthUserEvents to HWIOAuthEvents and the INIT events to INITIALIZE so it's more aligned with FOSUB. I also made the tests more complete. It tests the events are fired and the behavior has not changed.
