### PR TITLE
Remove php-http/guzzle6-adapter from the prod dependencies

### DIFF
--- a/Resources/doc/1-setting_up_the_bundle.md
+++ b/Resources/doc/1-setting_up_the_bundle.md
@@ -6,6 +6,16 @@ Step 1: Setting up the bundle
 composer require hwi/oauth-bundle
 ```
 
+This bundle uses the [HTTPlug library](http://docs.php-http.org/en/latest/#httplug).
+
+If it is not already done, you must also require on of the
+[HTTPlug client's adapters](http://docs.php-http.org/en/latest/clients.html#clients-adapters).
+For example:
+
+```bash
+composer require php-http/guzzle6-adapter
+```
+
 ### B) Enable the bundle
 
 Enable the bundle in the kernel:

--- a/composer.json
+++ b/composer.json
@@ -105,8 +105,7 @@
         "php-http/httplug":               "^1.0",
         "php-http/client-common":         "^1.3",
         "php-http/message-factory":       "^1.0",
-        "php-http/discovery":             "^1.0",
-        "php-http/guzzle6-adapter":       "^1.1"
+        "php-http/discovery":             "^1.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
Closes #1268 

The client definition must be updated accordingly:

https://github.com/hwi/HWIOAuthBundle/blob/6676269decf7d123baca2c05a7c5d07abda0a05b/DependencyInjection/HWIOAuthExtension.php#L237-L260