### PR TITLE
Fix #1125 wrong content length calculation for arrays parameters in oauth requests

### DIFF
--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -231,17 +231,13 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
         $request = new HttpRequest($method, $url);
         $response = new HttpResponse();
 
-        $contentLength = 0;
         if (is_string($content)) {
-            $contentLength = strlen($content);
-        } elseif (is_array($content)) {
-            $contentLength = strlen(implode('', $content));
+            $headers =  array_merge(array('Content-Length' => strlen($content)), $headers);
         }
 
         $headers = array_merge(
             array(
                 'User-Agent: HWIOAuthBundle (https://github.com/hwi/HWIOAuthBundle)',
-                'Content-Length: '.$contentLength,
             ),
             $headers
         );


### PR DESCRIPTION
Fix #1125

There was an old fix ( #527 ) breaking the behavior with array as parameters by specifying a wrong content-length. **It breaks the Sensiolabs connect adapter** (and maybe others).

Actually Buzz Curl adapter automatically calculate the content-length. So I guess the issue was present with _something else_. That's why I keep backward compatibility with string content variable but IMO it may be also remove.

This is an alternate fix but #657 also works.

There is no test because what needs to be test is the curl request and this imply to add functional test with `nc` (because curl uses an obscure `resource` untestable before sending request to server).

Related to:

* #527 : breaking change
* #657 : fix you didn't merge
* https://github.com/afsy/website/pull/85 : open source project fixed by this  PR

### This should probably merge in many branches
