### PR TITLE
[RFC] Add mention of "JcrollFoursquareApiBundle" in Foursquare docs

### DIFF
--- a/Resources/doc/resource_owners/foursquare.md
+++ b/Resources/doc/resource_owners/foursquare.md
@@ -17,6 +17,8 @@ hwi_oauth:
             client_secret:       <client_secret>
 ```
 
+For easy integration for making signed calls with your oauth token to the Foursquare REST API try the [JcrollFoursquareApiBundle](https://github.com/jcroll/foursquare-api-bundle).
+
 When you're done. Continue by configuring the security layer or go back to
 setup more resource owners.
 


### PR DESCRIPTION
As I updated the [JcrollFoursquareApiBundle to automatically integrate with the HWIOAuthBundle](https://github.com/jcroll/foursquare-api-bundle#basic-configuration) I thought it would be useful to mention it in your docs.
