### PR TITLE
Fix #1298

### DIFF
--- a/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -130,6 +130,10 @@ class OAuthProvider implements AuthenticationProviderInterface
      */
     protected function refreshToken(TokenInterface $expiredToken, ResourceOwnerInterface $resourceOwner)
     {
+        if (!$expiredToken->getRefreshToken()) {
+            return $expiredToken;
+        }
+
         $token = new OAuthToken($resourceOwner->refreshAccessToken($expiredToken->getRefreshToken()));
         $token->setRefreshToken($expiredToken->getRefreshToken());
         $this->tokenStorage->setToken($token);

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -268,7 +268,7 @@ class OAuthProviderTest extends TestCase
         $oauthTokenMock->expects($this->exactly(2))
             ->method('getResourceOwnerName')
             ->will($this->returnValue('github'));
-        $oauthTokenMock->expects($this->exactly(2))
+        $oauthTokenMock->expects($this->exactly(3))
             ->method('getRefreshToken')
             ->willReturn($expiredToken['refresh_token']);
 


### PR DESCRIPTION
Don't execute refreshAccessToken when there is no refreshToken