### PR TITLE
For invalid resource owner throw "not found" exception instead of runtime

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -22,7 +22,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AccountStatusException;
 use Symfony\Component\Security\Core\Security;
@@ -315,7 +314,7 @@ class ConnectController extends Controller
      *
      * @return ResourceOwnerInterface
      *
-     * @throws \RuntimeException if there is no resource owner with the given name
+     * @throws NotFoundHttpException if there is no resource owner with the given name
      */
     protected function getResourceOwnerByName($name)
     {
@@ -331,7 +330,7 @@ class ConnectController extends Controller
             }
         }
 
-        throw new \RuntimeException(sprintf("No resource owner with name '%s'.", $name));
+        throw new NotFoundHttpException(sprintf("No resource owner with name '%s'.", $name));
     }
 
     /**

--- a/Tests/Controller/AbstractConnectControllerTest.php
+++ b/Tests/Controller/AbstractConnectControllerTest.php
@@ -2,15 +2,27 @@
 
 namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 
+use HWI\Bundle\OAuthBundle\Connect\AccountConnectorInterface;
 use HWI\Bundle\OAuthBundle\Controller\ConnectController;
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
+use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
+use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
 
 abstract class AbstractConnectControllerTest extends TestCase
 {
@@ -20,62 +32,62 @@ abstract class AbstractConnectControllerTest extends TestCase
     protected $controller;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|AuthorizationCheckerInterface
      */
     protected $authorizationChecker;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|TokenStorageInterface
      */
     protected $tokenStorage;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|EngineInterface
      */
     protected $templating;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|RouterInterface
      */
     protected $router;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|ResourceOwnerMap
      */
     protected $resourceOwnerMap;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|ResourceOwnerInterface
      */
     protected $resourceOwner;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|AccountConnectorInterface
      */
     protected $accountConnector;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|OAuthUtils
      */
     protected $oAuthUtils;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|UserCheckerInterface
      */
     protected $userChecker;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|EventDispatcherInterface
      */
     protected $eventDispatcher;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|FormFactoryInterface
      */
     protected $formFactory;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|SessionInterface
      */
     protected $session;
 
@@ -99,34 +111,34 @@ abstract class AbstractConnectControllerTest extends TestCase
         $this->container->setParameter('hwi_oauth.firewall_names', array('default'));
         $this->container->setParameter('hwi_oauth.connect.confirmation', true);
 
-        $this->authorizationChecker = $this->getMockBuilder('\Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')
+        $this->authorizationChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->container->set('security.authorization_checker', $this->authorizationChecker);
 
-        $this->tokenStorage = $this->getMockBuilder('\Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')
+        $this->tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->container->set('security.token_storage', $this->tokenStorage);
 
-        $this->templating = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface')
+        $this->templating = $this->getMockBuilder(EngineInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->container->set('templating', $this->templating);
 
-        $this->router = $this->getMockBuilder('\Symfony\Component\Routing\RouterInterface')
+        $this->router = $this->getMockBuilder(RouterInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->container->set('router', $this->router);
 
-        $this->resourceOwner = $this->getMockBuilder('\HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface')
+        $this->resourceOwner = $this->getMockBuilder(ResourceOwnerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->resourceOwner->expects($this->any())
             ->method('getUserInformation')
             ->willReturn(new CustomUserResponse())
         ;
-        $this->resourceOwnerMap = $this->getMockBuilder('\HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap')
+        $this->resourceOwnerMap = $this->getMockBuilder(ResourceOwnerMap::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->resourceOwnerMap->expects($this->any())
@@ -135,32 +147,32 @@ abstract class AbstractConnectControllerTest extends TestCase
             ->willReturn($this->resourceOwner);
         $this->container->set('hwi_oauth.resource_ownermap.default', $this->resourceOwnerMap);
 
-        $this->accountConnector = $this->getMockBuilder('HWI\Bundle\OAuthBundle\Connect\AccountConnectorInterface')
+        $this->accountConnector = $this->getMockBuilder(AccountConnectorInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->container->set('hwi_oauth.account.connector', $this->accountConnector);
 
-        $this->oAuthUtils = $this->getMockBuilder('HWI\Bundle\OAuthBundle\Security\OAuthUtils')
+        $this->oAuthUtils = $this->getMockBuilder(OAuthUtils::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->container->set('hwi_oauth.security.oauth_utils', $this->oAuthUtils);
 
-        $this->userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')
+        $this->userChecker = $this->getMockBuilder(UserCheckerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->container->set('hwi_oauth.user_checker', $this->userChecker);
 
-        $this->eventDispatcher = $this->getMockBuilder('\Symfony\Component\EventDispatcher\EventDispatcherInterface')
+        $this->eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->container->set('event_dispatcher', $this->eventDispatcher);
 
-        $this->formFactory = $this->getMockBuilder('\Symfony\Component\Form\FormFactoryInterface')
+        $this->formFactory = $this->getMockBuilder(FormFactoryInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->container->set('form.factory', $this->formFactory);
 
-        $this->session = $this->getMockBuilder('\Symfony\Component\HttpFoundation\Session\SessionInterface')
+        $this->session = $this->getMockBuilder(SessionInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->request = Request::create('/');
@@ -184,26 +196,19 @@ abstract class AbstractConnectControllerTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function getAuthorizationChecker()
-    {
-        return $this->authorizationChecker;
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function getTokenStorage()
-    {
-        return $this->tokenStorage;
-    }
-
-    /**
      * @return string
      */
     protected function getAuthenticationErrorKey()
     {
         return Security::AUTHENTICATION_ERROR;
+    }
+
+    protected function mockAuthorizationCheck($granted = true)
+    {
+        $this->authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willReturn($granted)
+        ;
     }
 }

--- a/Tests/Controller/ConnectControllerConnectActionTest.php
+++ b/Tests/Controller/ConnectControllerConnectActionTest.php
@@ -26,16 +26,12 @@ class ConnectControllerConnectActionTest extends AbstractConnectControllerTest
             $this->getAuthenticationErrorKey() => $this->createAccountNotLinkedException(),
         ));
 
-        $this->getTokenStorage()->expects($this->once())
+        $this->tokenStorage->expects($this->once())
             ->method('getToken')
             ->willReturn(new CustomOAuthToken())
         ;
 
-        $this->getAuthorizationChecker()->expects($this->once())
-            ->method('isGranted')
-            ->with('IS_AUTHENTICATED_REMEMBERED')
-            ->willReturn(false)
-        ;
+        $this->mockAuthorizationCheck(false);
 
         $this->router->expects($this->once())
             ->method('generate')
@@ -52,12 +48,12 @@ class ConnectControllerConnectActionTest extends AbstractConnectControllerTest
             $this->getAuthenticationErrorKey() => $this->createAccountNotLinkedException(),
         ));
 
-        $this->getTokenStorage()->expects($this->once())
+        $this->tokenStorage->expects($this->once())
             ->method('getToken')
             ->willReturn(null)
         ;
 
-        $this->getAuthorizationChecker()->expects($this->never())
+        $this->authorizationChecker->expects($this->never())
             ->method('isGranted')
         ;
 

--- a/Tests/Controller/ConnectControllerConnectServiceActionTest.php
+++ b/Tests/Controller/ConnectControllerConnectServiceActionTest.php
@@ -3,6 +3,7 @@
 namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
+use Symfony\Component\Form\FormInterface;
 
 class ConnectControllerConnectServiceActionTest extends AbstractConnectControllerTest
 {
@@ -22,13 +23,21 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
      */
     public function testAlreadyConnected()
     {
-        $this->getAuthorizationChecker()->expects($this->once())
-            ->method('isGranted')
-            ->with('IS_AUTHENTICATED_REMEMBERED')
-            ->willReturn(false)
-        ;
+        $this->mockAuthorizationCheck(false);
 
         $this->controller->connectServiceAction($this->request, 'facebook');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function testUnknownResourceOwner()
+    {
+        $this->container->setParameter('hwi_oauth.firewall_names', []);
+
+        $this->mockAuthorizationCheck();
+
+        $this->controller->connectServiceAction($this->request, 'unknown');
     }
 
     public function testConnectConfirm()
@@ -37,11 +46,7 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
 
         $this->request->query->set('key', $key);
 
-        $this->getAuthorizationChecker()->expects($this->once())
-            ->method('isGranted')
-            ->with('IS_AUTHENTICATED_REMEMBERED')
-            ->willReturn(true)
-        ;
+        $this->mockAuthorizationCheck();
 
         $this->session->expects($this->once())
             ->method('get')
@@ -49,7 +54,7 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->willReturn(array())
         ;
 
-        $form = $this->getMockBuilder('\Symfony\Component\Form\FormInterface')
+        $form = $this->getMockBuilder(FormInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->formFactory->expects($this->once())
@@ -72,11 +77,7 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
         $this->request->query->set('key', $key);
         $this->request->setMethod('POST');
 
-        $this->getAuthorizationChecker()->expects($this->once())
-            ->method('isGranted')
-            ->with('IS_AUTHENTICATED_REMEMBERED')
-            ->willReturn(true)
-        ;
+        $this->mockAuthorizationCheck();
 
         $this->session->expects($this->once())
             ->method('get')
@@ -84,7 +85,7 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->willReturn(array())
         ;
 
-        $form = $this->getMockBuilder('\Symfony\Component\Form\FormInterface')
+        $form = $this->getMockBuilder(FormInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->formFactory->expects($this->once())
@@ -95,7 +96,7 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
         $form->expects($this->once())->method('isSubmitted')->willReturn(true);
         $form->expects($this->once())->method('isValid')->willReturn(true);
 
-        $this->getTokenStorage()->expects($this->once())
+        $this->tokenStorage->expects($this->once())
             ->method('getToken')
             ->willReturn(new CustomOAuthToken())
         ;
@@ -115,11 +116,7 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
         $this->request->query->set('key', $key);
         $this->container->setParameter('hwi_oauth.connect.confirmation', false);
 
-        $this->getAuthorizationChecker()->expects($this->once())
-            ->method('isGranted')
-            ->with('IS_AUTHENTICATED_REMEMBERED')
-            ->willReturn(true)
-        ;
+        $this->mockAuthorizationCheck();
 
         $this->session->expects($this->once())
             ->method('get')
@@ -127,7 +124,7 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->willReturn(array())
         ;
 
-        $this->getTokenStorage()->expects($this->once())
+        $this->tokenStorage->expects($this->once())
             ->method('getToken')
             ->willReturn(new CustomOAuthToken())
         ;
@@ -146,11 +143,7 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
 
         $this->request->query->set('key', $key);
 
-        $this->getAuthorizationChecker()->expects($this->once())
-            ->method('isGranted')
-            ->with('IS_AUTHENTICATED_REMEMBERED')
-            ->willReturn(true)
-        ;
+        $this->mockAuthorizationCheck();
 
         $this->resourceOwner->expects($this->once())
             ->method('handles')
@@ -162,7 +155,7 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->willReturn(array())
         ;
 
-        $form = $this->getMockBuilder('\Symfony\Component\Form\FormInterface')
+        $form = $this->getMockBuilder(FormInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->formFactory->expects($this->once())

--- a/Tests/Controller/ConnectControllerRedirectToServiceActionTest.php
+++ b/Tests/Controller/ConnectControllerRedirectToServiceActionTest.php
@@ -2,6 +2,9 @@
 
 namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
 class ConnectControllerRedirectToServiceActionTest extends AbstractConnectControllerTest
 {
     protected function setUp()
@@ -21,7 +24,7 @@ class ConnectControllerRedirectToServiceActionTest extends AbstractConnectContro
     {
         $response = $this->controller->redirectToServiceAction($this->request, 'facebook');
 
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals('http://domain.com/oauth/v2/auth', $response->getTargetUrl());
     }
 
@@ -59,7 +62,7 @@ class ConnectControllerRedirectToServiceActionTest extends AbstractConnectContro
         $this->oAuthUtils->expects($this->once())
             ->method('getAuthorizationUrl')
             ->with(
-                $this->isInstanceOf('Symfony\Component\HttpFoundation\Request'),
+                $this->isInstanceOf(Request::class),
                 'unknown'
             )
             ->will($this->throwException(new \RuntimeException()))

--- a/Tests/Controller/ConnectControllerRegistrationActionTest.php
+++ b/Tests/Controller/ConnectControllerRegistrationActionTest.php
@@ -2,7 +2,10 @@
 
 namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 
+use FOS\UserBundle\Form\Factory\FactoryInterface;
+use HWI\Bundle\OAuthBundle\Form\RegistrationFormHandlerInterface;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\User;
+use Symfony\Component\Form\Form;
 
 class ConnectControllerRegistrationActionTest extends AbstractConnectControllerTest
 {
@@ -22,11 +25,7 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
      */
     public function testAlreadyConnected()
     {
-        $this->getAuthorizationChecker()->expects($this->once())
-            ->method('isGranted')
-            ->with('IS_AUTHENTICATED_REMEMBERED')
-            ->willReturn(true)
-        ;
+        $this->mockAuthorizationCheck();
 
         $this->controller->registrationAction($this->request, time());
     }
@@ -60,7 +59,7 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
 
         $this->makeRegistrationForm();
 
-        $registrationFormHandler = $this->getMockBuilder('\HWI\Bundle\OAuthBundle\Form\RegistrationFormHandlerInterface')
+        $registrationFormHandler = $this->getMockBuilder(RegistrationFormHandlerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $registrationFormHandler->expects($this->once())
@@ -90,7 +89,7 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
 
         $this->makeRegistrationForm();
 
-        $registrationFormHandler = $this->getMockBuilder('\HWI\Bundle\OAuthBundle\Form\RegistrationFormHandlerInterface')
+        $registrationFormHandler = $this->getMockBuilder(RegistrationFormHandlerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $registrationFormHandler->expects($this->once())
@@ -113,7 +112,7 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
 
     private function makeRegistrationForm()
     {
-        $registrationForm = $this->getMockBuilder('\Symfony\Component\Form\Form')
+        $registrationForm = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
         $registrationForm->expects($this->any())
@@ -123,7 +122,7 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
         $this->container->setParameter('hwi_oauth.fosub_enabled', true);
 
         if (interface_exists('FOS\UserBundle\Form\Factory\FactoryInterface')) {
-            $registrationFormFactory = $this->getMockBuilder('FOS\UserBundle\Form\Factory\FactoryInterface')
+            $registrationFormFactory = $this->getMockBuilder(FactoryInterface::class)
                 ->disableOriginalConstructor()
                 ->getMock();
             $registrationFormFactory->expects($this->any())


### PR DESCRIPTION
Fixes #1144.
Replaces #1158.