### PR TITLE
Added WunderlistResourceOwner

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -76,6 +76,7 @@ class Configuration implements ConfigurationInterface
             'wechat',
             'windows_live',
             'wordpress',
+            'wunderlist',
             'yandex',
             '37signals',
             'itembase',

--- a/OAuth/ResourceOwner/WunderlistResourceOwner.php
+++ b/OAuth/ResourceOwner/WunderlistResourceOwner.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
+
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use Buzz\Message\RequestInterface as HttpRequestInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * LinkedinResourceOwner
+ *
+ * @author Guillaume Potier <guillaume@wisembly.com>
+ */
+class WunderlistResourceOwner extends GenericOAuth2ResourceOwner
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $paths = array(
+        'identifier'     => 'id',
+        'nickname'       => 'name',
+        'realname'       => 'name',
+        'email'          => 'email',
+    );
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function doGetUserInformationRequest($url, array $parameters = array())
+    {
+        return $this->httpRequest($url, null, array(
+            'X-Client-ID'       => $this->options['client_id'],
+            'X-Access-Token'    => $parameters['access_token'],
+        ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getUserInformation(array $accessToken, array $extraParameters = array())
+    {
+        $content = $this->doGetUserInformationRequest($this->options['infos_url'], array('access_token' => $accessToken['access_token']));
+
+        $response = $this->getUserResponse();
+        $response->setResponse($content->getContent());
+
+        $response->setResourceOwner($this);
+        $response->setOAuthToken(new OAuthToken($accessToken));
+
+        return $response;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults(array(
+            'authorization_url' => 'https://www.wunderlist.com/oauth/authorize',
+            'access_token_url'  => 'https://www.wunderlist.com/oauth/access_token',
+            'infos_url'         => 'https://a.wunderlist.com/api/v1/user',
+        ));
+    }
+}

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -69,6 +69,7 @@
         <parameter key="hwi_oauth.resource_owner.wechat.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\WechatResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.windows_live.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\WindowsLiveResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.wordpress.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\WordpressResourceOwner</parameter>
+        <parameter key="hwi_oauth.resource_owner.wunderlist.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\WunderlistResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.xing.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\XingResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.yahoo.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\YahooResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.yandex.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\YandexResourceOwner</parameter>

--- a/Resources/doc/2-configuring_resource_owners.md
+++ b/Resources/doc/2-configuring_resource_owners.md
@@ -75,6 +75,7 @@ hwi_oauth:
 - [Trello] (resource_owners/trello.md)
 - [Twitch] (resource_owners/twitch.md)
 - [Twitter] (resource_owners/twitter.md)
+- [Wunderlist](resource_owners/wunderlist.md)
 - [Vkontakte](resource_owners/vkontakte.md)
 - [Windows Live](resource_owners/windows_live.md)
 - [XING](resource_owners/xing.md)

--- a/Resources/doc/resource_owners/wunderlist.md
+++ b/Resources/doc/resource_owners/wunderlist.md
@@ -1,0 +1,25 @@
+Step 2x: Setup Wunderlist
+=====================
+
+First you will have to register your application on Wunderlist. Check out the
+documentation for more information: https://developer.wunderlist.com/apps.
+
+Next configure a resource owner of type `wunderlist` with appropriate
+`client_id`, `client_secret`.
+
+```yaml
+# app/config/config.yml
+
+hwi_oauth:
+    resource_owners:
+        any_name:
+            type:                wunderlist
+            client_id:           <client_id>
+            client_secret:       <client_secret>
+```
+
+When you're done. Continue by configuring the security layer or go back to
+setup more resource owners.
+
+- [Step 2: Configuring resource owners (Facebook, GitHub, Google, Windows Live and others](../2-configuring_resource_owners.md)
+- [Step 3: Configuring the security layer](../3-configuring_the_security_layer.md).

--- a/Tests/OAuth/ResourceOwner/WunderlistResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/WunderlistResourceOwnerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\WunderlistResourceOwner;
+
+class WunderlistResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
+{
+    protected $userResponse = <<<json
+{
+    "data": {
+        "id": 1,
+        "name": "bar"
+    }
+}
+json;
+
+    protected $paths = array(
+        'identifier' => 'data.id',
+        'nickname'   => 'data.name',
+        'realname'   => 'data.name',
+    );
+
+    protected $expectedUrls = array(
+        'authorization_url'      => 'http://user.auth/?test=2&response_type=code&client_id=clientid&redirect_uri=http%3A%2F%2Fredirect.to%2F',
+        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
+    );
+
+    protected function setUpResourceOwner($name, $httpUtils, array $options)
+    {
+        return new WunderlistResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
         "wechat",
         "windows live",
         "wordpress",
+        "wunderlist",
         "xing",
         "yahoo",
         "yandex",


### PR DESCRIPTION
Hi there,

This is WunderlistResourceOwner. I needed to create it as Wunderlist `infos_url` awaits in headers `X-Client-ID` and `X-Access-Token` which is not OAuth2 standard, and couldn't go with a regular generic OAuth2 resource owner.

Doc and test are also provided.

Best