### PR TITLE
Fix double call of getUserInformation()

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -224,8 +224,6 @@ class ConnectController extends Controller
             return $this->redirectToRoute($this->container->getParameter('hwi_oauth.failed_auth_path'));
         }
 
-        $userInformation = $resourceOwner->getUserInformation($accessToken);
-
         // Show confirmation page?
         if (!$this->container->getParameter('hwi_oauth.connect.confirmation')) {
             return $this->getConfirmationResponse($request, $accessToken, $service);
@@ -254,7 +252,7 @@ class ConnectController extends Controller
             'key' => $key,
             'service' => $service,
             'form' => $form->createView(),
-            'userInformation' => $userInformation,
+            'userInformation' => $resourceOwner->getUserInformation($accessToken),
         ));
     }
 


### PR DESCRIPTION
Previously the `connectServiceAction` would call `$resourceOwner->getUserInformation()` twice, if it returns early by returning `this.getConfirmationResponse()`:
* here: https://github.com/hwi/HWIOAuthBundle/blob/master/Controller/ConnectController.php#L227
* and here: https://github.com/hwi/HWIOAuthBundle/blob/master/Controller/ConnectController.php#L444

This seems unnecessary. But in the case of Twitter, I also had the problem that the first call to `getUserInformation` would return the expected data, the second would return a response just with an error message in the data.