### PR TITLE
Adds Asana ResourceOwner

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ class Configuration implements ConfigurationInterface
     private static $resourceOwners = array(
         'oauth2' => array(
             'amazon',
+            'asana',
             'auth0',
             'azure',
             'bitbucket2',

--- a/OAuth/ResourceOwner/AsanaResourceOwner.php
+++ b/OAuth/ResourceOwner/AsanaResourceOwner.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
+
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use Buzz\Message\RequestInterface as HttpRequestInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * AsanaResourceOwner
+ *
+ * @author Guillaume Potier <guillaume@wisembly.com>
+ */
+class AsanaResourceOwner extends GenericOAuth2ResourceOwner
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $paths = array(
+        'identifier'     => 'data.id',
+        'nickname'       => 'data.name',
+        'realname'       => 'data.name',
+        'email'          => 'data.email',
+    );
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults(array(
+            'authorization_url' => 'https://app.asana.com/-/oauth_authorize',
+            'access_token_url'  => 'https://app.asana.com/-/oauth_token',
+            'infos_url'         => 'https://app.asana.com/api/1.0/users/me',
+        ));
+    }
+}

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -17,6 +17,7 @@
         <parameter key="hwi_oauth.resource_owner.oauth2.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner</parameter>
 
         <parameter key="hwi_oauth.resource_owner.amazon.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\AmazonResourceOwner</parameter>
+        <parameter key="hwi_oauth.resource_owner.asana.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\AsanaResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.auth0.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\Auth0ResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.azure.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\AzureResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.bitbucket.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\BitbucketResourceOwner</parameter>

--- a/Resources/doc/2-configuring_resource_owners.md
+++ b/Resources/doc/2-configuring_resource_owners.md
@@ -35,6 +35,7 @@ hwi_oauth:
 ##### Built-in resource owners:
 
 - [37signals](resource_owners/37signals.md)
+- [Asana](resource_owners/asana.md)
 - [Amazon](resource_owners/amazon.md)
 - [Auth0](resource_owners/auth0.md)
 - [Azure](resource_owners/azure.md)

--- a/Resources/doc/resource_owners/asana.md
+++ b/Resources/doc/resource_owners/asana.md
@@ -1,0 +1,24 @@
+Step 2x: Setup Asana
+=====================
+First you will have to register your application on Asana. Check out the
+documentation for more information: https://app.asana.com/-/account_api.
+
+Next configure a resource owner of type `trello` with appropriate
+`client_id` and `client_secret`.
+
+```yaml
+# app/config/config.yml
+
+hwi_oauth:
+    resource_owners:
+        any_name:
+            type:                asana
+            client_id:           <client_id>
+            client_secret:       <client_secret>
+```
+
+When you're done. Continue by configuring the security layer or go back to
+setup more resource owners.
+
+- [Step 2: Configuring resource owners (Facebook, GitHub, Google, Windows Live and others](../2-configuring_resource_owners.md)
+- [Step 3: Configuring the security layer](../3-configuring_the_security_layer.md).

--- a/Resources/doc/resource_owners/asana.md
+++ b/Resources/doc/resource_owners/asana.md
@@ -3,7 +3,7 @@ Step 2x: Setup Asana
 First you will have to register your application on Asana. Check out the
 documentation for more information: https://app.asana.com/-/account_api.
 
-Next configure a resource owner of type `trello` with appropriate
+Next configure a resource owner of type `asana` with appropriate
 `client_id` and `client_secret`.
 
 ```yaml

--- a/Tests/OAuth/ResourceOwner/AsanaResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/AsanaResourceOwnerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\AsanaResourceOwner;
+
+class AsanaResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
+{
+    protected $userResponse = <<<json
+{
+    "data": {
+        "id": "1",
+        "name": "bar",
+        "email": "foo@bar.baz"
+    }
+}
+json;
+
+    protected $paths = array(
+        'identifier'      => 'data.id',
+    );
+
+    protected function setUpResourceOwner($name, $httpUtils, array $options)
+    {
+        return new AsanaResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "security",
 
         "amazon",
+        "asana",
         "auth0",
         "azure",
         "bitbucket",


### PR DESCRIPTION
Hi there,

Last of my 3rd PR, a new ResourceOwner, Asana!

Asana follows perfectly OAuth2, and all could be done using just generic oauth2 provider configuration in config file. But Asana creds needs to be refreshed quite often, and using a generic oauth2 provider in my project, I did not find a nice way to use the built-in refresh method of `GenericOAuth2ResourceOwner`. That's why I'm submitting Asana today, to be able to nicely refresh my expired token.

Thanks