### PR TITLE
Exclude tests from Composer autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,6 +127,15 @@
     "autoload": {
         "psr-4": {
             "HWI\\Bundle\\OAuthBundle\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+
+    "autoload-dev": {
+        "psr-4": {
+            "HWI\\Bundle\\OAuthBundle\\Tests\\": "Tests/"
         }
     },
 


### PR DESCRIPTION
Tests are not needed to be included for production usage.