### PR TITLE
Do not force setRefreshToken with old refresh_token on OAuthToken

### DIFF
--- a/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -116,7 +116,6 @@ class OAuthProvider implements AuthenticationProviderInterface
         $token->setResourceOwnerName($resourceOwner->getName());
         $token->setUser($user);
         $token->setAuthenticated(true);
-        $token->setRefreshToken($oldToken->getRefreshToken());
         $token->setCreatedAt($oldToken->getCreatedAt());
 
         return $token;

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -57,9 +57,6 @@ class OAuthProviderTest extends \PHPUnit_Framework_TestCase
         $oauthTokenMock->expects($this->exactly(2))
             ->method('getRawToken')
             ->will($this->returnValue($expectedToken));
-        $oauthTokenMock->expects($this->once())
-            ->method('getRefreshToken')
-            ->willReturn($expectedToken['refresh_token']);
 
         $resourceOwnerMock = $this->getResourceOwnerMock();
         $resourceOwnerMock->expects($this->once())


### PR DESCRIPTION
I'm working on a OAuth2 implementation, with `FOSOauthServerBundle` as Oauth2 server. I'm implementing the refresh token feature.

I saw in the code, that the refresh token of the old access token was set to the new `OAuthToken`. But when the refresh token is used to generate a new access token, a new pair of access token+refresh token is generated, and the old refresh token is removed. As a result, with the current implementation, the old refresh token is not saved inside the ``OAuthToken::refreshToken``.

Note that the ``OAuthToken::setRawToken``, implicitly called by the constructor, already set the good refresh token.

As a result, the current code works only to refresh one time the access token. The second time, the old refresh token is used, but already removed in the server.

The result inside the security, after a call to get a new access token:
![token inside security](https://media.didier.io/api/get/7947302b19b35e319ec98c84cf4b833b)

So, it is not necessary to call ``OAuthToken::setRefreshToken`` after building the ``OAuthToken``.