### PR TITLE
Fix building of POST data in RedditResourceOwner

### DIFF
--- a/OAuth/ResourceOwner/RedditResourceOwner.php
+++ b/OAuth/ResourceOwner/RedditResourceOwner.php
@@ -35,7 +35,7 @@ class RedditResourceOwner extends GenericOAuth2ResourceOwner
     {
         return $this->httpRequest(
             $url,
-            $parameters,
+            http_build_query($parameters, '', '&'),
             [
                 'Authorization: Basic '.base64_encode(sprintf('%s:%s', $this->options['client_id'], $this->options['client_secret'])),
             ],


### PR DESCRIPTION
According to Reddit OAuth2 documentation (https://github.com/reddit/reddit/wiki/OAuth2#retrieving-the-access-token) when retrieving the access token the parameters should be sent in the POST data like the following:
`grant_type=authorization_code&code=CODE&redirect_uri=URI`
So, the parameters should be encoded first using `http_build_query`.

Currently, retrieving the access token ends in `unsupported_grant_type`.
This PR fixes the current behaviour. 