### PR TITLE
[SF 4.0][BUG] set hwi_oauth.resource_ownermap.* services public

### DIFF
--- a/DependencyInjection/Security/Factory/OAuthFactory.php
+++ b/DependencyInjection/Security/Factory/OAuthFactory.php
@@ -79,6 +79,7 @@ class OAuthFactory extends AbstractFactory
         $container
             ->setDefinition($this->getResourceOwnerMapReference($id), new $definitionClassname('hwi_oauth.abstract_resource_ownermap'))
             ->replaceArgument(2, new Parameter('hwi_oauth.resource_ownermap.configured.'.$id))
+            ->setPublic(true)
         ;
     }
 


### PR DESCRIPTION
\HWI\Bundle\OAuthBundle\Controller\ConnectController::getResourceOwnerByName 
have to get services for > SF 4.0