### PR TITLE
Support for multiple OAuth2 state parameters

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -466,7 +466,7 @@ class ConnectController extends Controller
         if ($currentToken instanceof OAuthToken) {
             // Update user token with new details
             $newToken =
-                is_array($accessToken) &&
+                \is_array($accessToken) &&
                 (isset($accessToken['access_token']) || isset($accessToken['oauth_token'])) ?
                     $accessToken : $currentToken->getRawToken();
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -283,7 +283,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('type')
                                 ->validate()
                                     ->ifTrue(function ($type) {
-                                        return !Configuration::isResourceOwnerSupported($type);
+                                        return !self::isResourceOwnerSupported($type);
                                     })
                                     ->thenInvalid('Unknown resource owner type "%s".')
                                 ->end()
@@ -303,11 +303,11 @@ class Configuration implements ConfigurationInterface
                                                 return true;
                                             }
 
-                                            if (is_array($v)) {
-                                                return 0 === count($v);
+                                            if (\is_array($v)) {
+                                                return 0 === \count($v);
                                             }
 
-                                            if (is_string($v)) {
+                                            if (\is_string($v)) {
                                                 return empty($v);
                                             }
 
@@ -381,7 +381,7 @@ class Configuration implements ConfigurationInterface
                                 }
 
                                 // one of this two options must be set
-                                if (0 === count($c['paths'])) {
+                                if (0 === \count($c['paths'])) {
                                     return !isset($c['user_response_class']);
                                 }
 
@@ -399,7 +399,7 @@ class Configuration implements ConfigurationInterface
                             ->ifTrue(function ($c) {
                                 if (isset($c['service'])) {
                                     // ignore paths & options if none were set
-                                    return 0 !== count($c['paths']) || 0 !== count($c['options']) || 3 < count($c);
+                                    return 0 !== \count($c['paths']) || 0 !== \count($c['options']) || 3 < \count($c);
                                 }
 
                                 return false;

--- a/DependencyInjection/Security/Factory/OAuthFactory.php
+++ b/DependencyInjection/Security/Factory/OAuthFactory.php
@@ -225,7 +225,7 @@ class OAuthFactory extends AbstractFactory
                 ->end()
                 ->validate()
                     ->ifTrue(function ($c) {
-                        return 1 !== count($c) || !in_array(key($c), array('fosub', 'oauth', 'orm', 'service'), true);
+                        return 1 !== \count($c) || !\in_array(key($c), array('fosub', 'oauth', 'orm', 'service'), true);
                     })
                     ->thenInvalid("You should configure (only) one of: 'fosub', 'oauth', 'orm', 'service'.")
                 ->end()
@@ -246,7 +246,7 @@ class OAuthFactory extends AbstractFactory
                     ->ifTrue(function ($c) {
                         $checkPaths = array();
                         foreach ($c as $checkPath) {
-                            if (in_array($checkPath, $checkPaths, true)) {
+                            if (\in_array($checkPath, $checkPaths, true)) {
                                 return true;
                             }
 

--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -137,7 +137,7 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
      */
     protected function reconstructFormHandler(Request $request, Form $form)
     {
-        $handlerClass = get_class($this->registrationFormHandler);
+        $handlerClass = \get_class($this->registrationFormHandler);
 
         return new $handlerClass($form, $request, $this->userManager, $this->mailer, $this->tokenGenerator);
     }

--- a/OAuth/Exception/StateRetrievalException.php
+++ b/OAuth/Exception/StateRetrievalException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth\Exception;
+
+final class StateRetrievalException extends \InvalidArgumentException
+{
+    /**
+     * @param string $key The provided string key
+     *
+     * @return self
+     */
+    public static function forKey($key)
+    {
+        return new static(sprintf('No value found in state for key [%s]', $key));
+    }
+}

--- a/OAuth/RequestDataStorage/SessionStorage.php
+++ b/OAuth/RequestDataStorage/SessionStorage.php
@@ -59,13 +59,13 @@ class SessionStorage implements RequestDataStorageInterface
     public function save(ResourceOwnerInterface $resourceOwner, $value, $type = 'token')
     {
         if ('token' === $type) {
-            if (!is_array($value) || !isset($value['oauth_token'])) {
+            if (!\is_array($value) || !isset($value['oauth_token'])) {
                 throw new \InvalidArgumentException('Invalid request token.');
             }
 
             $key = $this->generateKey($resourceOwner, $value['oauth_token'], 'token');
         } else {
-            $key = $this->generateKey($resourceOwner, is_array($value) ? reset($value) : $value, $type);
+            $key = $this->generateKey($resourceOwner, \is_array($value) ? reset($value) : $value, $type);
         }
 
         $this->session->set($key, $value);

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -18,6 +18,8 @@ use HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
+use HWI\Bundle\OAuthBundle\OAuth\State\State;
+use HWI\Bundle\OAuthBundle\OAuth\StateInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -60,7 +62,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
     protected $name;
 
     /**
-     * @var string
+     * @var StateInterface
      */
     protected $state;
 
@@ -104,7 +106,18 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
         $this->configureOptions($resolver);
         $this->options = $resolver->resolve($options);
 
+        $this->state = $this->configureStateParameters();
+
         $this->configure();
+    }
+
+    private function configureStateParameters()
+    {
+        if (empty($this->options['state'])) {
+            return new State(null);
+        }
+
+        return new State($this->options['state']);
     }
 
     /**
@@ -148,6 +161,22 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
     public function addPaths(array $paths)
     {
         $this->paths = array_merge($this->paths, $paths);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addStateParameter($key, $value)
+    {
+        $this->state->add($key, $value);
     }
 
     /**

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -291,16 +291,6 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
     }
 
     /**
-     * Generate a non-guessable nonce value.
-     *
-     * @return string
-     */
-    protected function generateNonce()
-    {
-        return md5(microtime(true).uniqid('', true));
-    }
-
-    /**
      * @param string $url
      * @param array  $parameters
      *

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -278,9 +278,9 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
         }
 
         $headers += array('User-Agent' => 'HWIOAuthBundle (https://github.com/hwi/HWIOAuthBundle)');
-        if (is_string($content)) {
-            $headers += array('Content-Length' => (string) strlen($content));
-        } elseif (is_array($content)) {
+        if (\is_string($content)) {
+            $headers += array('Content-Length' => (string) \strlen($content));
+        } elseif (\is_array($content)) {
             $content = http_build_query($content, '', '&');
         }
 

--- a/OAuth/ResourceOwner/AzureResourceOwner.php
+++ b/OAuth/ResourceOwner/AzureResourceOwner.php
@@ -70,7 +70,7 @@ class AzureResourceOwner extends GenericOAuth2ResourceOwner
         $jwt = str_replace(array('-', '_'), array('+', '/'), $jwt);
 
         // complete token if needed
-        switch (strlen($jwt) % 4) {
+        switch (\strlen($jwt) % 4) {
             case 0:
                 break;
 

--- a/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Helper\Nonce;
 use HWI\Bundle\OAuthBundle\Security\OAuthErrorHandler;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Psr\Http\Message\ResponseInterface;
@@ -34,7 +35,7 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
         $parameters = array_merge([
             'oauth_consumer_key' => $this->options['client_id'],
             'oauth_timestamp' => time(),
-            'oauth_nonce' => $this->generateNonce(),
+            'oauth_nonce' => Nonce::generate(),
             'oauth_version' => '1.0',
             'oauth_signature_method' => $this->options['signature_method'],
             'oauth_token' => $accessToken['oauth_token'],
@@ -88,7 +89,7 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
         $parameters = array_merge(array(
             'oauth_consumer_key' => $this->options['client_id'],
             'oauth_timestamp' => time(),
-            'oauth_nonce' => $this->generateNonce(),
+            'oauth_nonce' => Nonce::generate(),
             'oauth_version' => '1.0',
             'oauth_signature_method' => $this->options['signature_method'],
             'oauth_token' => $requestToken['oauth_token'],
@@ -146,7 +147,7 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
         $parameters = array_merge([
             'oauth_consumer_key' => $this->options['client_id'],
             'oauth_timestamp' => $timestamp,
-            'oauth_nonce' => $this->generateNonce(),
+            'oauth_nonce' => Nonce::generate(),
             'oauth_version' => '1.0',
             'oauth_callback' => $redirectUri,
             'oauth_signature_method' => $this->options['signature_method'],

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Helper\Nonce;
 use HWI\Bundle\OAuthBundle\Security\OAuthErrorHandler;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
@@ -60,7 +61,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
     {
         if ($this->options['csrf']) {
             if (null === $this->state) {
-                $this->state = $this->generateNonce();
+                $this->state = Nonce::generate();
             }
 
             $this->storage->save($this, $this->state, 'csrf_state');

--- a/OAuth/ResourceOwner/JiraResourceOwner.php
+++ b/OAuth/ResourceOwner/JiraResourceOwner.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Helper\Nonce;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\OptionsResolver\Options;
@@ -43,7 +44,7 @@ class JiraResourceOwner extends GenericOAuth1ResourceOwner
         $parameters = array_merge(array(
             'oauth_consumer_key' => $this->options['client_id'],
             'oauth_timestamp' => time(),
-            'oauth_nonce' => $this->generateNonce(),
+            'oauth_nonce' => Nonce::generate(),
             'oauth_version' => '1.0',
             'oauth_signature_method' => $this->options['signature_method'],
             'oauth_token' => $accessToken['oauth_token'],
@@ -62,7 +63,7 @@ class JiraResourceOwner extends GenericOAuth1ResourceOwner
         $url = $this->normalizeUrl($this->options['infos_url'], array('username' => $content['name']));
 
         // Regenerate nonce & signature as URL was changed
-        $parameters['oauth_nonce'] = $this->generateNonce();
+        $parameters['oauth_nonce'] = Nonce::generate();
         $parameters['oauth_signature'] = OAuthUtils::signRequest(
             'GET',
             $url,

--- a/OAuth/ResourceOwner/OdnoklassnikiResourceOwner.php
+++ b/OAuth/ResourceOwner/OdnoklassnikiResourceOwner.php
@@ -92,7 +92,7 @@ class OdnoklassnikiResourceOwner extends GenericOAuth2ResourceOwner
                 return null;
             }
 
-            return is_array($value) ? implode(',', $value) : $value;
+            return \is_array($value) ? implode(',', $value) : $value;
         };
 
         $resolver->setNormalizer('fields', $fieldsNormalizer);

--- a/OAuth/ResourceOwner/VkontakteResourceOwner.php
+++ b/OAuth/ResourceOwner/VkontakteResourceOwner.php
@@ -98,7 +98,7 @@ class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
                 return null;
             }
 
-            return is_array($value) ? implode(',', $value) : $value;
+            return \is_array($value) ? implode(',', $value) : $value;
         };
 
         $resolver->setNormalizer('fields', $fieldsNormalizer);

--- a/OAuth/ResourceOwnerInterface.php
+++ b/OAuth/ResourceOwnerInterface.php
@@ -120,4 +120,10 @@ interface ResourceOwnerInterface
      * @return StateInterface
      */
     public function getState();
+
+    /**
+     * @param string $key
+     * @param string $value
+     */
+    public function addStateParameter($key, $value);
 }

--- a/OAuth/ResourceOwnerInterface.php
+++ b/OAuth/ResourceOwnerInterface.php
@@ -115,4 +115,9 @@ interface ResourceOwnerInterface
      * @param array  $extraParameters An array of parameters to add to the url
      */
     public function refreshAccessToken($refreshToken, array $extraParameters = []);
+
+    /**
+     * @return StateInterface
+     */
+    public function getState();
 }

--- a/OAuth/Response/AbstractUserResponse.php
+++ b/OAuth/Response/AbstractUserResponse.php
@@ -112,7 +112,7 @@ abstract class AbstractUserResponse implements UserResponseInterface
      */
     public function setData($data)
     {
-        if (is_array($data)) {
+        if (\is_array($data)) {
             $this->data = $data;
         } else {
             // First check that response exists, due too bug: https://bugs.php.net/bug.php?id=54484

--- a/OAuth/Response/PathUserResponse.php
+++ b/OAuth/Response/PathUserResponse.php
@@ -138,8 +138,8 @@ class PathUserResponse extends AbstractUserResponse
             return null;
         }
 
-        if (is_array($steps)) {
-            if (1 === count($steps)) {
+        if (\is_array($steps)) {
+            if (1 === \count($steps)) {
                 return $this->getValue(current($steps), $data);
             }
 

--- a/OAuth/State/State.php
+++ b/OAuth/State/State.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth\State;
+
+use HWI\Bundle\OAuthBundle\OAuth\Exception\StateRetrievalException;
+use HWI\Bundle\OAuthBundle\OAuth\StateInterface;
+use HWI\Bundle\OAuthBundle\Security\Helper\Nonce;
+use InvalidArgumentException;
+use Symfony\Component\Config\Definition\Exception\DuplicateKeyException;
+
+final class State implements StateInterface
+{
+    const DEFAULT_KEY = 'state';
+    const CSRF_TOKEN_KEY = 'csrf_token';
+
+    /**
+     * @var array
+     */
+    private $values = [];
+
+    /**
+     * @param string|array<string,string>|null The state parameter as a string or assoc array
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct($parameters)
+    {
+        if (!\is_array($parameters)) {
+            $parameters = $this->parseStringParameter($parameters);
+        }
+
+        if (!$this->isAssociatedArray($parameters)) {
+            throw new InvalidArgumentException('Constructor argument should be a non-empty, associative array');
+        }
+
+        foreach ($parameters as $key => $value) {
+            $this->add($key, $value);
+        }
+    }
+
+    /**
+     * @param string The state query parameter string
+     *
+     * @return array<string,string>
+     */
+    private function parseStringParameter($queryParameter)
+    {
+        $urlDecoded = urldecode($queryParameter);
+        $values = json_decode(base64_decode($urlDecoded), 1);
+
+        if (null === $values) {
+            $values[self::DEFAULT_KEY] = $urlDecoded;
+        }
+
+        return $values;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($key, $value)
+    {
+        if (isset($this->values[$key])) {
+            throw new DuplicateKeyException(sprintf('State key [%s] is already set.', $key));
+        }
+
+        $this->values[$key] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($key = self::DEFAULT_KEY)
+    {
+        if (!isset($this->values[$key])) {
+            throw StateRetrievalException::forKey($key);
+        }
+
+        return $this->values[$key];
+    }
+
+    /**
+     * @param string $token
+     */
+    public function setCsrfToken($token = null)
+    {
+        $this->values[self::CSRF_TOKEN_KEY] = $token;
+
+        if (null === $token) {
+            $this->values[self::CSRF_TOKEN_KEY] = Nonce::generate();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAll()
+    {
+        return $this->values;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCsrfToken()
+    {
+        return isset($this->values[self::CSRF_TOKEN_KEY]) ? $this->values[self::CSRF_TOKEN_KEY] : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Encodes the array of values to a string so it can be stored in a query parameter.
+     * Returns the plain value if only the default key or CSRF token has been set.
+     */
+    public function encode()
+    {
+        if ($this->isOnlyExistentKey(self::DEFAULT_KEY)) {
+            return urlencode($this->values[self::DEFAULT_KEY]);
+        }
+
+        if ($this->isOnlyExistentKey(self::CSRF_TOKEN_KEY)) {
+            return urlencode($this->values[self::CSRF_TOKEN_KEY]);
+        }
+
+        return urlencode($this->encodeArray($this->values));
+    }
+
+    /**
+     * @param array The array to encode
+     *
+     * @return string The encoded array
+     */
+    private static function encodeArray($array)
+    {
+        return base64_encode(json_encode($array));
+    }
+
+    /**
+     * Checks if a given key is set in the values array,
+     * and if it's the only key present.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    private function isOnlyExistentKey($key)
+    {
+        return isset($this->values[$key]) && array_keys($this->values) === [$key];
+    }
+
+    /**
+     * @param array
+     *
+     * @return bool
+     */
+    private function isAssociatedArray($array)
+    {
+        if ([] === $array) {
+            return false;
+        }
+
+        return array_keys($array) !== range(0, \count($array) - 1);
+    }
+}

--- a/OAuth/StateInterface.php
+++ b/OAuth/StateInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth;
+
+use HWI\Bundle\OAuthBundle\OAuth\Exception\StateRetrievalException;
+use Symfony\Component\Config\Definition\Exception\DuplicateKeyException;
+
+interface StateInterface
+{
+    /**
+     * @param string $key   The key to store a value to
+     * @param string $value The value to store
+     *
+     * @throws DuplicateKeyException
+     */
+    public function add($key, $value);
+
+    /**
+     * @param string $key
+     *
+     * @return string The value set to this key
+     *
+     * @throws StateRetrievalException
+     */
+    public function get($key);
+
+    /**
+     * @return array
+     */
+    public function getAll();
+
+    public function setCsrfToken();
+
+    /**
+     * @return string|null
+     */
+    public function getCsrfToken();
+
+    /**
+     * @return string
+     */
+    public function encode();
+}

--- a/Resources/doc/2-configuring_resource_owners.md
+++ b/Resources/doc/2-configuring_resource_owners.md
@@ -89,6 +89,11 @@ hwi_oauth:
 ### CSRF protection
 
 Set the _csrf_ option to **true** in the resource owner's configuration in order to protect your users from [CSRF](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)) attacks.
+This will be round-tripped to your application in the `state` parameter. 
+
+Other types of state can be configured under the `state` key, either as a single string or key/value pairs. State can
+also be passed directly in the `state` query parameter of your request, provided they don't override the configured keys
+and are json and base64 encoded, as can be seen in `OAuth/State/State`.
 ```yaml
 # app/config/config.yml
 hwi_oauth:
@@ -99,6 +104,9 @@ hwi_oauth:
             client_secret:       <client_secret>
             options:
                 csrf: true
+                state: 
+                  some: parameter
+                  some-other: parameter
 ```
 
 ### Continue to the next step!

--- a/Resources/doc/internals/reference_configuration.md
+++ b/Resources/doc/internals/reference_configuration.md
@@ -14,6 +14,9 @@ hwi_oauth:
             scope:               "user:email"
             options:
                 csrf:            true
+                state:
+                  some:          parameter
+                  some-other:     parameter
 
         google:
             type:                google

--- a/Security/Core/Authentication/Token/OAuthToken.php
+++ b/Security/Core/Authentication/Token/OAuthToken.php
@@ -67,7 +67,7 @@ class OAuthToken extends AbstractToken
 
         $this->setRawToken($accessToken);
 
-        parent::setAuthenticated(count($roles) > 0);
+        parent::setAuthenticated(\count($roles) > 0);
     }
 
     /**
@@ -101,7 +101,7 @@ class OAuthToken extends AbstractToken
      */
     public function setRawToken($token)
     {
-        if (is_array($token)) {
+        if (\is_array($token)) {
             if (isset($token['access_token'])) {
                 $this->accessToken = $token['access_token'];
             } elseif (isset($token['oauth_token'])) {

--- a/Security/Core/User/EntityUserProvider.php
+++ b/Security/Core/User/EntityUserProvider.php
@@ -105,8 +105,8 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
     {
         $accessor = PropertyAccess::createPropertyAccessor();
         $identifier = $this->properties['identifier'];
-        if (!$accessor->isReadable($user, $identifier) || !$this->supportsClass(get_class($user))) {
-            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_class($user)));
+        if (!$accessor->isReadable($user, $identifier) || !$this->supportsClass(\get_class($user))) {
+            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
         }
 
         $userId = $accessor->getValue($user, $identifier);

--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -97,7 +97,7 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
     public function connect(UserInterface $user, UserResponseInterface $response)
     {
         if (!$user instanceof User) {
-            throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\User, but got "%s".', get_class($user)));
+            throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\User, but got "%s".', \get_class($user)));
         }
 
         $property = $this->getProperty($response);
@@ -142,7 +142,7 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
 
         $identifier = $this->properties['identifier'];
         if (!$user instanceof User || !$this->accessor->isReadable($user, $identifier)) {
-            throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\User, but got "%s".', get_class($user)));
+            throw new UnsupportedUserException(sprintf('Expected an instance of FOS\UserBundle\Model\User, but got "%s".', \get_class($user)));
         }
 
         $userId = $this->accessor->getValue($user, $identifier);

--- a/Security/Core/User/OAuthUserProvider.php
+++ b/Security/Core/User/OAuthUserProvider.php
@@ -44,8 +44,8 @@ class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProvider
      */
     public function refreshUser(UserInterface $user)
     {
-        if (!$this->supportsClass(get_class($user))) {
-            throw new UnsupportedUserException(sprintf('Unsupported user class "%s"', get_class($user)));
+        if (!$this->supportsClass(\get_class($user))) {
+            throw new UnsupportedUserException(sprintf('Unsupported user class "%s"', \get_class($user)));
         }
 
         return $this->loadUserByUsername($user->getUsername());

--- a/Security/Helper/Nonce.php
+++ b/Security/Helper/Nonce.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Security\Helper;
+
+final class Nonce
+{
+    /**
+     * @return string
+     */
+    public static function generate()
+    {
+        return md5(microtime(true).uniqid('', true));
+    }
+}

--- a/Security/Http/Firewall/OAuthListener.php
+++ b/Security/Http/Firewall/OAuthListener.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Security\Http\Firewall;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use HWI\Bundle\OAuthBundle\OAuth\State\State;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -91,7 +92,8 @@ class OAuthListener extends AbstractAuthenticationListener
             return new RedirectResponse(sprintf('%s?code=%s&authenticated=true', $this->httpUtils->generateUri($request, 'hwi_oauth_connect_service'), $request->query->get('code')));
         }
 
-        $resourceOwner->isCsrfTokenValid($request->get('state'));
+        $csrfToken = $this->extractCsrfTokenFromState($request->get('state'));
+        $resourceOwner->isCsrfTokenValid($csrfToken);
 
         $accessToken = $resourceOwner->getAccessToken(
             $request,
@@ -102,5 +104,12 @@ class OAuthListener extends AbstractAuthenticationListener
         $token->setResourceOwnerName($resourceOwner->getName());
 
         return $this->authenticationManager->authenticate($token);
+    }
+
+    private function extractCsrfTokenFromState($stateParameter)
+    {
+        $state = new State($stateParameter);
+
+        return $state->getCsrfToken() ? $state->getCsrfToken() : $stateParameter;
     }
 }

--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -117,6 +117,7 @@ class OAuthUtils
         if ($request->query->get('state')) {
             $this->addQueryParameterToState($request->query->get('state'), $resourceOwner);
         }
+
         return $resourceOwner->getAuthorizationUrl($redirectUrl, $extraParameters);
     }
 
@@ -242,7 +243,7 @@ class OAuthUtils
                 break;
 
             case self::SIGNATURE_METHOD_RSA:
-                if (!function_exists('openssl_pkey_get_private')) {
+                if (!\function_exists('openssl_pkey_get_private')) {
                     throw new \RuntimeException('RSA-SHA1 signature method requires the OpenSSL extension.');
                 }
 

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -65,6 +65,10 @@ class MyCustomProvider implements ResourceOwnerInterface
     public function getState()
     {
     }
+
+    public function addStateParameter($key, $value)
+    {
+    }
 }
 
 /**

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -61,6 +61,10 @@ class MyCustomProvider implements ResourceOwnerInterface
     public function refreshAccessToken($refreshToken, array $extraParameters = array())
     {
     }
+
+    public function getState()
+    {
+    }
 }
 
 /**

--- a/Tests/OAuth/ResourceOwner/AmazonResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/AmazonResourceOwnerTest.php
@@ -31,8 +31,5 @@ json;
         'email' => 'email',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=profile&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=profile&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=profile';
 }

--- a/Tests/OAuth/ResourceOwner/Auth0ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/Auth0ResourceOwnerTest.php
@@ -45,10 +45,7 @@ json;
         'profilepicture' => 'picture',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'https://example.oauth0.com/authorize?auth0Client=eyJuYW1lIjoiSFdJT0F1dGhCdW5kbGUiLCJ2ZXJzaW9uIjoidW5rbm93biIsImVudmlyb25tZW50Ijp7Im5hbWUiOiJQSFAiLCJ2ZXJzaW9uIjoiRkFLRV9QSFBfVkVSU0lPTl9GT1JfVEVTVFMifX0=&response_type=code&client_id=clientid&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'https://example.oauth0.com/authorize?auth0Client=eyJuYW1lIjoiSFdJT0F1dGhCdW5kbGUiLCJ2ZXJzaW9uIjoidW5rbm93biIsImVudmlyb25tZW50Ijp7Im5hbWUiOiJQSFAiLCJ2ZXJzaW9uIjoiRkFLRV9QSFBfVkVSU0lPTl9GT1JfVEVTVFMifX0=&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
+    protected $authorizationUrlBasePart = 'https://example.oauth0.com/authorize?auth0Client=eyJuYW1lIjoiSFdJT0F1dGhCdW5kbGUiLCJ2ZXJzaW9uIjoidW5rbm93biIsImVudmlyb25tZW50Ijp7Im5hbWUiOiJQSFAiLCJ2ZXJzaW9uIjoiRkFLRV9QSFBfVkVSU0lPTl9GT1JfVEVTVFMifX0=&response_type=code&client_id=clientid';
 
     protected function setUpResourceOwner($name, HttpUtils $httpUtils, array $options)
     {

--- a/Tests/OAuth/ResourceOwner/AzureResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/AzureResourceOwnerTest.php
@@ -40,17 +40,8 @@ json;
         'profilepicture' => null,
     );
 
-    protected $expectedUrls = array(
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&resource=https%3A%2F%2Fgraph.windows.net',
-    );
-
-    public function testGetAuthorizationUrl()
-    {
-        $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&resource=https%3A%2F%2Fgraph.windows.net',
-            $this->resourceOwner->getAuthorizationUrl('http://redirect.to/')
-        );
-    }
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid';
+    protected $redirectUrlPart = '&redirect_uri=http%3A%2F%2Fredirect.to%2F&resource=https%3A%2F%2Fgraph.windows.net';
 
     public function testGetUserInformation()
     {

--- a/Tests/OAuth/ResourceOwner/DisqusResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/DisqusResourceOwnerTest.php
@@ -32,8 +32,5 @@ json;
         'realname' => 'response.name',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read';
 }

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -62,7 +62,7 @@ json;
 
     protected function getExpectedAuthorizationUrlWithState($stateParameter)
     {
-        return $this->authorizationUrlBasePart . '&state=' . $stateParameter . $this->redirectUrlPart;
+        return $this->authorizationUrlBasePart.'&state='.$stateParameter.$this->redirectUrlPart;
     }
 
     public function setUp()
@@ -146,7 +146,7 @@ json;
             $this->storage->expects($this->never())
                 ->method('save');
 
-            $expectedUrl = $this->authorizationUrlBasePart . $this->redirectUrlPart;
+            $expectedUrl = $this->authorizationUrlBasePart.$this->redirectUrlPart;
         } else {
             $this->storage->expects($this->once())
                 ->method('save')
@@ -367,10 +367,10 @@ json;
     }
 
     /**
-     * @param string $name
-     * @param array $options
-     * @param array $paths
-     * @param StateInterface $state Optional
+     * @param string         $name
+     * @param array          $options
+     * @param array          $paths
+     * @param StateInterface $state   Optional
      *
      * @throws \ReflectionException
      *
@@ -380,7 +380,7 @@ json;
     {
         $resourceOwner = parent::createResourceOwner($name, $options, $paths);
 
-        $reflection = new \ReflectionClass(get_class($resourceOwner));
+        $reflection = new \ReflectionClass(\get_class($resourceOwner));
         $stateProperty = $reflection->getProperty('state');
         $stateProperty->setAccessible(true);
 

--- a/Tests/OAuth/ResourceOwner/GitLabResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GitLabResourceOwnerTest.php
@@ -18,10 +18,7 @@ class GitLabResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
     protected $resourceOwnerClass = GitLabResourceOwner::class;
     protected $httpClientCalls = 1;
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read_user&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read_user&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read_user';
 
     public function testRevokeToken()
     {

--- a/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
@@ -34,10 +34,8 @@ json;
         'profilepicture' => 'picture',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile';
+    protected $redirectUrlPart = '&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline';
 
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\ExceptionInterface

--- a/Tests/OAuth/ResourceOwner/LinkedinResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/LinkedinResourceOwnerTest.php
@@ -32,8 +32,4 @@ json;
         'profilepicture' => 'pictureUrl',
     );
     protected $csrf = true;
-
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
 }

--- a/Tests/OAuth/ResourceOwner/PaypalResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/PaypalResourceOwnerTest.php
@@ -34,8 +34,5 @@ json;
         'realname' => 'name',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=openid+email&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=openid+email&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=openid+email';
 }

--- a/Tests/OAuth/ResourceOwner/RedditResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/RedditResourceOwnerTest.php
@@ -25,9 +25,7 @@ json;
 
     protected $csrf = true;
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=identity&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=identity';
 
     protected $paths = array(
         'identifier' => 'id',

--- a/Tests/OAuth/ResourceOwner/ResourceOwnerTestCase.php
+++ b/Tests/OAuth/ResourceOwner/ResourceOwnerTestCase.php
@@ -96,7 +96,7 @@ abstract class ResourceOwnerTestCase extends TestCase
             throw new \RuntimeException('Missing resource owner class declaration!');
         }
 
-        if (!in_array(ResourceOwnerInterface::class, class_implements($this->resourceOwnerClass), true)) {
+        if (!\in_array(ResourceOwnerInterface::class, class_implements($this->resourceOwnerClass), true)) {
             throw new \RuntimeException('Class is not implementing "ResourceOwnerInterface"!');
         }
 

--- a/Tests/OAuth/ResourceOwner/SlackResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/SlackResourceOwnerTest.php
@@ -32,8 +32,5 @@ json;
         'nickname' => 'user',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=identify&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=identify&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=identify';
 }

--- a/Tests/OAuth/ResourceOwner/SoundcloudResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/SoundcloudResourceOwnerTest.php
@@ -24,10 +24,7 @@ class SoundcloudResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 }
 json;
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=non-expiring&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=non-expiring&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=non-expiring';
 
     protected $paths = array(
         'identifier' => 'id',

--- a/Tests/OAuth/ResourceOwner/StackExchangeResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/StackExchangeResourceOwnerTest.php
@@ -36,10 +36,7 @@ json;
         'profilepicture' => 'items.0.profile_image',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=no_expiry&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=no_expiry&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=no_expiry';
 
     protected function setUpResourceOwner($name, HttpUtils $httpUtils, array $options)
     {

--- a/Tests/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwnerTest.php
@@ -34,8 +34,6 @@ json;
         'email' => 'identity.email_address',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&redirect_uri=http%3A%2F%2Fredirect.to%2F&type=web_server',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&type=web_server',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid';
+    protected $redirectUrlPart = '&redirect_uri=http%3A%2F%2Fredirect.to%2F&type=web_server';
 }

--- a/Tests/OAuth/ResourceOwner/ToshlResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/ToshlResourceOwnerTest.php
@@ -35,10 +35,6 @@ json;
         'email' => 'email',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
-
     public function testRevokeToken()
     {
         $this->httpResponseHttpCode = 204;

--- a/Tests/OAuth/ResourceOwner/VkontakteResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/VkontakteResourceOwnerTest.php
@@ -31,8 +31,5 @@ json;
         'realname' => 'response.user_name',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=email&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=email&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=email';
 }

--- a/Tests/OAuth/ResourceOwner/WindowsLiveResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/WindowsLiveResourceOwnerTest.php
@@ -29,8 +29,5 @@ json;
         'realname' => 'name',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=wl.signin&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=wl.signin&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=wl.signin';
 }

--- a/Tests/OAuth/ResourceOwner/WunderlistResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/WunderlistResourceOwnerTest.php
@@ -31,8 +31,5 @@ json;
         'realname' => 'data.name',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid';
 }

--- a/Tests/OAuth/ResourceOwner/YoutubeResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/YoutubeResourceOwnerTest.php
@@ -32,10 +32,8 @@ json;
         'profilepicture' => 'picture',
     );
 
-    protected $expectedUrls = array(
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline',
-    );
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly';
+    protected $redirectUrlPart = '&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline';
 
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException

--- a/Tests/OAuth/State/StateTest.php
+++ b/Tests/OAuth/State/StateTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\OAuth\State;
+
+use HWI\Bundle\OAuthBundle\OAuth\Exception\StateRetrievalException;
+use HWI\Bundle\OAuthBundle\OAuth\State\State;
+use HWI\Bundle\OAuthBundle\Security\Helper\Nonce;
+use Symfony\Component\Config\Definition\Exception\DuplicateKeyException;
+
+final class StateTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_VALUES = [
+        'foo' => 'bar',
+        'bar' => 'baz',
+        'foobar' => 'foobaz',
+    ];
+
+    public function testConstructorWithEncodedParameter()
+    {
+        $queryParameter = $this->encodeArray(self::TEST_VALUES);
+        $state = new State($queryParameter);
+
+        foreach (self::TEST_VALUES as $key => $value) {
+            self::assertEquals($value, $state->get($key));
+        }
+    }
+
+    public function testConstructorWithSingleValue()
+    {
+        $state = new State('random');
+        self::assertEquals('random', $state->get());
+    }
+
+    public function testConstructorWithArrayParameter()
+    {
+        $state = new State(self::TEST_VALUES);
+
+        foreach (self::TEST_VALUES as $key => $value) {
+            self::assertEquals($value, $state->get($key));
+        }
+    }
+
+    public function testFromEncodedParameterWithInvalidFormat()
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        $values = ['some', 'indexed', 'array'];
+        $queryParameter = $this->encodeArray($values);
+
+        new State($queryParameter);
+    }
+
+    public function testGetNonExistentValue()
+    {
+        $state = new State($this->encodeArray(self::TEST_VALUES));
+        self::expectException(StateRetrievalException::class);
+        $state->get('baz');
+    }
+
+    public function testAdd()
+    {
+        $state = new State($this->encodeArray(self::TEST_VALUES));
+
+        $state->add('baz', 'foo');
+        self::assertEquals('foo', $state->get('baz'));
+    }
+
+    public function testAddDuplicateKey()
+    {
+        self::expectException(DuplicateKeyException::class);
+
+        $state = new State($this->encodeArray(self::TEST_VALUES));
+        $state->add('foo', 'foobar');
+    }
+
+    public function testEncode()
+    {
+        $expectedParameter = $this->encodeArray(self::TEST_VALUES);
+        $state = new State($expectedParameter);
+
+        self::assertEquals($expectedParameter, $state->encode());
+    }
+
+    public function testEncodeOnlyValue()
+    {
+        $state = new State('random');
+        self::assertEquals('random', $state->encode());
+    }
+
+    public function testEncodeEmptyValue()
+    {
+        $state = new State(null);
+        self::assertNull($state->encode());
+    }
+
+    public function testSetCsrfTokenSetsProvidedToken()
+    {
+        $token = Nonce::generate();
+        $state = new State(null);
+
+        $state->setCsrfToken($token);
+        self::assertEquals($token, $state->getCsrfToken());
+    }
+
+    public function testSetCsrfTokenGeneratesToken()
+    {
+        $state = new State(null);
+        self::assertNull($state->getCsrfToken());
+
+        $state->setCsrfToken();
+        self::assertNotNull($state->getCsrfToken());
+    }
+
+    /**
+     * @param array $array The array to encode
+     *
+     * @return string The encoded result
+     */
+    private function encodeArray($array)
+    {
+        return urlencode(base64_encode(json_encode($array)));
+    }
+}

--- a/Tests/Security/Core/User/OAuthUserProviderTest.php
+++ b/Tests/Security/Core/User/OAuthUserProviderTest.php
@@ -57,7 +57,7 @@ class OAuthUserProviderTest extends TestCase
 
     public function testSupportsClass()
     {
-        $class = get_class(new OAuthUser('asm89'));
+        $class = \get_class(new OAuthUser('asm89'));
 
         $this->assertTrue($this->provider->supportsClass($class));
         $this->assertFalse($this->provider->supportsClass('\Some\Other\Class'));

--- a/Tests/Security/OAuthUtilsTest.php
+++ b/Tests/Security/OAuthUtilsTest.php
@@ -74,7 +74,7 @@ class OAuthUtilsTest extends TestCase
         $url = 'http://localhost:8080/login/check-instagram';
         $redirect = 'https://api.instagram.com/oauth/authorize?redirect='.rawurlencode($url);
 
-        $request = $this->getRequest($url . '?state=' . $state->encode());
+        $request = $this->getRequest($url.'?state='.$state->encode());
         $resource = $this->getMockBuilder(ResourceOwnerInterface::class)->getMock();
 
         $utils = new OAuthUtils($this->getHttpUtils($url), $this->getAutorizationChecker(false, $this->grantRule), true, $this->grantRule);

--- a/Tests/Security/OAuthUtilsTest.php
+++ b/Tests/Security/OAuthUtilsTest.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Tests\Security;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use HWI\Bundle\OAuthBundle\OAuth\State\State;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use PHPUnit\Framework\TestCase;
@@ -52,7 +53,7 @@ class OAuthUtilsTest extends TestCase
         $redirect = 'https://api.instagram.com/oauth/authorize?redirect='.rawurlencode($url);
 
         $utils = new OAuthUtils($this->getHttpUtils($url), $this->getAutorizationChecker(true, $this->grantRule), true, $this->grantRule);
-        $utils->addResourceOwnerMap($this->getMap($url, $redirect, true));
+        $utils->addResourceOwnerMap($this->getMap($url, $redirect, true, false));
 
         $this->assertEquals(
             $redirect,
@@ -62,6 +63,30 @@ class OAuthUtilsTest extends TestCase
         $this->assertEquals(
             'instagram',
             $request->attributes->get('service')
+        );
+    }
+
+    public function testGetAuthorizationUrlWithStateQueryParameters()
+    {
+        $parameters = ['foo' => 'bar', 'foobar' => 'foobaz'];
+        $state = new State($parameters);
+
+        $url = 'http://localhost:8080/login/check-instagram';
+        $redirect = 'https://api.instagram.com/oauth/authorize?redirect='.rawurlencode($url);
+
+        $request = $this->getRequest($url . '?state=' . $state->encode());
+        $resource = $this->getMockBuilder(ResourceOwnerInterface::class)->getMock();
+
+        $utils = new OAuthUtils($this->getHttpUtils($url), $this->getAutorizationChecker(false, $this->grantRule), true, $this->grantRule);
+        $utils->addResourceOwnerMap($this->getMap($url, $redirect, false, false, $resource));
+
+        $resource->expects($this->exactly(2))
+            ->method('addStateParameter')
+            ->withConsecutive(['foo', 'bar'], ['foobar', 'foobaz']);
+
+        $this->assertEquals(
+            $redirect,
+            $utils->getAuthorizationUrl($request, 'instagram')
         );
     }
 
@@ -163,9 +188,9 @@ class OAuthUtilsTest extends TestCase
         return Request::create($url, 'get', array(), array(), array(), array('SERVER_PORT' => 8080));
     }
 
-    private function getMap($url, $redirect, $hasUser = false, $hasOneRedirectUrl = false)
+    private function getMap($url, $redirect, $hasUser = false, $hasOneRedirectUrl = false, $resource = null)
     {
-        $resource = $this->getMockBuilder(ResourceOwnerInterface::class)
+        $resource = null !== $resource ? $resource : $this->getMockBuilder(ResourceOwnerInterface::class)
             ->getMock();
 
         $resource

--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,8 @@
         "php-http/httplug":               "^1.0",
         "php-http/client-common":         "^1.3",
         "php-http/message-factory":       "^1.0",
-        "php-http/discovery":             "^1.0"
+        "php-http/discovery":             "^1.0",
+        "ext-json": "^1.5"
     },
 
     "require-dev": {


### PR DESCRIPTION
Closes [this issue](https://github.com/hwi/HWIOAuthBundle/issues/1410) and [this one](https://github.com/hwi/HWIOAuthBundle/issues/1145).

It was already possible to pass extra query parameters and round-trip them, but not as part of the `state` query parameter. Because this PR adds an entity to hold and base64/json encode `State`, we can now pass more than one value in this object. 

Alternatively, a locally generated CSRF token can be passed and used to store any sort of state locally in the application. When it round-trips you can then use that taken do look up the state.