### PR TITLE
Fix sensio resource owner

### DIFF
--- a/OAuth/ResourceOwner/SensioConnectResourceOwner.php
+++ b/OAuth/ResourceOwner/SensioConnectResourceOwner.php
@@ -26,7 +26,7 @@ class SensioConnectResourceOwner extends GenericOAuth2ResourceOwner
      */
     protected function doGetTokenRequest($url, array $parameters = array())
     {
-        return $this->httpRequest($this->options['access_token_url'], $parameters, array(), 'POST');
+        return $this->httpRequest($this->options['access_token_url'], $parameters, array('Content-Type' => 'application/x-www-form-urlencoded'), 'POST');
     }
 
     /**


### PR DESCRIPTION
It appear that sensio force the usage of the form data header. This
header is not automatically provided when you use an http client from
httplug, that's the reason why we need to specify it.

Without this fix, the SensioResourceOwner is not working as expected.