### PR TITLE
Throw NotFoundHttpException when unknown resource owner is requested

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -257,7 +257,11 @@ class ConnectController extends Controller
      */
     public function redirectToServiceAction(Request $request, $service)
     {
-        $authorizationUrl = $this->container->get('hwi_oauth.security.oauth_utils')->getAuthorizationUrl($request, $service);
+        try {
+            $authorizationUrl = $this->container->get('hwi_oauth.security.oauth_utils')->getAuthorizationUrl($request, $service);
+        } catch (\RuntimeException $e) {
+            throw new NotFoundHttpException($e->getMessage(), $e);
+        }
 
         // Check for a return path and store it before redirect
         if ($request->hasSession()) {

--- a/Tests/Controller/ConnectControllerRedirectToServiceActionTest.php
+++ b/Tests/Controller/ConnectControllerRedirectToServiceActionTest.php
@@ -51,6 +51,9 @@ class ConnectControllerRedirectToServiceActionTest extends AbstractConnectContro
         $this->controller->redirectToServiceAction($this->request, 'facebook');
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
     public function testUnknownResourceOwner()
     {
         $this->oAuthUtils->expects($this->once())
@@ -62,7 +65,6 @@ class ConnectControllerRedirectToServiceActionTest extends AbstractConnectContro
             ->will($this->throwException(new \RuntimeException()))
         ;
 
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
         $this->controller->redirectToServiceAction($this->request, 'unknown');
     }
 }

--- a/Tests/Controller/ConnectControllerRedirectToServiceActionTest.php
+++ b/Tests/Controller/ConnectControllerRedirectToServiceActionTest.php
@@ -50,4 +50,19 @@ class ConnectControllerRedirectToServiceActionTest extends AbstractConnectContro
 
         $this->controller->redirectToServiceAction($this->request, 'facebook');
     }
+
+    public function testUnknownResourceOwner()
+    {
+        $this->oAuthUtils->expects($this->once())
+            ->method('getAuthorizationUrl')
+            ->with(
+                $this->isInstanceOf('Symfony\Component\HttpFoundation\Request'),
+                'unknown'
+            )
+            ->will($this->throwException(new \RuntimeException()))
+        ;
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->controller->redirectToServiceAction($this->request, 'unknown');
+    }
 }


### PR DESCRIPTION
Resolves issue: https://github.com/hwi/HWIOAuthBundle/issues/837

I wonder if we should be more precise, and instead of catching all RuntimeExceptions thrown, create a new UnknownResourceOwner exception for this specific problem.

Your call.