### PR TITLE
Fix generic resource owner example

### DIFF
--- a/Resources/doc/resource_owners/others.md
+++ b/Resources/doc/resource_owners/others.md
@@ -12,6 +12,7 @@ hwi_oauth:
     resource_owners:
         my_custom:
             type:                oauth2
+            class:               \HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner
             client_id:           <client_id>
             client_secret:       <client_secret>
             access_token_url:    https://path.to/oauth/v2/token
@@ -34,6 +35,7 @@ hwi_oauth:
     resource_owners:
         my_custom:
             type:                oauth1
+            class:               \HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth1ResourceOwner
             client_id:           <client_id>
             client_secret:       <client_secret>
             request_token_url:   https://path.to/oauth/v1/requestToken


### PR DESCRIPTION
While testing #1514, I discovered that the doc example for a generic resource owner is broken, because the `class` option is no longer optional.

This fixes the docs example.