### PR TITLE
Add fixXmlConfig for firewall names

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -149,6 +149,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode = $builder->root('hwi_oauth');
         $rootNode
+            ->fixXmlConfig('firewall_name')
             ->children()
                 ->arrayNode('firewall_names')
                     ->isRequired()


### PR DESCRIPTION
We recently run into the problem to have just one firewall configured in our project and using xml as format for consistency.
To avoid running into the string vs. array problem if just one element available in xml we had to add the fixXmlConfig for the firewall_names property.