### PR TITLE
Changing Linkedin authorization and access token to v2

### DIFF
--- a/OAuth/ResourceOwner/LinkedinResourceOwner.php
+++ b/OAuth/ResourceOwner/LinkedinResourceOwner.php
@@ -57,8 +57,8 @@ class LinkedinResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
-            'authorization_url' => 'https://www.linkedin.com/uas/oauth2/authorization',
-            'access_token_url' => 'https://www.linkedin.com/uas/oauth2/accessToken',
+            'authorization_url' => 'https://www.linkedin.com/oauth/v2/authorization',
+            'access_token_url' => 'https://www.linkedin.com/oauth/v2/accessToken',
             'infos_url' => 'https://api.linkedin.com/v1/people/~:(id,formatted-name,email-address,picture-url)?format=json',
 
             'csrf' => true,


### PR DESCRIPTION
Hi,


The LinkedIn Oauth 1 has a security flow.
It does not required an email validation a LinkedIn side.

My website has been hacked by this way with the current implementation of hwi :
- I had an admin account (lets say admin@mysite.com) register on my website with common register form
- The admin@mysite.com account on linkedin did not exist
- The attacker registered at linkedin with admin@mysite.com
- He asked phone verification instead of eamil verification, the account was confirmed
- He did login on my website with linkedin connect and got admin privileges.

These holes can be corrected just by changing the authorization url.

(Linked warned not to use the v1 version anymore).