### PR TITLE
YahooResourceOwner > Fix inconsistency in arguments

### DIFF
--- a/OAuth/ResourceOwner/YahooResourceOwner.php
+++ b/OAuth/ResourceOwner/YahooResourceOwner.php
@@ -49,7 +49,7 @@ class YahooResourceOwner extends GenericOAuth1ResourceOwner
      */
     protected function doGetUserInformationRequest($url, array $parameters = array())
     {
-        return $this->httpRequest($url, null, $parameters, array('Accept: application/json'));
+        return $this->httpRequest($url, null, array('Accept: application/json'), null, $parameters);
     }
 
     /**


### PR DESCRIPTION
Somehow this was not caught by the test suite.

```php
protected function httpRequest($url, $content = null, array $headers = array(), $method = null, array $parameters = array())
```

