### PR TITLE
Make resource owner services public

### DIFF
--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -140,7 +140,7 @@
             </call>
         </service>
 
-        <service id="hwi_oauth.abstract_resource_owner.generic" abstract="true">
+        <service id="hwi_oauth.abstract_resource_owner.generic" abstract="true" public="true">
             <argument type="service" id="hwi_oauth.http_client" />
             <argument type="service" id="security.http_utils" />
             <argument type="collection" /><!-- options -->


### PR DESCRIPTION
When they are private Symfony 4 will prune them and you'll get an exception:

```
The "hwi_oauth.resource_owner.some_resource_owner" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.
```