### PR TITLE
When throwing a generic exception at least include the previous exception

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -103,7 +103,7 @@ class ConnectController extends Controller
 
         if (!$error instanceof AccountNotLinkedException || time() - $key > 300) {
             // todo: fix this
-            throw new \Exception('Cannot register an account.');
+            throw new \Exception('Cannot register an account.', 0, $error instanceof \Exception ? $error : null);
         }
 
         $userInformation = $this


### PR DESCRIPTION
Hard to debug what is going on otherwise. Not really sure what the "fix this" comment is refering to in the line above.
