### PR TITLE
Fixes Trello ResourceOwner

### DIFF
--- a/OAuth/ResourceOwner/TrelloResourceOwner.php
+++ b/OAuth/ResourceOwner/TrelloResourceOwner.php
@@ -24,12 +24,27 @@ class TrelloResourceOwner extends GenericOAuth1ResourceOwner
      * {@inheritDoc}
      */
     protected $paths = array(
-        'identifier'     => '_id',
+        'identifier'     => 'id',
         'nickname'       => 'username',
         'realname'       => 'fullName',
         'email'          => 'email',
         'profilepicture' => 'avatarSource',
     );
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAuthorizationUrl($redirectUri, array $extraParameters = array())
+    {
+        $token = $this->getRequestToken($redirectUri, $extraParameters);
+
+        return $this->normalizeUrl($this->options['authorization_url'], array(
+            'scope'         => $this->options['scopes'],
+            'name'          => $this->options['application'],
+            'expiration'    => $this->options['expiration'],
+            'oauth_token'   => $token['oauth_token'],
+        ));
+    }
 
     /**
      * {@inheritDoc}
@@ -43,6 +58,10 @@ class TrelloResourceOwner extends GenericOAuth1ResourceOwner
             'request_token_url' => 'https://trello.com/1/OAuthGetRequestToken',
             'access_token_url'  => 'https://trello.com/1/OAuthGetAccessToken',
             'infos_url'         => 'https://api.trello.com/1/members/me?fields=username,fullName,avatarSource,email',
+            'realm'             => 'trello.com',
+            'application'       => null,
+            'scopes'            => 'read',
+            'expiration'        => null,
         ));
     }
 }

--- a/Resources/doc/resource_owners/trello.md
+++ b/Resources/doc/resource_owners/trello.md
@@ -4,7 +4,7 @@ First you will have to register your application on Trello. Check out the
 documentation for more information: https://trello.com/docs/gettingstarted/authorize.html.
 
 Next configure a resource owner of type `trello` with appropriate
-`client_id`, `client_secret` and `scope`.
+`client_id`, `client_secret`, `application`, `scopes` and `expiration`.
 
 ```yaml
 # app/config/config.yml
@@ -15,6 +15,11 @@ hwi_oauth:
             type:                trello
             client_id:           <client_id>
             client_secret:       <client_secret>
+
+        options:
+            application: <your application name>
+            scopes: <read,write>
+            expiration: <never>
 ```
 
 When you're done. Continue by configuring the security layer or go back to

--- a/Tests/OAuth/ResourceOwner/TrelloResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/TrelloResourceOwnerTest.php
@@ -17,18 +17,33 @@ class TrelloResourceOwnerTest extends GenericOAuth1ResourceOwnerTest
 {
     protected $userResponse = <<<json
 {
-    "_id": "1",
+    "id": "1",
     "username": "bar",
     "fullName": "foo"
 }
 json;
     protected $paths = array(
-        'identifier'     => '_id',
+        'identifier'     => 'id',
         'nickname'       => 'username',
         'realname'       => 'fullName',
         'email'          => 'email',
         'profilepicture' => 'avatarSource',
     );
+
+
+    public function testGetAuthorizationUrlContainOAuthTokenAndSecret()
+    {
+        $this->mockBuzz('{"oauth_token": "token", "oauth_token_secret": "secret"}', 'application/json; charset=utf-8');
+
+        $this->storage->expects($this->once())
+            ->method('save')
+            ->with($this->resourceOwner, array('oauth_token' => 'token', 'oauth_token_secret' => 'secret', 'timestamp' => time()));
+
+        $this->assertEquals(
+            'http://user.auth/?test=3&scope=read&oauth_token=token',
+            $this->resourceOwner->getAuthorizationUrl('http://redirect.to/')
+        );
+    }
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {


### PR DESCRIPTION
Hi there,

As mentioned in #794, #434, Trello provider does not work anymore.

Some points:
- Trello is returning a 500 status code if `realm` is given in `/OAuthGetRequestToken` headers. In fact, [that line](https://github.com/hwi/HWIOAuthBundle/blob/master/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php#L195) adds a default realm if not specified (or `null` or `false` which is more serious, a stricter check should be done here, but that is another story). Passing a bullshit realm fixes the 500 and makes the integration work again
- Trello does not return (anymore?) an `_id`. Switched to `id`
- Finally, I added the ability to pass some very important options IMHO
  - `scopes`: by default, only `read`. I need `read,write` in my app, I'm glad to be able to override it
  - `expiration`: 1 month by default, glad to be able to make it `never`
  - `application`: application name. Otherwise "An unknown application" is wanting some creds. Freaky ;)

Hope you could merge that one. Atm that config makes the job:

```yaml
        trello:
            type: oauth1
            client_id:           %oauth.trello.client_id%
            client_secret:       %oauth.trello.client_secret%
            request_token_url:   https://trello.com/1/OAuthGetRequestToken
            access_token_url:    https://trello.com/1/OAuthGetAccessToken
            authorization_url:   https://trello.com/1/OAuthAuthorizeToken?scope=read,write&name=Wisembly&expiration=never
            infos_url:           https://api.trello.com/1/members/me?fields=username,fullName,avatarSource,email
            realm:               "fucking bullshit shitty fu*k"

            paths:
                identifier: id
                nickname: username
                realname: fullName
```

But I like to have it working built in.

Best