### PR TITLE
Fix deprecations with Symfony 4.1 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.2
   - 7.1
   - 7.0
+  - 5.6
   - nightly
 
 cache:
@@ -19,6 +20,10 @@ env:
 matrix:
   fast_finish: true
   include:
+    - php: 5.6
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: FOSUSERBUNDLE_VERSION=1.3.*
     - php: 7.0
       env: SYMFONY_VERSION=2.8.*
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ matrix:
       env: STABILITY=beta
     - php: 7.1
       env: TARGET=csfixer_dry_run
+    - php: 7.2
+      env: STABILITY=beta SYMFONY_VERSION=4.1.*
+
   allow_failures:
     - php: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 7.2
   - 7.1
   - 7.0
-  - 5.6
   - nightly
 
 cache:
@@ -20,10 +19,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 5.6
-      env: FOSUSERBUNDLE_VERSION=1.3.*
     - php: 7.0
       env: SYMFONY_VERSION=2.8.*
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
     - php: 7.1
       env: TARGET=csfixer_dry_run
     - php: 7.2
-      env: STABILITY=beta SYMFONY_VERSION=4.1.*
+      env: SYMFONY_VERSION=4.1.*
 
   allow_failures:
     - php: nightly

--- a/Resources/config/routing/connect.xml
+++ b/Resources/config/routing/connect.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="hwi_oauth_connect_service" path="/service/{service}">
-        <default key="_controller">HWI\Bundle\OAuthBundle\Controller\ConnectController::connectService</default>
+        <default key="_controller">HWI\Bundle\OAuthBundle\Controller\ConnectController::connectServiceAction</default>
     </route>
 
     <route id="hwi_oauth_connect_registration" path="/registration/{key}">

--- a/Resources/config/routing/connect.xml
+++ b/Resources/config/routing/connect.xml
@@ -5,10 +5,10 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="hwi_oauth_connect_service" path="/service/{service}">
-        <default key="_controller">HWIOAuthBundle:Connect:connectService</default>
+        <default key="_controller">HWI\Bundle\OAuthBundle\Controller\ConnectController::connectService</default>
     </route>
 
     <route id="hwi_oauth_connect_registration" path="/registration/{key}">
-        <default key="_controller">HWIOAuthBundle:Connect:registration</default>
+        <default key="_controller">HWI\Bundle\OAuthBundle\Controller\ConnectController::registrationAction</default>
     </route>
 </routes>

--- a/Resources/config/routing/login.xml
+++ b/Resources/config/routing/login.xml
@@ -5,6 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="hwi_oauth_connect" path="/">
-        <default key="_controller">HWIOAuthBundle:Connect:connect</default>
+        <default key="_controller">HWI\Bundle\OAuthBundle\Controller\ConnectController::connectAction</default>
     </route>
 </routes>

--- a/Resources/config/routing/redirect.xml
+++ b/Resources/config/routing/redirect.xml
@@ -5,6 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="hwi_oauth_service_redirect" path="/{service}">
-        <default key="_controller">HWIOAuthBundle:Connect:redirectToService</default>
+        <default key="_controller">HWI\Bundle\OAuthBundle\Controller\ConnectController::redirectToServiceAction</default>
     </route>
 </routes>


### PR DESCRIPTION
I remove PHP 5.6 support because build failed currently in master.