### PR TITLE
Fix serialization of AccountNotLinkedException

### DIFF
--- a/Security/Core/Exception/AccountNotLinkedException.php
+++ b/Security/Core/Exception/AccountNotLinkedException.php
@@ -91,7 +91,6 @@ class AccountNotLinkedException extends UsernameNotFoundException implements OAu
     {
         return serialize(array(
             $this->resourceOwnerName,
-            $this->getToken(),
             parent::serialize(),
         ));
     }
@@ -103,11 +102,8 @@ class AccountNotLinkedException extends UsernameNotFoundException implements OAu
     {
         list(
             $this->resourceOwnerName,
-            $token,
             $parentData
         ) = unserialize($str);
-
-        $this->setToken($token);
 
         parent::unserialize($parentData);
     }

--- a/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
+++ b/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Tests\Security\Core\Authentication\Token;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
 use PHPUnit\Framework\TestCase;
 
 class OAuthTokenTest extends TestCase
@@ -101,5 +102,12 @@ class OAuthTokenTest extends TestCase
         );
         $token = new OAuthToken($expectedToken, array('ROLE_TEST'));
         $this->assertTrue($token->isExpired());
+    }
+
+    public function testSerializeTokenInException()
+    {
+        $exception = new AccountNotLinkedException($this->token);
+        $str = serialize($exception);
+        unserialize($str);
     }
 }


### PR DESCRIPTION
The embedded token is serialized twice, which makes the unserialization
fail.