### PR TITLE
Add Content-Type header to OAuth2 calls.

### DIFF
--- a/DependencyInjection/CompilerPass/SetResourceOwnerServiceNameCompilerPass.php
+++ b/DependencyInjection/CompilerPass/SetResourceOwnerServiceNameCompilerPass.php
@@ -27,7 +27,7 @@ class SetResourceOwnerServiceNameCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         foreach (array_keys($container->getAliases()) as $alias) {
-            if (strpos($alias, 'hwi_oauth.resource_owner.') !== 0) {
+            if (0 !== strpos($alias, 'hwi_oauth.resource_owner.')) {
                 continue;
             }
 

--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -122,9 +122,9 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
 
         do {
             $user = $this->userManager->findUserByUsername($testName);
-        } while ($user !== null && $i < $this->iterations && $testName = $name.++$i);
+        } while (null !== $user && $i < $this->iterations && $testName = $name.++$i);
 
-        return $user !== null ? '' : $testName;
+        return null !== $user ? '' : $testName;
     }
 
     /**

--- a/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -170,7 +170,7 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
             throw new AuthenticationException(sprintf('OAuth error: "%s"', $response['oauth_problem']));
         }
 
-        if (isset($response['oauth_callback_confirmed']) && $response['oauth_callback_confirmed'] !== 'true') {
+        if (isset($response['oauth_callback_confirmed']) && 'true' !== $response['oauth_callback_confirmed']) {
             throw new AuthenticationException('Defined OAuth callback was not confirmed.');
         }
 

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -231,4 +231,14 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
 
         $resolver->setNormalizer('scope', $scopeNormalizer);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function httpRequest($url, $content = null, array $headers = [], $method = null)
+    {
+        $headers += array('Content-Type' => 'application/x-www-form-urlencoded');
+
+        return parent::httpRequest($url, $content, $headers, $method);
+    }
 }

--- a/Security/Core/User/OAuthUserProvider.php
+++ b/Security/Core/User/OAuthUserProvider.php
@@ -56,6 +56,6 @@ class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProvider
      */
     public function supportsClass($class)
     {
-        return $class === 'HWI\\Bundle\\OAuthBundle\\Security\\Core\\User\\OAuthUser';
+        return 'HWI\\Bundle\\OAuthBundle\\Security\\Core\\User\\OAuthUser' === $class;
     }
 }

--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -225,7 +225,7 @@ class OAuthUtils
                     throw new \RuntimeException('RSA-SHA1 signature method requires the OpenSSL extension.');
                 }
 
-                if (strpos($clientSecret, '-----BEGIN') === 0) {
+                if (0 === strpos($clientSecret, '-----BEGIN')) {
                     $privateKey = openssl_pkey_get_private($clientSecret, $tokenSecret);
                 } else {
                     $privateKey = openssl_pkey_get_private(file_get_contents($clientSecret), $tokenSecret);


### PR DESCRIPTION
Add the `Content-Type: application/x-www-form-urlencoded` header to all OAuth2 calls made via the GenericOAuth2ResourceOwner class. 
The need for this change was initially caused by errors when using the GoogleResourceOwner. Authentication attempts failed with the following error:
```
[2017-09-19 11:40:29] security.INFO: Authentication request failed. {"exception":"[object] (HWI\\Bundle\\OAuthBundle\\OAuth\\Exception\\HttpTransportException(code: 400): Error while sending HTTP request at {%project_path%}/vendor/hwi/oauth-bundle/OAuth/ResourceOwner/AbstractResourceOwner.php:266, 
Http\\Client\\Exception\\HttpException(code: 400): Client error: `POST https://accounts.google.com/o/oauth2/token` resulted in a `400 Bad Request` response:\n{\n  \"error\" : \"invalid_request\",\n  \"error_description\" : \"Missing header: Content-Type\"\n}\n at {%project_path%}/vendor/php-http/guzzle6-adapter/src/Promise.php:127, 
GuzzleHttp\\Exception\\ClientException(code: 400): Client error: `POST https://accounts.google.com/o/oauth2/token` resulted in a `400 Bad Request` response:\n{\n  \"error\" : \"invalid_request\",\n  \"error_description\" : \"Missing header: Content-Type\"\n}\n at {%project_path%}/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php:113)"} []
```
Looking at the [Google documentation on Oauth2 requests](https://developers.google.com/identity/protocols/OAuth2InstalledApp#exchange-authorization-code), they indeed require the Content-Type header to be set with a `application/x-www-form-urlencoded` value. 

Observing the [Oauth2 RFC specifications](https://tools.ietf.org/html/rfc6749#section-4.1.1) shows that the Content-Type: application/x-www-form-urlencoded is actually part of the Oauth2 RFC, and should be set on all Oauth2 request.

A recent [pull request has implemented this for the SensioResourceOwner](https://github.com/hwi/HWIOAuthBundle/commit/54d5975d0a774a56544867a36f214c9fed31da11). It should however be the default for all Oauth2 calls, and is therefore added to the `GenericOAuth2ResourceOwner` class.