### PR TITLE
Fixes wrong variable and sets created at timestamp

### DIFF
--- a/OAuth/ResourceOwnerInterface.php
+++ b/OAuth/ResourceOwnerInterface.php
@@ -109,4 +109,10 @@ interface ResourceOwnerInterface
      * @param array $paths
      */
     public function addPaths(array $paths);
+
+    /**
+     * @param string $refreshToken    Refresh token
+     * @param array  $extraParameters An array of parameters to add to the url
+     */
+    public function refreshAccessToken($refreshToken, array $extraParameters = []);
 }

--- a/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -107,11 +107,12 @@ class OAuthProvider implements AuthenticationProviderInterface
         $this->userChecker->checkPreAuth($user);
         $this->userChecker->checkPostAuth($user);
 
-        $token = new OAuthToken($token->getRawToken(), $user->getRoles());
+        $token = new OAuthToken($oldToken->getRawToken(), $user->getRoles());
         $token->setResourceOwnerName($resourceOwner->getName());
         $token->setUser($user);
         $token->setAuthenticated(true);
         $token->setRefreshToken($oldToken->getRefreshToken());
+        $token->setCreatedAt($oldToken->getCreatedAt());
 
         return $token;
     }

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -56,6 +56,10 @@ class MyCustomProvider implements ResourceOwnerInterface
     public function addPaths(array $paths)
     {
     }
+
+    public function refreshAccessToken($refreshToken, array $extraParameters = array())
+    {
+    }
 }
 
 /**

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -246,14 +246,14 @@ class OAuthProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testTokenRefreshesWhenExpired()
     {
-        $expectedToken = array(
+        $expiredToken = array(
             'access_token' => 'access_token',
             'refresh_token' => 'refresh_token',
             'expires_in' => '666',
             'oauth_token_secret' => 'secret',
         );
 
-        $newToken = array(
+        $refreshedToken = array(
             'access_token' => 'access_token_new',
             'refresh_token' => 'refresh_token',
             'expires_in' => '666_new',
@@ -269,16 +269,16 @@ class OAuthProviderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('github'));
         $oauthTokenMock->expects($this->exactly(2))
             ->method('getRefreshToken')
-            ->willReturn($expectedToken['refresh_token']);
+            ->willReturn($expiredToken['refresh_token']);
 
         $resourceOwnerMock = $this->getResourceOwnerMock();
         $resourceOwnerMock->expects($this->once())
             ->method('refreshAccessToken')
-            ->with($expectedToken['refresh_token'])
-            ->willReturn($newToken);
+            ->with($expiredToken['refresh_token'])
+            ->willReturn($refreshedToken);
         $resourceOwnerMock->expects($this->once())
             ->method('getUserInformation')
-            ->with($newToken)
+            ->with($refreshedToken)
             ->will($this->returnValue($this->getUserResponseMock()));
         $resourceOwnerMock->expects($this->once())
             ->method('getName')
@@ -317,11 +317,11 @@ class OAuthProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($token->isAuthenticated());
         $this->assertInstanceOf(OAuthToken::class, $token);
 
-        $this->assertEquals($newToken, $token->getRawToken());
-        $this->assertEquals($newToken['access_token'], $token->getAccessToken());
-        $this->assertEquals($newToken['refresh_token'], $token->getRefreshToken());
-        $this->assertEquals($newToken['expires_in'], $token->getExpiresIn());
-        $this->assertEquals($newToken['oauth_token_secret'], $token->getTokenSecret());
+        $this->assertEquals($refreshedToken, $token->getRawToken());
+        $this->assertEquals($refreshedToken['access_token'], $token->getAccessToken());
+        $this->assertEquals($refreshedToken['refresh_token'], $token->getRefreshToken());
+        $this->assertEquals($refreshedToken['expires_in'], $token->getExpiresIn());
+        $this->assertEquals($refreshedToken['oauth_token_secret'], $token->getTokenSecret());
         $this->assertEquals($userMock, $token->getUser());
         $this->assertEquals('github', $token->getResourceOwnerName());
 

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -243,4 +243,90 @@ class OAuthProviderTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
     }
+
+    public function testTokenRefreshesWhenExpired()
+    {
+        $expectedToken = array(
+            'access_token' => 'access_token',
+            'refresh_token' => 'refresh_token',
+            'expires_in' => '666',
+            'oauth_token_secret' => 'secret',
+        );
+
+        $newToken = array(
+            'access_token' => 'access_token_new',
+            'refresh_token' => 'refresh_token',
+            'expires_in' => '666_new',
+            'oauth_token_secret' => 'secret_new',
+        );
+
+        $oauthTokenMock = $this->getOAuthTokenMock();
+        $oauthTokenMock->expects($this->once())
+            ->method('isExpired')
+            ->willReturn(true);
+        $oauthTokenMock->expects($this->exactly(2))
+            ->method('getResourceOwnerName')
+            ->will($this->returnValue('github'));
+        $oauthTokenMock->expects($this->exactly(2))
+            ->method('getRefreshToken')
+            ->willReturn($expectedToken['refresh_token']);
+
+        $resourceOwnerMock = $this->getResourceOwnerMock();
+        $resourceOwnerMock->expects($this->once())
+            ->method('refreshAccessToken')
+            ->with($expectedToken['refresh_token'])
+            ->willReturn($newToken);
+        $resourceOwnerMock->expects($this->once())
+            ->method('getUserInformation')
+            ->with($newToken)
+            ->will($this->returnValue($this->getUserResponseMock()));
+        $resourceOwnerMock->expects($this->once())
+            ->method('getName')
+            ->will($this->returnValue('github'));
+
+        $resourceOwnerMapMock = $this->getResourceOwnerMapMock();
+        $resourceOwnerMapMock->expects($this->once())
+            ->method('getResourceOwnerByName')
+            ->with($this->equalTo('github'))
+            ->will($this->returnValue($resourceOwnerMock));
+        $resourceOwnerMapMock->expects($this->once())
+            ->method('hasResourceOwnerByName')
+            ->with($this->equalTo('github'))
+            ->will($this->returnValue(true));
+
+        $userMock = $this->getUserMock();
+        $userMock->expects($this->once())
+            ->method('getRoles')
+            ->will($this->returnValue(array('ROLE_TEST')));
+
+        $userProviderMock = $this->getOAuthAwareUserProviderMock();
+        $userProviderMock->expects($this->once())
+            ->method('loadUserByOAuthUserResponse')
+            ->will($this->returnValue($userMock));
+
+        $userCheckerMock = $this->getUserCheckerMock();
+        $userCheckerMock->expects($this->once())
+            ->method('checkPostAuth')
+            ->with($userMock);
+
+        $tokenStorageMock = $this->getTokenStorageMock();
+
+        $oauthProvider = new OAuthProvider($userProviderMock, $resourceOwnerMapMock, $userCheckerMock, $tokenStorageMock);
+
+        $token = $oauthProvider->authenticate($oauthTokenMock);
+        $this->assertTrue($token->isAuthenticated());
+        $this->assertInstanceOf(OAuthToken::class, $token);
+
+        $this->assertEquals($newToken, $token->getRawToken());
+        $this->assertEquals($newToken['access_token'], $token->getAccessToken());
+        $this->assertEquals($newToken['refresh_token'], $token->getRefreshToken());
+        $this->assertEquals($newToken['expires_in'], $token->getExpiresIn());
+        $this->assertEquals($newToken['oauth_token_secret'], $token->getTokenSecret());
+        $this->assertEquals($userMock, $token->getUser());
+        $this->assertEquals('github', $token->getResourceOwnerName());
+
+        $roles = $token->getRoles();
+        $this->assertCount(1, $roles);
+        $this->assertEquals('ROLE_TEST', $roles[0]->getRole());
+    }
 }


### PR DESCRIPTION
getRawToken method being called from wrong token object.
Sets created at timestamp as isExpired method was always returning false.