### PR TITLE
Prevent 302 error with header location to be sent twice.

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -279,7 +279,6 @@ class ConnectController extends Controller
             }
         }
 
-        $this->redirect($authorizationUrl)->sendHeaders();
         return new RedirectResponse($authorizationUrl);
     }
 


### PR DESCRIPTION
Fix https://github.com/hwi/HWIOAuthBundle/issues/1092