### PR TITLE
Using submit instead of handleRequest

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -237,7 +237,7 @@ class ConnectController extends Controller
             ? $this->createForm(FormType::class)
             : $this->createForm('form');
         // Handle the form
-        $form->handleRequest($request);
+        $form->submit($request->request->all());
 
         if ($form->isSubmitted() && $form->isValid()) {
             return $this->getConfirmationResponse($request, $accessToken, $service);


### PR DESCRIPTION
Using handleRequest can create issues because we don't send any data, and the form doesn't get submitted.