### PR TITLE
Removed FOSUserBundle dev dependency from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - php: 7.0
       env: SYMFONY_VERSION=3.0.*
     - php: 7.0
-      env: FOSUSERBUNDLE_VERSION=2.0.*@dev
+      env: FOSUSERBUNDLE_VERSION=2.0.*
   allow_failures:
     - php: hhvm
 


### PR DESCRIPTION
FOSUserBundle 2.0 is now final.