### PR TITLE
Keycloak Provider

### DIFF
--- a/OAuth/ResourceOwner/KeycloakResourceOwner.php
+++ b/OAuth/ResourceOwner/KeycloakResourceOwner.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: andreaquintino
+ * Date: 17/01/19
+ * Time: 17.18
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * KeycloakResourceOwner.
+ *
+ * @author Andrea Quintino <andreaquin1990@gmail.com>
+ */
+class KeycloakResourceOwner extends GenericOAuth2ResourceOwner
+{
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+          ->setRequired('realms')
+          ->setRequired('protocol')
+          ->setDefault('protocol', 'openid-connect');
+    }
+}

--- a/OAuth/ResourceOwner/KeycloakResourceOwner.php
+++ b/OAuth/ResourceOwner/KeycloakResourceOwner.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andreaquintino
- * Date: 17/01/19
- * Time: 17.18
- */
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 

--- a/OAuth/ResourceOwner/KeycloakResourceOwner.php
+++ b/OAuth/ResourceOwner/KeycloakResourceOwner.php
@@ -17,14 +17,45 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class KeycloakResourceOwner extends GenericOAuth2ResourceOwner
 {
+    public function configure()
+    {
+        $this->prepareBaseAuthenticationUrl();
+    }
+
+    public function getAuthorizationUrl($redirectUri, array $extraParameters = array())
+    {
+        return parent::getAuthorizationUrl($redirectUri, array_merge([
+          'approval_prompt' => $this->getOption('approval_prompt')
+        ],$extraParameters));
+    }
 
     public function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
 
         $resolver
+          ->setDefined(['protocol', 'response_type', 'approval_prompt'])
           ->setRequired('realms')
-          ->setRequired('protocol')
-          ->setDefault('protocol', 'openid-connect');
+          ->setDefaults([
+            'protocol' => 'openid-connect',
+            'scope' =>  'name,email',
+            'response_type' => 'code',
+            'approval_prompt' => 'auto'
+          ]);
+    }
+
+    protected function prepareBaseAuthenticationUrl()
+    {
+        $baseAuthUrl = trim($this->getOption('authorization_url'), '/');
+        //check if already configured
+        if(strpos($baseAuthUrl, '/realms') !== false) {
+            return;
+        }
+
+        $baseAuthUrl .= '/realms/'.$this->getOption('realms');
+        $baseAuthUrl .= '/protocol/'.$this->getOption('protocol').'/auth';
+
+        $this->options['authorization_url'] = $baseAuthUrl;
+
     }
 }

--- a/OAuth/ResourceOwner/KeycloakResourceOwner.php
+++ b/OAuth/ResourceOwner/KeycloakResourceOwner.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -16,11 +25,11 @@ class KeycloakResourceOwner extends GenericOAuth2ResourceOwner
         $this->prepareBaseAuthenticationUrl();
     }
 
-    public function getAuthorizationUrl($redirectUri, array $extraParameters = array())
+    public function getAuthorizationUrl($redirectUri, array $extraParameters = [])
     {
         return parent::getAuthorizationUrl($redirectUri, array_merge([
-          'approval_prompt' => $this->getOption('approval_prompt')
-        ],$extraParameters));
+          'approval_prompt' => $this->getOption('approval_prompt'),
+        ], $extraParameters));
     }
 
     public function configureOptions(OptionsResolver $resolver)
@@ -32,9 +41,9 @@ class KeycloakResourceOwner extends GenericOAuth2ResourceOwner
           ->setRequired('realms')
           ->setDefaults([
             'protocol' => 'openid-connect',
-            'scope' =>  'name,email',
+            'scope' => 'name,email',
             'response_type' => 'code',
-            'approval_prompt' => 'auto'
+            'approval_prompt' => 'auto',
           ]);
     }
 
@@ -42,7 +51,7 @@ class KeycloakResourceOwner extends GenericOAuth2ResourceOwner
     {
         $baseAuthUrl = trim($this->getOption('authorization_url'), '/');
         //check if already configured
-        if(strpos($baseAuthUrl, '/realms') !== false) {
+        if (false !== strpos($baseAuthUrl, '/realms')) {
             return;
         }
 
@@ -50,6 +59,5 @@ class KeycloakResourceOwner extends GenericOAuth2ResourceOwner
         $baseAuthUrl .= '/protocol/'.$this->getOption('protocol').'/auth';
 
         $this->options['authorization_url'] = $baseAuthUrl;
-
     }
 }

--- a/Tests/OAuth/ResourceOwner/KeycloakResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/KeycloakResourceOwnerTest.php
@@ -12,5 +12,22 @@ use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\KeycloakResourceOwner;
 
 class KeycloakResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
+    protected $options = array(
+      'client_id' => 'clientid',
+      'client_secret' => 'clientsecret',
+      'realms' => 'example',
+
+      'infos_url' => 'http://keycloak.info/auth',
+      'authorization_url' => 'http://keycloak.auth/auth',
+      'access_token_url' => 'http://keycloak.auth/auth',
+
+      'attr_name' => 'access_token',
+    );
+
+    protected $expectedUrls = array(
+      'authorization_url' => 'http://keycloak.auth/auth/realms/example/protocol/openid-connect/auth?response_type=code&client_id=clientid&scope=name%2Cemail&redirect_uri=http%3A%2F%2Fredirect.to%2F&approval_prompt=auto',
+      'authorization_url_csrf' => 'http://keycloak.auth/auth/realms/example/protocol/openid-connect/auth?response_type=code&client_id=clientid&scope=name%2Cemail&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&approval_prompt=auto',
+    );
+
     protected $resourceOwnerClass = KeycloakResourceOwner::class;
 }

--- a/Tests/OAuth/ResourceOwner/KeycloakResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/KeycloakResourceOwnerTest.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: andreaquintino
+ * Date: 17/01/19
+ * Time: 17.12
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\KeycloakResourceOwner;
+
+class KeycloakResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
+{
+    protected $resourceOwnerClass = KeycloakResourceOwner::class;
+}

--- a/Tests/OAuth/ResourceOwner/KeycloakResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/KeycloakResourceOwnerTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andreaquintino
- * Date: 17/01/19
- * Time: 17.12
- */
 
 namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
 

--- a/Tests/OAuth/ResourceOwner/KeycloakResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/KeycloakResourceOwnerTest.php
@@ -1,12 +1,21 @@
 <?php
 
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\KeycloakResourceOwner;
 
 class KeycloakResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
-    protected $options = array(
+    protected $options = [
       'client_id' => 'clientid',
       'client_secret' => 'clientsecret',
       'realms' => 'example',
@@ -16,12 +25,12 @@ class KeycloakResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
       'access_token_url' => 'http://keycloak.auth/auth',
 
       'attr_name' => 'access_token',
-    );
+    ];
 
-    protected $expectedUrls = array(
+    protected $expectedUrls = [
       'authorization_url' => 'http://keycloak.auth/auth/realms/example/protocol/openid-connect/auth?response_type=code&client_id=clientid&scope=name%2Cemail&redirect_uri=http%3A%2F%2Fredirect.to%2F&approval_prompt=auto',
       'authorization_url_csrf' => 'http://keycloak.auth/auth/realms/example/protocol/openid-connect/auth?response_type=code&client_id=clientid&scope=name%2Cemail&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&approval_prompt=auto',
-    );
+    ];
 
     protected $resourceOwnerClass = KeycloakResourceOwner::class;
 }


### PR DESCRIPTION
Hello guys, we created a new authentication provider integration for [keycloak](https://www.keycloak.org/) which is an open source identity and access management system. 

We actually need also to integrate this provider in 0.5 version for our purposes.  How should we proceed about it? Can you provide a backport or should we open another PR for 0.5 version?

Thanks a lot 