### PR TITLE
Fixed headers passed to httpRequest method in various resource owners

### DIFF
--- a/OAuth/ResourceOwner/FiwareResourceOwner.php
+++ b/OAuth/ResourceOwner/FiwareResourceOwner.php
@@ -49,7 +49,7 @@ class FiwareResourceOwner extends GenericOAuth2ResourceOwner
         ), $extraParameters);
 
         $headers = array(
-            'Authorization: Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret']),
+            'Authorization' => 'Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret']),
         );
 
         $response = $this->httpRequest($this->options['access_token_url'], http_build_query($parameters, '', '&'), $headers, 'POST');
@@ -72,7 +72,7 @@ class FiwareResourceOwner extends GenericOAuth2ResourceOwner
                     array('access_token' => $accessToken['access_token'])
                 ),
                 null,
-                array('Authorization: Bearer')
+                array('Authorization' => 'Bearer')
             );
         } else {
             $content = $this->doGetUserInformationRequest(

--- a/OAuth/ResourceOwner/GitHubResourceOwner.php
+++ b/OAuth/ResourceOwner/GitHubResourceOwner.php
@@ -43,7 +43,7 @@ class GitHubResourceOwner extends GenericOAuth2ResourceOwner
         if (empty($responseData['email'])) {
             // fetch the email addresses linked to the account
             $content = $this->httpRequest(
-                $this->normalizeUrl($this->options['emails_url']), null, array('Authorization: Bearer '.$accessToken['access_token'])
+                $this->normalizeUrl($this->options['emails_url']), null, array('Authorization' => 'Bearer '.$accessToken['access_token'])
             );
 
             foreach ($this->getResponseContent($content) as $email) {
@@ -68,7 +68,7 @@ class GitHubResourceOwner extends GenericOAuth2ResourceOwner
         $response = $this->httpRequest(
             sprintf($this->options['revoke_token_url'], $this->options['client_id'], $token),
             null,
-            array('Authorization: Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret'])),
+            array('Authorization' => 'Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret'])),
             'DELETE'
         );
 

--- a/OAuth/ResourceOwner/JawboneResourceOwner.php
+++ b/OAuth/ResourceOwner/JawboneResourceOwner.php
@@ -48,8 +48,8 @@ class JawboneResourceOwner extends GenericOAuth2ResourceOwner
         $url = $this->normalizeUrl($this->options['infos_url'].'/'.$type, $extraParameters);
 
         $headers = array(
-            'Authorization: Bearer '.$accessToken['access_token'],
-            'Accept: application/json',
+            'Authorization' => 'Bearer '.$accessToken['access_token'],
+            'Accept' => 'application/json',
         );
 
         return $this->httpRequest($url, null, $headers);

--- a/OAuth/ResourceOwner/RunKeeperResourceOwner.php
+++ b/OAuth/ResourceOwner/RunKeeperResourceOwner.php
@@ -36,7 +36,7 @@ class RunKeeperResourceOwner extends GenericOAuth2ResourceOwner
         $response = $this->httpRequest(
             $this->normalizeUrl($this->options['user_resource_url']),
             null,
-            array('Authorization: Bearer '.$accessToken)
+            array('Authorization' => 'Bearer '.$accessToken)
         );
 
         return $this->getResponseContent($response);

--- a/OAuth/ResourceOwner/ToshlResourceOwner.php
+++ b/OAuth/ResourceOwner/ToshlResourceOwner.php
@@ -41,7 +41,7 @@ class ToshlResourceOwner extends GenericOAuth2ResourceOwner
         $response = $this->httpRequest(
             $this->options['revoke_token_url'],
             null,
-            array('Authorization: Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret'])),
+            array('Authorization' => 'Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret'])),
             'DELETE'
         );
 

--- a/OAuth/ResourceOwner/TraktResourceOwner.php
+++ b/OAuth/ResourceOwner/TraktResourceOwner.php
@@ -37,8 +37,8 @@ class TraktResourceOwner extends GenericOAuth2ResourceOwner
     public function getUserInformation(array $accessToken, array $extraParameters = array())
     {
         $content = $this->httpRequest($this->normalizeUrl($this->options['infos_url']), null, array(
-            'Authorization: Bearer '.$accessToken['access_token'],
-            'Content-Type: application/json',
+            'Authorization' => 'Bearer '.$accessToken['access_token'],
+            'Content-Type' => 'application/json',
             'trakt-api-key' => $this->options['client_id'],
             'trakt-api-version' => 2,
         ));


### PR DESCRIPTION
Authorization headers were passed in a wrong way in several resource owners which are listed below. They should be passed as key => value arrays where the key is the header name.

It caused malfunctions, i.e. in GitHub resource owner the user's e-mail was null, because API request to `https://api.github.com/user/emails` was returning 401 status code (Authorization header wasn't being applied). Example of resulting headers array in httpRequest before the change:
```
Array
(
    [0] => Authorization: Bearer 47bce5c74f589f4867dbd57e9ca9f808
    [Content-Type] => application/x-www-form-urlencoded
)
```

Resource owners affected by this:
- Fiware
- GitHub
- Jawbone
- RunKeeper
- Toshl
- Trakt