### PR TITLE
Allow to use authentication in "get token requests" to match OAuth2 RFC

### DIFF
--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -166,9 +166,11 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
     protected function doGetTokenRequest($url, array $parameters = [])
     {
         $query = http_build_query($parameters, '', '&');
-        $headers = [
-            'Authorization' => 'Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret']),
-        ];
+        $headers = [];
+
+        if ($this->options['client_secret']) {
+            $headers['Authorization'] = 'Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret']);
+        }
 
         return $this->httpRequest($url, $query, $headers);
     }

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -167,7 +167,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
     {
         $headers = [];
 
-        if ($this->options['get_token_with_basic_auth']) {
+        if ($this->options['use_authorization_to_get_token']) {
             if ($this->options['client_secret']) {
                 $headers['Authorization'] = 'Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret']);
             }
@@ -220,7 +220,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
             'attr_name' => 'access_token',
             'use_commas_in_scope' => false,
             'use_bearer_authorization' => true,
-            'get_token_with_basic_auth' => true,
+            'use_authorization_to_get_token' => true,
         ]);
 
         $resolver->setDefined('revoke_token_url');

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -87,8 +87,6 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
         $parameters = array_merge([
             'code' => $request->query->get('code'),
             'grant_type' => 'authorization_code',
-            'client_id' => $this->options['client_id'],
-            'client_secret' => $this->options['client_secret'],
             'redirect_uri' => $redirectUri,
         ], $extraParameters);
 
@@ -108,8 +106,6 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
         $parameters = array_merge([
             'refresh_token' => $refreshToken,
             'grant_type' => 'refresh_token',
-            'client_id' => $this->options['client_id'],
-            'client_secret' => $this->options['client_secret'],
         ], $extraParameters);
 
         $response = $this->doGetTokenRequest($this->options['access_token_url'], $parameters);
@@ -169,7 +165,12 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
      */
     protected function doGetTokenRequest($url, array $parameters = [])
     {
-        return $this->httpRequest($url, http_build_query($parameters, '', '&'));
+        $query = http_build_query($parameters, '', '&');
+        $headers = [
+            'Authorization' => 'Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret']),
+        ];
+
+        return $this->httpRequest($url, $query, $headers);
     }
 
     /**

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -165,12 +165,18 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
      */
     protected function doGetTokenRequest($url, array $parameters = [])
     {
-        $query = http_build_query($parameters, '', '&');
         $headers = [];
 
-        if ($this->options['client_secret']) {
-            $headers['Authorization'] = 'Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret']);
+        if ($this->options['get_token_with_basic_auth']) {
+            if ($this->options['client_secret']) {
+                $headers['Authorization'] = 'Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret']);
+            }
+        } else {
+            $parameters['client_id'] = $this->options['client_id'];
+            $parameters['client_secret'] = $this->options['client_secret'];
         }
+
+        $query = http_build_query($parameters, '', '&');
 
         return $this->httpRequest($url, $query, $headers);
     }
@@ -214,6 +220,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
             'attr_name' => 'access_token',
             'use_commas_in_scope' => false,
             'use_bearer_authorization' => true,
+            'get_token_with_basic_auth' => true,
         ]);
 
         $resolver->setDefined('revoke_token_url');


### PR DESCRIPTION
This PR fixes #1513: the token request for the generic OAuth2 resource owner was sending the client secret in the body, which is not preferred and discouraged by the RFC.