### PR TITLE
fix #1119 - StackExchange Resource Owner

### DIFF
--- a/Tests/OAuth/ResourceOwner/StackExchangeResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/StackExchangeResourceOwnerTest.php
@@ -17,15 +17,21 @@ class StackExchangeResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
     protected $userResponse = <<<json
 {
-    "user_id": "1",
-    "display_name": "bar"
+   "items" : [
+      {
+         "display_name" : "bar",
+         "profile_image" : "https://foo.com/bar.png",
+         "user_id" : 1
+      }
+   ]
 }
 json;
 
     protected $paths = array(
-        'identifier'  => 'user_id',
-        'nickname'    => 'display_name',
-        'realname'    => 'display_name'
+        'identifier'     => 'items.0.user_id',
+        'nickname'       => 'items.0.display_name',
+        'realname'       => 'items.0.display_name',
+        'profilepicture' => 'items.0.profile_image',
     );
 
     protected $expectedUrls = array(
@@ -35,6 +41,6 @@ json;
 
     protected function setUpResourceOwner($name, $httpUtils, array $options)
     {
-        return new StackExchangeResourceOwner($this->buzzClient, $httpUtils, $options, $name, $this->storage);
+        return new StackExchangeResourceOwner($this->buzzClient, $httpUtils, array_merge($options, array('key' => 'baz')), $name, $this->storage);
     }
 }


### PR DESCRIPTION
fix #1119
* zlib now required if using stackexchange resource owner
* response is systematically ungzipped (see: https://api.stackexchange.com/docs/compression)
* disabled bearer authentication as it is not supported anymore by SE
* site parameter given (by default stackoverflow)
* application key parameter given (mandatory, see https://stackapps.com/apps/oauth/)
* path for each user item is now good
* fixed tests accordignly

Default configuration (parameters = mandatory fields):

```yaml
        stack:
            type: stack_exchange
            client_id: %stack_client_id%
            client_secret: %stack_secret%
            options:
                key: %stack_key%
                site: stackoverflow
```

Result:

![stack_working](https://cloud.githubusercontent.com/assets/4152132/20456009/82bab71e-ae6a-11e6-8050-1b5a8255bf17.png)

