### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ HWIOAuthBundle
 
 [![Build Status](https://secure.travis-ci.org/hwi/HWIOAuthBundle.svg?branch=master)](http://travis-ci.org/hwi/HWIOAuthBundle) [![Latest Stable Version](https://poser.pugx.org/hwi/oauth-bundle/v/stable.svg)](https://packagist.org/packages/hwi/oauth-bundle) [![Total Downloads](https://poser.pugx.org/hwi/oauth-bundle/downloads.svg)](https://packagist.org/packages/hwi/oauth-bundle) [![Latest Unstable Version](https://poser.pugx.org/hwi/oauth-bundle/v/unstable.svg)](https://packagist.org/packages/hwi/oauth-bundle) [![License](https://poser.pugx.org/hwi/oauth-bundle/license.svg)](https://packagist.org/packages/hwi/oauth-bundle)
 
-The HWIOAuthBundle adds support for authenticating users via OAuth1.0a or OAuth2 in Symfony2.
+The HWIOAuthBundle adds support for authenticating users via OAuth1.0a or OAuth2 in Symfony.
 
 This bundle contains support for 58 different providers:
 * 37signals,


### PR DESCRIPTION
Like many other bundles, we should just call it Symfony.