### PR TITLE
Fixed Symfony 2.3 tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,6 +109,7 @@
         "symfony/property-access":      "~2.3|~3.0",
         "symfony/validator":            "~2.3|~3.0",
         "symfony/twig-bundle":          "~2.3|~3.0",
+        "symfony/stopwatch":            "~2.5|~3.0",
         "symfony/phpunit-bridge":       "~2.7|~3.0",
         "friendsofsymfony/user-bundle": "~1.3|~2.0",
         "phpunit/phpunit":              "~4.8|~5.0",


### PR DESCRIPTION
The package `fabpot/php-cs-fixer` requires `symfony/stopwatch` 2.5 or higher.