### PR TITLE
Allows overriding resource owner options by using values in session

### DIFF
--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -112,6 +112,18 @@ class OAuthUtils
             }
         }
 
+        // grab extra parameters from session
+
+        if ($request->hasSession()) {
+            // initialize the session for preventing SessionUnavailableException
+            $session = $request->getSession();
+            $session->start();
+            $sessionKey = "_security.$name.parameters";
+            $extraSessionParameters = $session->get($sessionKey, []);
+            $extraParameters = array_merge($extraParameters, $extraSessionParameters);
+            $session->remove($sessionKey);
+        }
+
         return $resourceOwner->getAuthorizationUrl($redirectUrl, $extraParameters);
     }
 


### PR DESCRIPTION
Hello!

When working with some OAuth providers, we've realised that some scenarios need the set of extra parameters to the authorization URL. One example: using Google as a provider, to ensure the retrieval of a new refresh token it is needed to set an extra parameter named `approval_prompt` with the value `force` in the authorization URL. We couldn't find any way to handle this scenario in the library, so we've developed the proposed solution.

The idea is to set those extra parameters in the session so the AuthBundle could add them in the `getAuthorizationUrl` method. 

For example, this is how we set the `approval_prompt` parameter in our code:

```php
$authOptions = ['approval_prompt' => 'force'];
$request->getSession()->set('_security.google.parameters', $authOptions);
```

Before completing the PR (I suppose I need to complete tests and documentation), what do you think about the proposed solution? Are we missing something in the library which let us to these extra parameters in the authorization URL?