### PR TITLE
Check for grant_rule value IS_AUTHENTICATED_FULLY

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -164,7 +164,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('IS_AUTHENTICATED_REMEMBERED')
                     ->validate()
                         ->ifTrue(function ($role) {
-                            return 'IS_AUTHENTICATED_REMEMBERED' !== $role || 'IS_AUTHENTICATED_FULLY' !== $role;
+                            return !('IS_AUTHENTICATED_REMEMBERED' === $role || 'IS_AUTHENTICATED_FULLY' === $role);
                         })
                         ->thenInvalid('Unknown grant role set "%s".')
                     ->end()


### PR DESCRIPTION
I get:
```
PHP Fatal error:  Uncaught InvalidArgumentException: Unknown grant role set ""IS_AUTHENTICATED_FULLY"" but it should pass.
```
This is a fix for that.

I've tested with values IS_AUTHENTICATED_FULLY (passes), IS_AUTHENTICATED_REMEMBERED (passes) and IS_AUTHENTICATED_FULLYZ (fails).