### PR TITLE
Improvements for Twig template support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,14 @@ matrix:
       env: SYMFONY_VERSION=3.0.*
     - php: 7.0
       env: FOSUSERBUNDLE_VERSION=2.0.*
-    - php: 7.0
+    - php: 7.1
       env: TARGET=csfixer_dry_run
   allow_failures:
     - php: nightly
 
 before_install:
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi;
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
+  - phpenv config-rm xdebug.ini || echo "xdebug not available";
+  - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini;
 
 before_script:
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --dev --no-update; fi;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 ## 0.6.0 (2017-07-xx)
 * BC BREAK: Fully replaced Buzz library with usage of HTTPlug & Guzzle 6,
 * BC BREAK: `hwi.http_client` config options are remove. HTTP configuration must rely on the HTTPlug client,
+* BC BREAK: Template engine other than Twig are no longer supported,
+* BC BREAK: Option `hwi_oauth.templating_engine` was removed,
 * Added: `php-http/httplug-bundle` support, to auto-provide needed HTTPlug services and get full Symfony integration,
 * Added: `hwi.http.client` and `hwi.http.message_factory` config keys to provide your own HTTPlug services,
 * Added: `HWIOAuthEvents`,

--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -74,7 +74,7 @@ class ConnectController extends Controller
             }
         }
 
-        return $this->render('HWIOAuthBundle:Connect:login.html.'.$this->getTemplatingEngine(), array(
+        return $this->render('@HWIOAuth/Connect/login.html.twig', array(
             'error' => $error,
         ));
     }
@@ -143,7 +143,7 @@ class ConnectController extends Controller
                 if ($targetPath = $this->getTargetPath($session)) {
                     $response = $this->redirect($targetPath);
                 } else {
-                    $response = $this->render('HWIOAuthBundle:Connect:registration_success.html.'.$this->getTemplatingEngine(), array(
+                    $response = $this->render('@HWIOAuth/Connect/registration_success.html.twig', array(
                         'userInformation' => $userInformation,
                     ));
                 }
@@ -165,7 +165,7 @@ class ConnectController extends Controller
             return $response;
         }
 
-        return $this->render('HWIOAuthBundle:Connect:registration.html.'.$this->getTemplatingEngine(), array(
+        return $this->render('@HWIOAuth/Connect/registration.html.twig', array(
             'key' => $key,
             'form' => $form->createView(),
             'userInformation' => $userInformation,
@@ -250,7 +250,7 @@ class ConnectController extends Controller
             return $response;
         }
 
-        return $this->render('HWIOAuthBundle:Connect:connect_confirm.html.'.$this->getTemplatingEngine(), array(
+        return $this->render('@HWIOAuth/Connect/connect_confirm.html.twig', array(
             'key' => $key,
             'service' => $service,
             'form' => $form->createView(),
@@ -406,16 +406,6 @@ class ConnectController extends Controller
     }
 
     /**
-     * Returns templating engine name.
-     *
-     * @return string
-     */
-    protected function getTemplatingEngine()
-    {
-        return $this->container->getParameter('hwi_oauth.templating.engine');
-    }
-
-    /**
      * @param SessionInterface $session
      *
      * @return string|null
@@ -472,7 +462,7 @@ class ConnectController extends Controller
             if ($targetPath = $this->getTargetPath($request->getSession())) {
                 $response = $this->redirect($targetPath);
             } else {
-                $response = $this->render('HWIOAuthBundle:Connect:connect_success.html.'.$this->getTemplatingEngine(), array(
+                $response = $this->render('@HWIOAuth/Connect/connect_success.html.twig', array(
                     'userInformation' => $userInformation,
                     'service' => $service,
                 ));

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -158,7 +158,6 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('target_path_parameter')->defaultNull()->end()
                 ->booleanNode('use_referer')->defaultFalse()->end()
                 ->booleanNode('failed_use_referer')->defaultFalse()->end()
-                ->scalarNode('templating_engine')->defaultValue('twig')->end()
                 ->scalarNode('failed_auth_path')->defaultValue('hwi_oauth_connect')->end()
                 ->scalarNode('grant_rule')
                     ->defaultValue('IS_AUTHENTICATED_REMEMBERED')

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -88,8 +88,6 @@ class HWIOAuthExtension extends Extension
 
         $this->createConnectIntegration($container, $config);
 
-        $container->setParameter('hwi_oauth.templating.engine', $config['templating_engine']);
-
         $container->setAlias('hwi_oauth.user_checker', 'security.user_checker');
     }
 

--- a/Resources/views/Connect/connect_confirm.html.twig
+++ b/Resources/views/Connect/connect_confirm.html.twig
@@ -1,4 +1,4 @@
-{% extends 'HWIOAuthBundle::layout.html.twig' %}
+{% extends '@HWIOAuth/layout.html.twig' %}
 
 {% block hwi_oauth_content %}
     <h3>{{ 'header.connecting' | trans({}, 'HWIOAuthBundle')}}</h3>

--- a/Resources/views/Connect/connect_success.html.twig
+++ b/Resources/views/Connect/connect_success.html.twig
@@ -1,4 +1,4 @@
-{% extends 'HWIOAuthBundle::layout.html.twig' %}
+{% extends '@HWIOAuth/layout.html.twig' %}
 
 {% block hwi_oauth_content %}
     <h3>{{ 'header.success' | trans({'%name%': userInformation.realName}, 'HWIOAuthBundle') }}</h3>

--- a/Resources/views/Connect/login.html.twig
+++ b/Resources/views/Connect/login.html.twig
@@ -1,4 +1,4 @@
-{% extends 'HWIOAuthBundle::layout.html.twig' %}
+{% extends '@HWIOAuth/layout.html.twig' %}
 
 {% block hwi_oauth_content %}
     {% if error is defined and error %}

--- a/Resources/views/Connect/registration.html.twig
+++ b/Resources/views/Connect/registration.html.twig
@@ -1,4 +1,4 @@
-{% extends 'HWIOAuthBundle::layout.html.twig' %}
+{% extends '@HWIOAuth/layout.html.twig' %}
 
 {% block hwi_oauth_content %}
     <h3>{{ 'header.register' | trans({'%name%': userInformation.realName}, 'HWIOAuthBundle') }}</h3>

--- a/Resources/views/Connect/registration_success.html.twig
+++ b/Resources/views/Connect/registration_success.html.twig
@@ -1,4 +1,4 @@
-{% extends 'HWIOAuthBundle::layout.html.twig' %}
+{% extends '@HWIOAuth/layout.html.twig' %}
 
 {% block hwi_oauth_content %}
     <h3>{{ 'header.registration_success' | trans({'%username%': app.user.username}, 'HWIOAuthBundle') }}</h3>

--- a/Tests/Controller/AbstractConnectControllerTest.php
+++ b/Tests/Controller/AbstractConnectControllerTest.php
@@ -19,7 +19,6 @@ use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -32,6 +31,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Templating\EngineInterface;
 
 abstract class AbstractConnectControllerTest extends TestCase
 {
@@ -53,7 +53,7 @@ abstract class AbstractConnectControllerTest extends TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|EngineInterface
      */
-    protected $templating;
+    protected $twig;
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|RouterInterface
@@ -115,7 +115,6 @@ abstract class AbstractConnectControllerTest extends TestCase
         parent::setUp();
 
         $this->container = new Container();
-        $this->container->setParameter('hwi_oauth.templating.engine', 'twig');
         $this->container->setParameter('hwi_oauth.connect', true);
         $this->container->setParameter('hwi_oauth.firewall_names', array('default'));
         $this->container->setParameter('hwi_oauth.connect.confirmation', true);
@@ -131,10 +130,10 @@ abstract class AbstractConnectControllerTest extends TestCase
             ->getMock();
         $this->container->set('security.token_storage', $this->tokenStorage);
 
-        $this->templating = $this->getMockBuilder(EngineInterface::class)
+        $this->twig = $this->getMockBuilder(EngineInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->container->set('templating', $this->templating);
+        $this->container->set('twig', $this->twig);
 
         $this->router = $this->getMockBuilder(RouterInterface::class)
             ->disableOriginalConstructor()

--- a/Tests/Controller/ConnectControllerConnectActionTest.php
+++ b/Tests/Controller/ConnectControllerConnectActionTest.php
@@ -21,9 +21,9 @@ class ConnectControllerConnectActionTest extends AbstractConnectControllerTest
     {
         $this->container->setParameter('hwi_oauth.connect', true);
 
-        $this->templating->expects($this->once())
-            ->method('renderResponse')
-            ->with('HWIOAuthBundle:Connect:login.html.twig')
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with('@HWIOAuth/Connect/login.html.twig')
         ;
 
         $this->controller->connectAction($this->request);
@@ -81,9 +81,9 @@ class ConnectControllerConnectActionTest extends AbstractConnectControllerTest
             $this->getAuthenticationErrorKey() => new AccessDeniedException('You shall not pass the request.'),
         ));
 
-        $this->templating->expects($this->once())
-            ->method('renderResponse')
-            ->with('HWIOAuthBundle:Connect:login.html.twig', array('error' => 'You shall not pass the request.'))
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with('@HWIOAuth/Connect/login.html.twig', array('error' => 'You shall not pass the request.'))
         ;
 
         $this->controller->connectAction($this->request);
@@ -103,9 +103,9 @@ class ConnectControllerConnectActionTest extends AbstractConnectControllerTest
             ->willReturn(new AccessDeniedException('You shall not pass the session.'))
         ;
 
-        $this->templating->expects($this->once())
-            ->method('renderResponse')
-            ->with('HWIOAuthBundle:Connect:login.html.twig', array('error' => 'You shall not pass the session.'))
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with('@HWIOAuth/Connect/login.html.twig', array('error' => 'You shall not pass the session.'))
         ;
 
         $this->controller->connectAction($this->request);

--- a/Tests/Controller/ConnectControllerConnectServiceActionTest.php
+++ b/Tests/Controller/ConnectControllerConnectServiceActionTest.php
@@ -14,7 +14,6 @@ namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 use HWI\Bundle\OAuthBundle\HWIOAuthEvents;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\HttpFoundation\Response;
 
 class ConnectControllerConnectServiceActionTest extends AbstractConnectControllerTest
 {
@@ -84,9 +83,9 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->with(HWIOAuthEvents::CONNECT_INITIALIZE)
         ;
 
-        $this->templating->expects($this->once())
-            ->method('renderResponse')
-            ->with('HWIOAuthBundle:Connect:connect_confirm.html.twig')
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with('@HWIOAuth/Connect/connect_confirm.html.twig')
         ;
 
         $this->controller->connectServiceAction($this->request, 'facebook');
@@ -133,14 +132,12 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->with(HWIOAuthEvents::CONNECT_COMPLETED)
         ;
 
-        $response = new Response();
-        $this->templating->expects($this->once())
-            ->method('renderResponse')
-            ->with('HWIOAuthBundle:Connect:connect_success.html.twig')
-            ->willReturn($response)
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with('@HWIOAuth/Connect/connect_success.html.twig')
         ;
 
-        $this->assertSame($response, $this->controller->connectServiceAction($this->request, 'facebook'));
+        $this->controller->connectServiceAction($this->request, 'facebook');
     }
 
     public function testConnectNoConfirmation()
@@ -173,14 +170,12 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->with(HWIOAuthEvents::CONNECT_COMPLETED)
         ;
 
-        $response = new Response();
-        $this->templating->expects($this->once())
-            ->method('renderResponse')
-            ->with('HWIOAuthBundle:Connect:connect_success.html.twig')
-            ->willReturn($response)
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with('@HWIOAuth/Connect/connect_success.html.twig')
         ;
 
-        $this->assertSame($response, $this->controller->connectServiceAction($this->request, 'facebook'));
+        $this->controller->connectServiceAction($this->request, 'facebook');
     }
 
     public function testResourceOwnerHandle()
@@ -214,9 +209,9 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->willReturn($form)
         ;
 
-        $this->templating->expects($this->once())
-            ->method('renderResponse')
-            ->with('HWIOAuthBundle:Connect:connect_confirm.html.twig')
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with('@HWIOAuth/Connect/connect_confirm.html.twig')
         ;
 
         $this->controller->connectServiceAction($this->request, 'facebook');

--- a/Tests/Controller/ConnectControllerRegistrationActionTest.php
+++ b/Tests/Controller/ConnectControllerRegistrationActionTest.php
@@ -16,7 +16,6 @@ use HWI\Bundle\OAuthBundle\Form\RegistrationFormHandlerInterface;
 use HWI\Bundle\OAuthBundle\HWIOAuthEvents;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\User;
 use Symfony\Component\Form\Form;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\SecurityEvents;
 
 class ConnectControllerRegistrationActionTest extends AbstractConnectControllerTest
@@ -97,9 +96,9 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
             ->with(HWIOAuthEvents::REGISTRATION_INITIALIZE)
         ;
 
-        $this->templating->expects($this->once())
-            ->method('renderResponse')
-            ->with('HWIOAuthBundle:Connect:registration.html.twig')
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with('@HWIOAuth/Connect/registration.html.twig')
         ;
 
         $this->controller->registrationAction($this->request, $key);
@@ -147,14 +146,12 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
             ->with(HWIOAuthEvents::REGISTRATION_COMPLETED)
         ;
 
-        $response = new Response();
-        $this->templating->expects($this->once())
-            ->method('renderResponse')
-            ->with('HWIOAuthBundle:Connect:registration_success.html.twig')
-            ->willReturn($response)
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with('@HWIOAuth/Connect/registration_success.html.twig')
         ;
 
-        $this->assertSame($response, $this->controller->registrationAction($this->request, $key));
+        $this->controller->registrationAction($this->request, $key);
     }
 
     private function makeRegistrationForm()

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -399,8 +399,6 @@ class HWIOAuthExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertParameter(false, 'hwi_oauth.connect');
 
-        $this->assertParameter('twig', 'hwi_oauth.templating.engine');
-
         $this->assertAlias('security.user_checker', 'hwi_oauth.user_checker');
     }
 


### PR DESCRIPTION
Replace deprecated Twig namespaced template paths with correct approach.

Removed support for different template engine than Twig.

Closes #1260, #1278