### PR TITLE
Use automatic HTTP content decoding

### DIFF
--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -49,6 +49,7 @@ class HWIOAuthExtension extends Extension
         $httpClient->addMethodCall('setTimeout', array($config['http_client']['timeout']));
         $httpClient->addMethodCall('setMaxRedirects', array($config['http_client']['max_redirects']));
         $httpClient->addMethodCall('setIgnoreErrors', array($config['http_client']['ignore_errors']));
+        $httpClient->addMethodCall('setOption', array(CURLOPT_ENCODING, ''));
         if (isset($config['http_client']['proxy']) && $config['http_client']['proxy'] != '') {
             $httpClient->addMethodCall('setProxy', array($config['http_client']['proxy']));
         }

--- a/OAuth/ResourceOwner/StackExchangeResourceOwner.php
+++ b/OAuth/ResourceOwner/StackExchangeResourceOwner.php
@@ -37,21 +37,16 @@ class StackExchangeResourceOwner extends GenericOAuth2ResourceOwner
      */
     public function getUserInformation(array $accessToken, array $extraParameters = array())
     {
-        if (!extension_loaded('zlib')) {
-            throw new AuthenticationException('OAuth error: Stack Exchange resource owner requires zlib installed. See https://api.stackexchange.com/docs/compression for details.');
-        }
-
         $parameters = array_merge(
            array($this->options['attr_name'] => $accessToken['access_token']),
            array('site' => $this->options['site'], 'key' => $this->options['key']),
            $extraParameters
         );
 
-        $compressed = $this->doGetUserInformationRequest($this->normalizeUrl($this->options['infos_url'], $parameters));
-        $content = file_get_contents('compress.zlib://data:;base64,'.base64_encode($compressed->getContent()));
+        $content = $this->doGetUserInformationRequest($this->normalizeUrl($this->options['infos_url'], $parameters));
 
         $response = $this->getUserResponse();
-        $response->setData($content);
+        $response->setData($content->getContent());
         $response->setResourceOwner($this);
         $response->setOAuthToken(new OAuthToken($accessToken));
 


### PR DESCRIPTION
The Stack Exchange API [relies](https://api.stackexchange.com/docs/compression) on a HTTP client which is able to handle compressed (GZIP or DEFLATE) responses. After enabling automatic decoding in our cURL instance, the manual decoding is no longer needed.

After applying this patch, all tests should pass with HHVM.