### PR TITLE
Update Facebook endpoint to v3.1

### DIFF
--- a/OAuth/ResourceOwner/FacebookResourceOwner.php
+++ b/OAuth/ResourceOwner/FacebookResourceOwner.php
@@ -103,10 +103,10 @@ class FacebookResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
-            'authorization_url' => 'https://www.facebook.com/v2.8/dialog/oauth',
-            'access_token_url' => 'https://graph.facebook.com/v2.8/oauth/access_token',
-            'revoke_token_url' => 'https://graph.facebook.com/v2.8/me/permissions',
-            'infos_url' => 'https://graph.facebook.com/v2.8/me?fields=id,first_name,last_name,name,email,picture.type(large)',
+            'authorization_url' => 'https://www.facebook.com/v3.1/dialog/oauth',
+            'access_token_url' => 'https://graph.facebook.com/v3.1/oauth/access_token',
+            'revoke_token_url' => 'https://graph.facebook.com/v3.1/me/permissions',
+            'infos_url' => 'https://graph.facebook.com/v3.1/me?fields=id,first_name,last_name,name,email,picture.type(large)',
             'use_commas_in_scope' => true,
             'display' => null,
             'auth_type' => null,


### PR DESCRIPTION
Hey,

following this issue https://github.com/hwi/HWIOAuthBundle/issues/1431;
I have tested the Facebook API v3.1 and it seems to not have some breaking change for Facebook Connect and GET me. 

![capture du 2018-10-01 10-40-17](https://user-images.githubusercontent.com/4228646/46278475-8005cd00-c566-11e8-8d41-75f385421463.png)

Feel free to comment and ask me any modification!

Cheers 