### PR TITLE
fix undefined variable $definitionClassname

### DIFF
--- a/DependencyInjection/Security/Factory/OAuthFactory.php
+++ b/DependencyInjection/Security/Factory/OAuthFactory.php
@@ -150,6 +150,7 @@ class OAuthFactory extends AbstractFactory
     protected function createEntryPoint($container, $id, $config, $defaultEntryPoint)
     {
         $entryPointId = 'hwi_oauth.authentication.entry_point.oauth.'.$id;
+        $definitionClassname = $this->getDefinitionClassname();
 
         $container
             ->setDefinition($entryPointId, new $definitionClassname('hwi_oauth.authentication.entry_point.oauth'))


### PR DESCRIPTION
Due to #1290, the `$definitionClassname` is not set at `OAuthFactory::createEntryPoint` (line 155).

This PR fix this, by setting the `$definitionClassname` variable.