### PR TITLE
Documentation fix

### DIFF
--- a/Resources/doc/resource_owners/azure.md
+++ b/Resources/doc/resource_owners/azure.md
@@ -18,6 +18,7 @@ hwi_oauth:
             type:          azure
             client_id:     <client_id>
             client_secret: <client_secret>
+            infos_url:     https://graph.microsoft.com/v1.0/me
 
             options:
                 resource:    https://graph.windows.net


### PR DESCRIPTION
You have to set the infos_url now (since 0.6) or this integration wont work. Based on the fix suggested here: https://github.com/hwi/HWIOAuthBundle/issues/1362#issuecomment-396943062