### PR TITLE
Extend HttpTransportException from AuthenticationException

### DIFF
--- a/OAuth/Exception/HttpTransportException.php
+++ b/OAuth/Exception/HttpTransportException.php
@@ -11,7 +11,9 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\Exception;
 
-class HttpTransportException extends \RuntimeException
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+class HttpTransportException extends AuthenticationException
 {
     private $ownerName;
 


### PR DESCRIPTION
We have this problem: requests to oauth providers that fail, or timeout (see issue [655](https://github.com/hwi/HWIOAuthBundle/issues/655)) are thrown as **HttpTransportException** , which end up as uncaught exceptions.

This is a problem, because there's no way to retry the authentication, without messing up the generic error handling for our own, actual server exceptions (internal server error and such).

By extending from **Symfony\Component\Security\Core\Exception\AuthenticationException**,  those transport errors, when dealing with the oauth provider, are treated as authentication errors.

This allows, when a security **failure_path** is defined, to setup an specific authentication error, with a retry option if desired, instead of being redirected to a generic error page.

I'd like to discuss if this is a sensible approach, or maybe we missed something, when dealing with such errors.