### PR TITLE
Allow: private key usage without file

### DIFF
--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -225,7 +225,12 @@ class OAuthUtils
                     throw new \RuntimeException('RSA-SHA1 signature method requires the OpenSSL extension.');
                 }
 
-                $privateKey = openssl_pkey_get_private(file_get_contents($clientSecret), $tokenSecret);
+                if (strpos($clientSecret, '-----BEGIN') === 0) {
+                    $privateKey = openssl_pkey_get_private($clientSecret, $tokenSecret);
+                } else {
+                    $privateKey = openssl_pkey_get_private(file_get_contents($clientSecret), $tokenSecret);
+                }
+
                 $signature = false;
 
                 openssl_sign($baseString, $signature, $privateKey);


### PR DESCRIPTION
Hi,

we have the scenario where we dynamically generate private keys which we can't store in a file. Unfortunately this doesn't let us use the `RSA-SHA1` request signing as it expects to load the private key from file.

With this PR the private key can directly be passed as `$clientSecret` as an alternative I can also adjust the solution to pass in a `Resource` instead of a string?