### PR TITLE
Updating SensioConnect to use the new URLs

### DIFF
--- a/OAuth/ResourceOwner/SensioConnectResourceOwner.php
+++ b/OAuth/ResourceOwner/SensioConnectResourceOwner.php
@@ -45,9 +45,9 @@ class SensioConnectResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
-            'authorization_url' => 'https://connect.sensiolabs.com/oauth/authorize',
-            'access_token_url' => 'https://connect.sensiolabs.com/oauth/access_token',
-            'infos_url' => 'https://connect.sensiolabs.com/api',
+            'authorization_url' => 'https://connect.symfony.com/oauth/authorize',
+            'access_token_url' => 'https://connect.symfony.com/oauth/access_token',
+            'infos_url' => 'https://connect.symfony.com/api',
 
             'user_response_class' => SensioConnectUserResponse::class,
 

--- a/Resources/doc/2-configuring_resource_owners.md
+++ b/Resources/doc/2-configuring_resource_owners.md
@@ -67,7 +67,7 @@ hwi_oauth:
 - [QQ](resource_owners/qq.md)
 - [Reddit](resource_owners/reddit.md)
 - [Salesforce](resource_owners/salesforce.md)
-- [SensioLabs Connect](resource_owners/sensio_connect.md)
+- [Symfony Connect](resource_owners/sensio_connect.md)
 - [Sina Weibo](resource_owners/sina_weibo.md)
 - [Spotify](resource_owners/spotify.md)
 - [Soundcloud](resource_owners/soundcloud.md)

--- a/Resources/doc/resource_owners/sensio_connect.md
+++ b/Resources/doc/resource_owners/sensio_connect.md
@@ -1,6 +1,6 @@
-Step 2x: Setup SensioLabs Connect
-=================================
-First you will have to register your application on [SensioLabs Connect](https://connect.sensiolabs.com/account/app/new).
+Step 2x: Setup Symfony (formerly SensioLabs) Connect
+====================================================
+First you will have to register your application on [Symfony Connect](https://connect.symfony.com/account/app/new).
 
 Next configure a resource owner of type `sensio_connect` with appropriate
 `client_id`, `client_secret` and `scope`. All those information will be


### PR DESCRIPTION
At this moment, the SSL cert on the old URLs is broken. So, until now, this change wasn't strictly needed (the old URLs still worked), but at this moment it is. But I don't believe there is any difference in behavior - we just made this change manually for SymfonyCasts by overriding this config.

We could go further in the future and change the config keys, class names, etc. But in this PR, I strictly wanted to get things working.