### PR TITLE
Do not show deprecation warnings during tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit bootstrap="./Tests/bootstrap.php" colors="true">
-
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+    </php>
     <testsuites>
         <testsuite name="HWIOAuthBundle test suite">
             <directory suffix="Test.php">./Tests</directory>


### PR DESCRIPTION
The last build jobs using php 7.x are failing due to a deprecation warning.

I just fixed them adding an env variable in phpunit config file, according to [this](https://travis-ci.org/hwi/HWIOAuthBundle/jobs/489134389).