### PR TITLE
Updated slack resource owner to use new Slack API methods

### DIFF
--- a/OAuth/ResourceOwner/SlackResourceOwner.php
+++ b/OAuth/ResourceOwner/SlackResourceOwner.php
@@ -24,8 +24,9 @@ class SlackResourceOwner extends GenericOAuth2ResourceOwner
      * {@inheritdoc}
      */
     protected $paths = array(
-        'identifier' => 'user_id',
-        'nickname' => 'user',
+        'identifier' => 'user.id',
+        'nickname' => 'user.name',
+        'email' => 'user.email',
     );
 
     /**
@@ -38,7 +39,7 @@ class SlackResourceOwner extends GenericOAuth2ResourceOwner
         $resolver->setDefaults(array(
             'authorization_url' => 'https://slack.com/oauth/authorize',
             'access_token_url' => 'https://slack.com/api/oauth.access',
-            'infos_url' => 'https://slack.com/api/auth.test',
+            'infos_url' => 'https://slack.com/api/users.identity',
 
             'scope' => 'identify',
 


### PR DESCRIPTION
`Used https://api.slack.com/methods/users.identity` instead of `https://api.slack.com/methods/auth.test` as recommended here : `https://api.slack.com/docs/sign-in-with-slack#identify_users_and_their_workspaces`