### PR TITLE
Use paths from resource owner class

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -350,7 +350,7 @@ class Configuration implements ConfigurationInterface
                         ->validate()
                             ->ifTrue(function ($c) {
                                 // skip if this contains a service
-                                if (isset($c['service'])) {
+                                if (isset($c['service']) || isset($c['class'])) {
                                     return false;
                                 }
 

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -262,6 +262,22 @@ class HWIOAuthExtensionTest extends \PHPUnit_Framework_TestCase
         $loader->load(array($config), $this->containerBuilder);
     }
 
+    public function testConfigurationPassValidOAuth2WithClassOnly()
+    {
+        $loader = new HWIOAuthExtension();
+        $config = $this->getEmptyConfig();
+        $config['resource_owners'] = array(
+            'valid' => array(
+                'type'              => 'oauth2',
+                'class'             => 'HWI\Bundle\OAuthBundle\Tests\DependencyInjection\MyCustomProvider',
+                'client_id'         => 'client_id',
+                'client_secret'     => 'client_secret',
+            ),
+        );
+
+        $loader->load(array($config), $this->containerBuilder);
+    }
+
     public function testConfigurationPassValidOAuth2WithPathsAndClass()
     {
         $loader = new HWIOAuthExtension();


### PR DESCRIPTION
At the moment, `paths` must be configured for `oauth1`/`oauth2` resource owners even when a `class` is supplied and the paths are defined within this class. After applying this patch, resource owners with `class` can be configured the same way as other pre-defined types.