### PR TITLE
#1305 replace Reference instance with service name string

### DIFF
--- a/DependencyInjection/Security/Factory/OAuthFactory.php
+++ b/DependencyInjection/Security/Factory/OAuthFactory.php
@@ -87,11 +87,11 @@ class OAuthFactory extends AbstractFactory
      *
      * @param string $id
      *
-     * @return Reference
+     * @return string
      */
     protected function getResourceOwnerMapReference($id)
     {
-        return new Reference('hwi_oauth.resource_ownermap.'.$id);
+        return 'hwi_oauth.resource_ownermap.'.$id;
     }
 
     /**

--- a/Security/Http/Firewall/OAuthListener.php
+++ b/Security/Http/Firewall/OAuthListener.php
@@ -14,6 +14,7 @@ namespace HWI\Bundle\OAuthBundle\Security\Http\Firewall;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapInterface;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -38,11 +39,11 @@ class OAuthListener extends AbstractAuthenticationListener
     private $checkPaths;
 
     /**
-     * @param ResourceOwnerMapInterface $resourceOwnerMap
+     * @param string $resourceOwnerMap
      */
-    public function setResourceOwnerMap(ResourceOwnerMapInterface $resourceOwnerMap)
+    public function setResourceOwnerMap($resourceOwnerMap)
     {
-        $this->resourceOwnerMap = $resourceOwnerMap;
+        $this->resourceOwnerMap = new Reference($resourceOwnerMap);
     }
 
     /**


### PR DESCRIPTION
The first argument at `setDefinition` expected to be `string`, but `Reference` instance received.
Previously it was not a problem because `Reference` was passed to `strtolower`, now, when this call was removed - Reference passed to unset() as a key.