### PR TITLE
Move to abstract controller

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -19,7 +19,7 @@ use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -38,7 +38,7 @@ use Symfony\Component\Security\Http\SecurityEvents;
 /**
  * @author Alexander <iam.asm89@gmail.com>
  */
-class ConnectController extends Controller
+class ConnectController extends AbstractController
 {
     /**
      * Action that handles the login 'form'. If connecting is enabled the

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This bundle contains support for 58 different providers:
 * Itembase,
 * Jawbone,
 * JIRA,
+* Keycloak,
 * LinkedIn,
 * Mail.ru
 * Odnoklassniki,


### PR DESCRIPTION
[BC Proposal] I want to replace old Symfony Controller with AbstractController. I remove support with php5.6 and Symfony ^2.8 to make it possible.

What do you think?


Made with :heart: by [![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)