### PR TITLE
Use Linkedin API v2 to fetch user info

### DIFF
--- a/OAuth/ResourceOwner/LinkedinResourceOwner.php
+++ b/OAuth/ResourceOwner/LinkedinResourceOwner.php
@@ -11,6 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
+use HWI\Bundle\OAuthBundle\OAuth\Response\LinkedinUserResponse;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -26,13 +27,38 @@ class LinkedinResourceOwner extends GenericOAuth2ResourceOwner
      */
     protected $paths = array(
         'identifier' => 'id',
-        'nickname' => 'formattedName',
+        'nickname' => 'emailAddress',
         'firstname' => 'firstName',
         'lastname' => 'lastName',
-        'realname' => 'formattedName',
         'email' => 'emailAddress',
-        'profilepicture' => 'pictureUrl',
+        'profilepicture' => 'profilePicture',
     );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUserInformation(array $accessToken, array $extraParameters = array())
+    {
+        $response = parent::getUserInformation($accessToken, $extraParameters);
+
+        $responseData = $response->getData();
+        // The user info returned by /me doesn't contain the email so we make an extra request to fetch it
+        $content = $this->httpRequest(
+            $this->normalizeUrl($this->options['email_url'], $extraParameters),
+            null,
+            array('Authorization' => 'Bearer '.$accessToken['access_token'])
+        );
+
+        $emailResponse = $this->getResponseContent($content);
+        if (isset($emailResponse['elements']) && count($emailResponse['elements']) > 0) {
+            $responseData['emailAddress'] = $emailResponse['elements'][0]['handle~']['emailAddress'];
+        }
+        // errors not handled because I don't see any relevant thing to do with them
+
+        $response->setData($responseData);
+
+        return $response;
+    }
 
     /**
      * {@inheritdoc}
@@ -45,10 +71,13 @@ class LinkedinResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritdoc}
      */
-    protected function doGetUserInformationRequest($url, array $parameters = array())
+    protected function httpRequest($url, $content = null, array $headers = [], $method = null)
     {
-        // LinkedIn uses different variable as they still support OAuth1.0a
-        return parent::doGetUserInformationRequest(str_replace('access_token', 'oauth2_access_token', $url), $parameters);
+        // Linkedin v2 API is supposed to require Content-Type: application/json but it works without
+        // and request to get the access token doesn't seems to work with Content-Type: application/json
+        // so we don't put any Content-Type header.
+        // Skip the Content-Type header in GenericOAuth2ResourceOwner::httpRequest
+        return AbstractResourceOwner::httpRequest($url, $content, $headers, $method);
     }
 
     /**
@@ -59,13 +88,17 @@ class LinkedinResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
+            'scope' => 'r_liteprofile r_emailaddress',
             'authorization_url' => 'https://www.linkedin.com/oauth/v2/authorization',
             'access_token_url' => 'https://www.linkedin.com/oauth/v2/accessToken',
-            'infos_url' => 'https://api.linkedin.com/v1/people/~:(id,first-name,last-name,formatted-name,email-address,picture-url)?format=json',
+            'infos_url' => 'https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))',
+            'email_url' => 'https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))',
+
+            'user_response_class' => LinkedinUserResponse::class,
 
             'csrf' => true,
 
-            'use_bearer_authorization' => false,
+            'use_bearer_authorization' => true,
         ));
     }
 }

--- a/OAuth/Response/LinkedinUserResponse.php
+++ b/OAuth/Response/LinkedinUserResponse.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace HWI\Bundle\OAuthBundle\OAuth\Response;
+
+
+class LinkedinUserResponse extends PathUserResponse
+{
+    /**
+     * Helper to extract the preferred locale value from MultiLocaleString
+     * https://docs.microsoft.com/en-us/linkedin/shared/references/v2/object-types#multilocalestring
+     *
+     * @param $path
+     * @return mixed
+     */
+    protected function getPreferredLocaleValue($path)
+    {
+        $multiLocaleString = $this->getValueForPath($path);
+        $preferredLocale = $multiLocaleString['preferredLocale']['language'] . '_' . $multiLocaleString['preferredLocale']['country'];
+        return $multiLocaleString['localized'][$preferredLocale];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFirstName()
+    {
+        return $this->getPreferredLocaleValue('firstname');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastName()
+    {
+        return $this->getPreferredLocaleValue('lastname');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProfilePicture()
+    {
+        // https://docs.microsoft.com/en-us/linkedin/shared/references/v2/profile/profile-picture
+        $profilePicture = $this->getValueForPath('profilepicture');
+        if (
+            !isset($profilePicture['displayImage~'])
+            || !isset($profilePicture['displayImage~']['elements'])
+            || count($profilePicture['displayImage~']['elements']) == 0
+        ) {
+            return null;
+        }
+
+        $publicElements = array_filter($profilePicture['displayImage~']['elements'], function($element) {
+            return $element['authorizationMethod'] === 'PUBLIC';
+        });
+        if (count($publicElements) == 0) return null;
+
+        // the last images seems to always be the one with the best quality so we take this one
+        $element = array_values(array_slice($publicElements, -1))[0];
+        return $element['identifiers'][0]['identifier'];
+    }
+}

--- a/Resources/doc/resource_owners/linkedin.md
+++ b/Resources/doc/resource_owners/linkedin.md
@@ -5,8 +5,8 @@ documentation for more information: https://developer.linkedin.com/documents/aut
 
 Next configure a resource owner of type `linkedin` with appropriate `client_id`,
 `client_secret` and `scope`.
-Example of values for scope: `r_basicprofile`, `r_emailaddress`, `r_fullprofile` 
-as described by [Linkedin API](https://developer.linkedin.com/documents/profile-fields)
+Example of values for scope: `r_liteprofile`, `r_emailaddress`
+as described by [Linkedin API](https://docs.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin/context#step-2-request-an-authorization-code)
 
 ```yaml
 # app/config.yml

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":        "hwi/oauth-bundle",
+    "name":        "smyler/oauth-bundle",
     "type":        "symfony-bundle",
     "homepage":    "http://github.com/hwi/HWIOAuthBundle",
     "license":     "MIT",


### PR DESCRIPTION
Linkedin has depreciate its v1 API; it will stop working on the 1st March
2019 (https://engineering.linkedin.com/blog/2018/12/developer-program-updates).

The change to the v2 was done for the authorization & access_token
endpoints in 8951d956baf1 but the endpoint to fetch the info was still v1.

The v2 endpoint return a very different payload; there is a lot less info
with the default permission and there isn't the email address anymore.
Therefore an extra request is done to get the user's email address and a
custom UserResponse has been written to support the complex JSON schema.

Note: I get some inspiration from https://github.com/laravel/socialite/pull/310/files