### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -15,6 +15,7 @@ use Http\Client\Common\HttpMethodsClient;
 use Http\HttplugBundle\HttplugBundle;
 use HWI\Bundle\OAuthBundle\DependencyInjection\HWIOAuthExtension;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Yaml\Parser;
@@ -65,7 +66,7 @@ class MyCustomProvider implements ResourceOwnerInterface
 /**
  * Code bases on FOSUserBundle tests.
  */
-class HWIOAuthExtensionTest extends \PHPUnit_Framework_TestCase
+class HWIOAuthExtensionTest extends TestCase
 {
     /**
      * @var ContainerBuilder

--- a/Tests/Form/FOSUBRegistrationFormHandlerTest.php
+++ b/Tests/Form/FOSUBRegistrationFormHandlerTest.php
@@ -16,10 +16,11 @@ use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManagerInterface;
 use HWI\Bundle\OAuthBundle\Form\FOSUBRegistrationFormHandler;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
 
-class FOSUBRegistrationFormHandlerTest extends \PHPUnit_Framework_TestCase
+class FOSUBRegistrationFormHandlerTest extends TestCase
 {
     public function testProcessReturnsFalseForNotPostRequest()
     {

--- a/Tests/OAuth/ResourceOwner/ResourceOwnerTestCase.php
+++ b/Tests/OAuth/ResourceOwner/ResourceOwnerTestCase.php
@@ -15,9 +15,10 @@ use Http\Client\Common\HttpMethodsClient;
 use Http\Discovery\MessageFactoryDiscovery;
 use HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Http\HttpUtils;
 
-abstract class ResourceOwnerTestCase extends \PHPUnit_Framework_TestCase
+abstract class ResourceOwnerTestCase extends TestCase
 {
     /** @var \PHPUnit_Framework_MockObject_MockObject|HttpMethodsClient */
     protected $httpClient;

--- a/Tests/OAuth/Response/PathUserResponseTest.php
+++ b/Tests/OAuth/Response/PathUserResponseTest.php
@@ -13,8 +13,9 @@ namespace HWI\Bundle\OAuthBundle\Tests\OAuth\Response;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
+use PHPUnit\Framework\TestCase;
 
-class PathUserResponseTest extends \PHPUnit_Framework_TestCase
+class PathUserResponseTest extends TestCase
 {
     /**
      * @var PathUserResponse

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -19,11 +19,12 @@ use HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAwareExceptionInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthAwareUserProviderInterface;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\OAuthAwareException;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class OAuthProviderTest extends \PHPUnit_Framework_TestCase
+class OAuthProviderTest extends TestCase
 {
     public function testSupportsOAuthToken()
     {

--- a/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
+++ b/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
@@ -12,8 +12,9 @@
 namespace HWI\Bundle\OAuthBundle\Tests\Security\Core\Authentication\Token;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use PHPUnit\Framework\TestCase;
 
-class OAuthTokenTest extends \PHPUnit_Framework_TestCase
+class OAuthTokenTest extends TestCase
 {
     /**
      * @var OAuthToken

--- a/Tests/Security/Core/User/EntityUserProviderTest.php
+++ b/Tests/Security/Core/User/EntityUserProviderTest.php
@@ -18,8 +18,9 @@ use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\User\EntityUserProvider;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\User;
+use PHPUnit\Framework\TestCase;
 
-class EntityUserProviderTest extends \PHPUnit_Framework_TestCase
+class EntityUserProviderTest extends TestCase
 {
     public function setUp()
     {

--- a/Tests/Security/Core/User/FOSUBUserProviderTest.php
+++ b/Tests/Security/Core/User/FOSUBUserProviderTest.php
@@ -16,8 +16,9 @@ use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\User\FOSUBUserProvider;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\FOSUser;
+use PHPUnit\Framework\TestCase;
 
-class FOSUBUserProviderTest extends \PHPUnit_Framework_TestCase
+class FOSUBUserProviderTest extends TestCase
 {
     public function setUp()
     {

--- a/Tests/Security/Core/User/OAuthUserProviderTest.php
+++ b/Tests/Security/Core/User/OAuthUserProviderTest.php
@@ -14,9 +14,10 @@ namespace HWI\Bundle\OAuthBundle\Tests\Security\Core\User;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser;
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUserProvider;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\User\User;
 
-class OAuthUserProviderTest extends \PHPUnit_Framework_TestCase
+class OAuthUserProviderTest extends TestCase
 {
     /**
      * @var OAuthUserProvider

--- a/Tests/Security/Core/User/OAuthUserTest.php
+++ b/Tests/Security/Core/User/OAuthUserTest.php
@@ -12,8 +12,9 @@
 namespace HWI\Bundle\OAuthBundle\Tests\Security\Core\User;
 
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser;
+use PHPUnit\Framework\TestCase;
 
-class OAuthUserTest extends \PHPUnit_Framework_TestCase
+class OAuthUserTest extends TestCase
 {
     /**
      * @var OAuthUser

--- a/Tests/Security/OAuthUtilsTest.php
+++ b/Tests/Security/OAuthUtilsTest.php
@@ -14,12 +14,13 @@ namespace HWI\Bundle\OAuthBundle\Tests\Security;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 
-class OAuthUtilsTest extends \PHPUnit_Framework_TestCase
+class OAuthUtilsTest extends TestCase
 {
     private $grantRule = 'IS_AUTHENTICATED_REMEMBERED';
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead os `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to `PHPUnit 6`, that <b>now are namespaced</b>, and no longer use snake case class names.