### PR TITLE
Update to httplug configuration

### DIFF
--- a/Resources/doc/internals/configuring_the_http_client.md
+++ b/Resources/doc/internals/configuring_the_http_client.md
@@ -68,7 +68,7 @@ httplug:
             factory: 'httplug.factory.guzzle6'
             config: # You pass here the Guzzle configuration, exactly like before.
                 timeout: 10
-                verify_peer: false
+                verify: false
                 max_redirects: 1
                 ignore_errors: false
                 proxy: "example.com:8080"


### PR DESCRIPTION
verify_peer parameter has been renamed into verify
http://php-translation.readthedocs.io/en/latest/guides/configure-httplug.html