### PR TITLE
HttplugBundle integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog
 =========
 ## 0.6.0 (2017-07-xx)
 * BC BREAK: Fully replaced Buzz library with usage of HTTPlug & Guzzle 6,
+* BC BREAK: `hwi.http_client` config options are remove. HTTP configuration must rely on the HTTPlug client,
+* Added: `php-http/httplug-bundle` support, to auto-provide needed HTTPlug services and get full Symfony integration,
+* Added: `hwi.http.client` and `hwi.http.message_factory` config keys to provide your own HTTPlug services,
 * Added: `HWIOAuthEvents`,
 * Added: `ResourceOwnerInterface::addPaths()` method for easier managing paths in resource owners,
 * Fixed: Update Facebook API to v2.8,

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -420,14 +420,11 @@ class Configuration implements ConfigurationInterface
     {
         $node
             ->children()
-                ->arrayNode('http_client')
+                ->arrayNode('http')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('timeout')->defaultValue(5)->cannotBeEmpty()->end()
-                        ->booleanNode('verify_peer')->defaultTrue()->end()
-                        ->scalarNode('max_redirects')->defaultValue(5)->cannotBeEmpty()->end()
-                        ->booleanNode('ignore_errors')->defaultTrue()->end()
-                        ->scalarNode('proxy')->end()
+                        ->scalarNode('client')->defaultValue('httplug.client.default')->end()
+                        ->scalarNode('message_factory')->defaultValue('httplug.message_factory.default')->end()
                     ->end()
                 ->end()
             ->end()

--- a/Resources/config/http_client.xml
+++ b/Resources/config/http_client.xml
@@ -6,8 +6,8 @@
 
     <services>
         <service id="hwi_oauth.http_client" class="Http\Client\Common\HttpMethodsClient">
-            <argument /> <!-- HttpClient for Httplug, managed by extension -->
-            <argument /> <!-- MessageFactory for Httplug, managed by extension -->
+            <argument type="service" id="hwi_oauth.http.client"/>
+            <argument type="service" id="hwi_oauth.http.message_factory"/>
         </service>
     </services>
 </container>

--- a/Resources/doc/1-setting_up_the_bundle.md
+++ b/Resources/doc/1-setting_up_the_bundle.md
@@ -3,8 +3,14 @@ Step 1: Setting up the bundle
 ### A) Add HWIOAuthBundle to your project
 
 ```bash
-composer require hwi/oauth-bundle
+composer require hwi/oauth-bundle php-http/guzzle6-adapter php-http/httplug-bundle
 ```
+
+Why `php-http/guzzle6-adapter`? We are decoupled from any HTTP messaging client with help by [HTTPlug](http://httplug.io/).
+
+Why `php-http/httplug-bundle`? This is the official [Symfony integration](https://packagist.org/packages/php-http/httplug-bundle) of HTTPlug.
+This permit to provide the required HTTP client and message factory with ease.
+The dependency is optional but you will have to [provide your own services](internals/configuring_the_http_client.md) if you don't setup it.
 
 ### B) Enable the bundle
 
@@ -17,10 +23,15 @@ public function registerBundles()
 {
     $bundles = array(
         // ...
+        new Http\HttplugBundle\HttplugBundle(), // If you require the php-http/httplug-bundle package.
         new HWI\Bundle\OAuthBundle\HWIOAuthBundle(),
     );
 }
 ```
+
+Configure at least one httplug client from `HttplugBundle`. The default one will be use if not specified.
+
+See the [vendor documentation](http://docs.php-http.org/en/latest/integrations/symfony-bundle.html#installation) for mor information.
 
 ### C) Import the routing
 

--- a/Resources/doc/internals/configuring_the_http_client.md
+++ b/Resources/doc/internals/configuring_the_http_client.md
@@ -1,24 +1,30 @@
 Internals: Configuring the HTTP Client
 ======================================
 As you already noticed, HWIOAuthBundle depends on [Httplug](http://httplug.io)
-a lightweight library for issuing HTTP requests. This library is used by every of the resource
-owners, it's pre-configured by default, but you can adjust some settings of this library to
-reflect requirements of your environment.
+a lightweight library for issuing HTTP requests.
+
+The HTTP client configuration does now directly rely on HttplugBundle if installed.
+You can see all configuration options and plugins on the
+[vendor documentation](http://docs.php-http.org/en/latest/integrations/symfony-bundle.html#usage).
+
+If you want to use a different Httplug client/factory than the default one(s), you can specify it:
 
 ```yaml
 # app/config/config.yml
 
+httplug:
+    clients:
+        default:
+            factory: 'httplug.factory.curl'
+        hwi_special:
+            factory: 'httplug.factory.guzzle6'
+
 hwi_oauth:
-    http_client:
-        timeout:       10 # Time in seconds, after library will shutdown request, by default: 5
-        verify_peer:   false # Setting allowing you to turn off SSL verification, by default: true
-        ignore_errors: false # Setting allowing you to easier debug request errors, by default: true
-        max_redirects: 1 # Number of HTTP redirection request after which library will shutdown request,
-                         # by default: 5
-        proxy: "example.com:8080" # String with proxy configuration for cURL connections, ignored by default.
-                                    # "" -> don't set proxy and will use proxy system
-                                    # "example.com:8080" -> set custom proxy
-                                    # ":" -> disable proxy usage, ignoring also proxy system and ENVIRONMENT variables
+    http:
+        client: httplug.client.hwi_special # Default to httplug.client.default
+        factory: httplug.stream_factory    # Default to httplug.message_factory.default
 ```
+
+If you don't want to use the HTTPlug Bundle, the client and factory services **must be specified**.
 
 [Return to the index.](../index.md)

--- a/Resources/doc/internals/reference_configuration.md
+++ b/Resources/doc/internals/reference_configuration.md
@@ -89,13 +89,6 @@ hwi_oauth:
 #        registration_form: my_registration_form
 #        account_connector: my_link_provider # can be the same as your user provider
 
-    # optional HTTP Client configuration
-    http_client:
-        timeout:       5
-        verify_peer:   true
-        ignore_errors: true
-        max_redirects: 5
-
     # allows to switch templating engine for bundle views
     #templating_engine: "php"
 

--- a/Resources/doc/resource_owners/fiware.md
+++ b/Resources/doc/resource_owners/fiware.md
@@ -18,6 +18,14 @@ If you are using the FI-WARE Lab Cloud you will have to increase the timeout for
 ```yaml
 # app/config/config.yml
 
+# With php-http/httplug-bundle
+httplug:
+    clients:
+        default:
+            factory: 'httplug.factory.guzzle6'
+            config:
+                timeout: 15
+
 hwi_oauth:
     resource_owners:
         any_name:
@@ -25,8 +33,6 @@ hwi_oauth:
             base_url:            <base_url>
             client_id:           <client_id>
             client_secret:       <client_secret>
-    http_client:
-            timeout:             15
 ```
 
 When you're done. Continue by configuring the security layer or go back to

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Tests\DependencyInjection;
 
 use Http\Client\Common\HttpMethodsClient;
+use Http\HttplugBundle\HttplugBundle;
 use HWI\Bundle\OAuthBundle\DependencyInjection\HWIOAuthExtension;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -688,6 +689,10 @@ EOF;
         parent::setUp();
 
         $this->containerBuilder = new ContainerBuilder();
+
+        $this->containerBuilder->setParameter('kernel.bundles', [
+            'HttplugBundle' => new HttplugBundle(),
+        ]);
     }
 
     protected function tearDown()

--- a/composer.json
+++ b/composer.json
@@ -105,8 +105,7 @@
         "php-http/httplug":               "^1.0",
         "php-http/client-common":         "^1.3",
         "php-http/message-factory":       "^1.0",
-        "php-http/discovery":             "^1.0",
-        "php-http/guzzle6-adapter":       "^1.1"
+        "php-http/discovery":             "^1.0"
     },
 
     "require-dev": {
@@ -117,6 +116,7 @@
         "symfony/stopwatch":            "^2.7|^3.0|^4.0",
         "symfony/phpunit-bridge":       "^2.7|^3.0|^4.0",
         "friendsofsymfony/user-bundle": "^1.3|^2.0",
+        "php-http/httplug-bundle":      "^1.7",
         "phpunit/phpunit":              "^5.7",
         "friendsofphp/php-cs-fixer":    "^2.0"
     },
@@ -128,6 +128,7 @@
     "suggest": {
         "doctrine/doctrine-bundle":     "to use Doctrine user provider",
         "friendsofsymfony/user-bundle": "to connect FOSUB with this bundle",
+        "php-http/httplug-bundle":      "to provide required HTTP client with ease.",
         "symfony/property-access":      "to use FOSUB integration with this bundle",
         "symfony/twig-bundle":          "to use the Twig hwi_oauth_* functions"
     },


### PR DESCRIPTION
Closes #1267
Fixes #1269 

- [x] Bundle default client injection
- [x] Client and message factory config option
- [x] Changelog note about `http_client` options removal. HTTP request configuration must rely on httplug configuration and plugin(s).
- [x] Make the bundle option
- [x] Update doc because of the optional bundle requirement
- [x] Fix the tests