### PR TITLE
Do not reset the registration key on each view so that reload works

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -139,7 +139,6 @@ class ConnectController extends Controller
         }
 
         // reset the error in the session
-        $key = time();
         $session->set('_hwi_oauth.registration_error.'.$key, $error);
 
         return $this->render('HWIOAuthBundle:Connect:registration.html.'.$this->getTemplatingEngine(), array(

--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -101,8 +101,7 @@ class ConnectController extends Controller
         $error = $session->get('_hwi_oauth.registration_error.'.$key);
         $session->remove('_hwi_oauth.registration_error.'.$key);
 
-        if (!$error instanceof AccountNotLinkedException || time() - $key > 300) {
-            // todo: fix this
+        if (!$error instanceof AccountNotLinkedException) {
             throw new \Exception('Cannot register an account.', 0, $error instanceof \Exception ? $error : null);
         }
 


### PR DESCRIPTION
This fixes https://github.com/hwi/HWIOAuthBundle/issues/430 so that users can refresh the registration page without getting an error message. The downside is that because the key is a timestamp, the total time till completion is now 300 seconds - see https://github.com/hwi/HWIOAuthBundle/blob/master/Controller/ConnectController.php#L104. If we want to extend this period every time they submit the form I can add an additional expiration time.