### PR TITLE
Fix for "Content-Length" header parameter which must be a string

### DIFF
--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -250,7 +250,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
 
         $headers += array('User-Agent' => 'HWIOAuthBundle (https://github.com/hwi/HWIOAuthBundle)');
         if (is_string($content)) {
-            $headers += array('Content-Length' => (string)(strlen($content)));
+            $headers += array('Content-Length' => (string) strlen($content));
         } elseif (is_array($content)) {
             $content = http_build_query($content, '', '&');
         }

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -250,7 +250,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
 
         $headers += array('User-Agent' => 'HWIOAuthBundle (https://github.com/hwi/HWIOAuthBundle)');
         if (is_string($content)) {
-            $headers += array('Content-Length' => strlen($content));
+            $headers += array('Content-Length' => strval(strlen($content)));
         } elseif (is_array($content)) {
             $content = http_build_query($content, '', '&');
         }

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -250,7 +250,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
 
         $headers += array('User-Agent' => 'HWIOAuthBundle (https://github.com/hwi/HWIOAuthBundle)');
         if (is_string($content)) {
-            $headers += array('Content-Length' => strval(strlen($content)));
+            $headers += array('Content-Length' => (string)(strlen($content)));
         } elseif (is_array($content)) {
             $content = http_build_query($content, '', '&');
         }


### PR DESCRIPTION
Fix for "Content-Length" header parameter which must be a string.

It fixes bug with Nyholm/psr7 0.3.0 which try to make a trim on integer at /vendor/nyholm/psr7/src/MessageTrait.php:215