### PR TITLE
Fix #1240 - Missing array on Definition instanciation

### DIFF
--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -242,7 +242,7 @@ class HWIOAuthExtension extends Extension
                     new Definition(
                         GuzzleAdapter::class,
                         [
-                            new Definition(GuzzleClient::class, $guzzleConfig),
+                            new Definition(GuzzleClient::class, [$guzzleConfig]),
                         ]
                     ),
                     [

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -242,7 +242,7 @@ class HWIOAuthExtension extends Extension
                     new Definition(
                         GuzzleAdapter::class,
                         [
-                            new Definition(GuzzleClient::class, [$guzzleConfig]),
+                            new Definition(GuzzleClient::class, array($guzzleConfig)),
                         ]
                     ),
                     [


### PR DESCRIPTION
[Definition](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Definition.php#L52) takes arguments as an array.