### PR TITLE
GitLab: change user endpoint to v4

### DIFF
--- a/OAuth/ResourceOwner/GitLabResourceOwner.php
+++ b/OAuth/ResourceOwner/GitLabResourceOwner.php
@@ -42,7 +42,7 @@ class GitLabResourceOwner extends GenericOAuth2ResourceOwner
             'authorization_url' => 'https://gitlab.com/oauth/authorize',
             'access_token_url' => 'https://gitlab.com/oauth/token',
             'revoke_token_url' => 'https://gitlab.com/oauth/revoke',
-            'infos_url' => 'https://gitlab.com/api/v3/user',
+            'infos_url' => 'https://gitlab.com/api/v4/user',
 
             'scope' => 'read_user',
             'use_commas_in_scope' => false,


### PR DESCRIPTION
GitLab API v3 was removed with GitLab 11.0.

https://docs.gitlab.com/ee/api/#current-status

The endpoint `https://gitlab.com/api/v3/user` only returns an error `API V3 is no longer supported. Use API V4 instead.` and no more user data