### PR TITLE
Implemented getUserInformation for Dropbox v2

### DIFF
--- a/OAuth/ResourceOwner/DropboxResourceOwner.php
+++ b/OAuth/ResourceOwner/DropboxResourceOwner.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -26,10 +27,10 @@ class DropboxResourceOwner extends GenericOAuth2ResourceOwner
      * {@inheritdoc}
      */
     protected $paths = array(
-      'identifier' => 'account_id',
-      'nickname' => 'email',
-      'realname' => 'email',
-      'email' => 'email',
+        'identifier' => 'account_id',
+        'nickname' => 'email',
+        'realname' => 'email',
+        'email' => 'email',
     );
 
     /**
@@ -40,41 +41,39 @@ class DropboxResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
-          'authorization_url' => 'https://www.dropbox.com/oauth2/authorize',
-          'access_token_url' => 'https://api.dropbox.com/oauth2/token',
-          'infos_url' => 'https://api.dropboxapi.com/2/users/get_current_account',
+            'authorization_url' => 'https://www.dropbox.com/oauth2/authorize',
+            'access_token_url' => 'https://api.dropbox.com/oauth2/token',
+            'infos_url' => 'https://api.dropboxapi.com/2/users/get_current_account',
         ));
     }
 
     /**
-     *
      * Dropbox API v2 requires a POST request to simply get user info
      *
      * @param array $accessToken
      * @param array $extraParameters
-     * @return \HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface
+     * @return UserResponseInterface
      */
-    public function getUserInformation(
-      array $accessToken,
-      array $extraParameters = array()
+    public function getUserInformation(array $accessToken,
+        array $extraParameters = array()
     ) {
         if ($this->options['use_bearer_authorization']) {
             $content = $this->httpRequest(
-              $this->normalizeUrl($this->options['infos_url'],
-                $extraParameters),
-              'null',
-              array(
-                'Authorization' => 'Bearer ' . $accessToken['access_token'],
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json; charset=utf-8',
-              ), 'POST');
+                $this->normalizeUrl($this->options['infos_url'],
+                    $extraParameters),
+                'null',
+                array(
+                    'Authorization' => 'Bearer ' . $accessToken['access_token'],
+                    'Accept' => 'application/json',
+                    'Content-Type' => 'application/json; charset=utf-8',
+                ), 'POST');
         } else {
             $content = $this->doGetUserInformationRequest(
-              $this->normalizeUrl(
-                $this->options['infos_url'],
-                array_merge(array($this->options['attr_name'] => $accessToken['access_token']),
-                  $extraParameters)
-              )
+                $this->normalizeUrl(
+                    $this->options['infos_url'],
+                    array_merge(array($this->options['attr_name'] => $accessToken['access_token']),
+                        $extraParameters)
+                )
             );
         }
 
@@ -82,7 +81,7 @@ class DropboxResourceOwner extends GenericOAuth2ResourceOwner
         $response->setData($content instanceof ResponseInterface ? (string)$content->getBody() : $content);
         $response->setResourceOwner($this);
         $response->setOAuthToken(new OAuthToken($accessToken));
-        return $response;
 
+        return $response;
     }
 }

--- a/OAuth/ResourceOwner/DropboxResourceOwner.php
+++ b/OAuth/ResourceOwner/DropboxResourceOwner.php
@@ -48,10 +48,11 @@ class DropboxResourceOwner extends GenericOAuth2ResourceOwner
     }
 
     /**
-     * Dropbox API v2 requires a POST request to simply get user info
+     * Dropbox API v2 requires a POST request to simply get user info!
      *
      * @param array $accessToken
      * @param array $extraParameters
+     *
      * @return UserResponseInterface
      */
     public function getUserInformation(array $accessToken,
@@ -63,7 +64,7 @@ class DropboxResourceOwner extends GenericOAuth2ResourceOwner
                     $extraParameters),
                 'null',
                 array(
-                    'Authorization' => 'Bearer ' . $accessToken['access_token'],
+                    'Authorization' => 'Bearer'. ' ' . $accessToken['access_token'],
                     'Accept' => 'application/json',
                     'Content-Type' => 'application/json; charset=utf-8',
                 ), 'POST');

--- a/OAuth/ResourceOwner/DropboxResourceOwner.php
+++ b/OAuth/ResourceOwner/DropboxResourceOwner.php
@@ -79,7 +79,7 @@ class DropboxResourceOwner extends GenericOAuth2ResourceOwner
         }
 
         $response = $this->getUserResponse();
-        $response->setData($content instanceof ResponseInterface ? (string)$content->getBody() : $content);
+        $response->setData($content instanceof ResponseInterface ? (string) $content->getBody() : $content);
         $response->setResourceOwner($this);
         $response->setOAuthToken(new OAuthToken($accessToken));
 

--- a/OAuth/ResourceOwner/DropboxResourceOwner.php
+++ b/OAuth/ResourceOwner/DropboxResourceOwner.php
@@ -64,7 +64,7 @@ class DropboxResourceOwner extends GenericOAuth2ResourceOwner
                     $extraParameters),
                 'null',
                 array(
-                    'Authorization' => 'Bearer'. ' ' . $accessToken['access_token'],
+                    'Authorization' => 'Bearer'.' '.$accessToken['access_token'],
                     'Accept' => 'application/json',
                     'Content-Type' => 'application/json; charset=utf-8',
                 ), 'POST');

--- a/OAuth/ResourceOwner/DropboxResourceOwner.php
+++ b/OAuth/ResourceOwner/DropboxResourceOwner.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -25,10 +26,10 @@ class DropboxResourceOwner extends GenericOAuth2ResourceOwner
      * {@inheritdoc}
      */
     protected $paths = array(
-        'identifier' => 'account_id',
-        'nickname' => 'email',
-        'realname' => 'email',
-        'email' => 'email',
+      'identifier' => 'account_id',
+      'nickname' => 'email',
+      'realname' => 'email',
+      'email' => 'email',
     );
 
     /**
@@ -39,30 +40,49 @@ class DropboxResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
-            'authorization_url' => 'https://www.dropbox.com/oauth2/authorize',
-            'access_token_url' => 'https://api.dropbox.com/oauth2/token',
-            'infos_url' => 'https://api.dropboxapi.com/2/users/get_current_account',
+          'authorization_url' => 'https://www.dropbox.com/oauth2/authorize',
+          'access_token_url' => 'https://api.dropbox.com/oauth2/token',
+          'infos_url' => 'https://api.dropboxapi.com/2/users/get_current_account',
         ));
     }
 
-    public function getUserInformation(array $accessToken, array $extraParameters = array())
-    {
+    /**
+     *
+     * Dropbox API v2 requires a POST request to simply get user info
+     *
+     * @param array $accessToken
+     * @param array $extraParameters
+     * @return \HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface
+     */
+    public function getUserInformation(
+      array $accessToken,
+      array $extraParameters = array()
+    ) {
         if ($this->options['use_bearer_authorization']) {
-            $content = $this->httpRequest($this->normalizeUrl($this->options['infos_url'], $extraParameters), 'null',
-                array(
-                    'Content-type: application/json; charset=UTF-8',
-                    'Authorization: Bearer ' . $accessToken['access_token']
-                ), 'POST');
+            $content = $this->httpRequest(
+              $this->normalizeUrl($this->options['infos_url'],
+                $extraParameters),
+              'null',
+              array(
+                'Authorization' => 'Bearer ' . $accessToken['access_token'],
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json; charset=utf-8',
+              ), 'POST');
         } else {
-            $content = $this->doGetUserInformationRequest($this->normalizeUrl($this->options['infos_url'],
-                array_merge(array($this->options['attr_name'] => $accessToken['access_token']), $extraParameters)));
+            $content = $this->doGetUserInformationRequest(
+              $this->normalizeUrl(
+                $this->options['infos_url'],
+                array_merge(array($this->options['attr_name'] => $accessToken['access_token']),
+                  $extraParameters)
+              )
+            );
         }
 
         $response = $this->getUserResponse();
-        $response->setResponse($content->getContent());
-
+        $response->setData($content instanceof ResponseInterface ? (string)$content->getBody() : $content);
         $response->setResourceOwner($this);
         $response->setOAuthToken(new OAuthToken($accessToken));
         return $response;
+
     }
 }

--- a/Tests/OAuth/ResourceOwner/DropboxResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/DropboxResourceOwnerTest.php
@@ -18,9 +18,9 @@ class DropboxResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
     protected $resourceOwnerClass = DropboxResourceOwner::class;
     protected $userResponse = '{"uid": "1", "email": "bar"}';
     protected $paths = array(
-        'identifier' => 'uid',
+        'identifier' => 'account_id',
         'nickname' => 'email',
-        'realname' => 'display_name',
+        'realname' => 'email',
         'email' => 'email',
     );
 

--- a/Tests/OAuth/ResourceOwner/DropboxResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/DropboxResourceOwnerTest.php
@@ -16,7 +16,7 @@ use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\DropboxResourceOwner;
 class DropboxResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
     protected $resourceOwnerClass = DropboxResourceOwner::class;
-    protected $userResponse = '{"uid": "1", "email": "bar"}';
+    protected $userResponse = '{"account_id": "1", "email": "bar"}';
     protected $paths = array(
         'identifier' => 'account_id',
         'nickname' => 'email',


### PR DESCRIPTION
Implemented getUserInformation method to comply with changes in Dropbox API V2.
see https://www.dropbox.com/developers/reference/migration-guide
For the same reason I have updated identifier mapping to 'account_id' and realname to email since real_name is gone in V2 (is now display_name but nested in a name sub-array within response, and in order to not overcomplicate thing I think it's fine to display email)