### PR TITLE
Remove DefinitionDecorator check

### DIFF
--- a/DependencyInjection/Security/Factory/OAuthFactory.php
+++ b/DependencyInjection/Security/Factory/OAuthFactory.php
@@ -15,7 +15,6 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractF
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -68,8 +67,6 @@ class OAuthFactory extends AbstractFactory
      */
     protected function createResourceOwnerMap(ContainerBuilder $container, $id, array $config)
     {
-        $definitionClassname = $this->getDefinitionClassname();
-
         $resourceOwnersMap = [];
         foreach ($config['resource_owners'] as $name => $checkPath) {
             $resourceOwnersMap[$name] = $checkPath;
@@ -77,7 +74,7 @@ class OAuthFactory extends AbstractFactory
         $container->setParameter('hwi_oauth.resource_ownermap.configured.'.$id, $resourceOwnersMap);
 
         $container
-            ->setDefinition($this->getResourceOwnerMapReference($id), new $definitionClassname('hwi_oauth.abstract_resource_ownermap'))
+            ->setDefinition($this->getResourceOwnerMapReference($id), new ChildDefinition('hwi_oauth.abstract_resource_ownermap'))
             ->replaceArgument(2, new Parameter('hwi_oauth.resource_ownermap.configured.'.$id))
             ->setPublic(true)
         ;
@@ -100,13 +97,12 @@ class OAuthFactory extends AbstractFactory
      */
     protected function createAuthProvider(ContainerBuilder $container, $id, $config, $userProviderId)
     {
-        $definitionClassname = $this->getDefinitionClassname();
         $providerId = 'hwi_oauth.authentication.provider.oauth.'.$id;
 
         $this->createResourceOwnerMap($container, $id, $config);
 
         $container
-            ->setDefinition($providerId, new $definitionClassname('hwi_oauth.authentication.provider.oauth'))
+            ->setDefinition($providerId, new ChildDefinition('hwi_oauth.authentication.provider.oauth'))
             ->addArgument($this->createOAuthAwareUserProvider($container, $id, $config['oauth_user_provider']))
             ->addArgument($this->getResourceOwnerMapReference($id))
             ->addArgument(new Reference('hwi_oauth.user_checker'))
@@ -118,19 +114,18 @@ class OAuthFactory extends AbstractFactory
 
     protected function createOAuthAwareUserProvider(ContainerBuilder $container, $id, $config)
     {
-        $definitionClassname = $this->getDefinitionClassname();
         $serviceId = 'hwi_oauth.user.provider.entity.'.$id;
 
         // todo: move this to factories?
         switch (key($config)) {
             case 'oauth':
                 $container
-                    ->setDefinition($serviceId, new $definitionClassname('hwi_oauth.user.provider'))
+                    ->setDefinition($serviceId, new ChildDefinition('hwi_oauth.user.provider'))
                 ;
                 break;
             case 'orm':
                 $container
-                    ->setDefinition($serviceId, new $definitionClassname('hwi_oauth.user.provider.entity'))
+                    ->setDefinition($serviceId, new ChildDefinition('hwi_oauth.user.provider.entity'))
                     ->addArgument($config['orm']['class'])
                     ->addArgument($config['orm']['properties'])
                     ->addArgument($config['orm']['manager_name'])
@@ -151,10 +146,9 @@ class OAuthFactory extends AbstractFactory
     protected function createEntryPoint($container, $id, $config, $defaultEntryPoint)
     {
         $entryPointId = 'hwi_oauth.authentication.entry_point.oauth.'.$id;
-        $definitionClassname = $this->getDefinitionClassname();
 
         $container
-            ->setDefinition($entryPointId, new $definitionClassname('hwi_oauth.authentication.entry_point.oauth'))
+            ->setDefinition($entryPointId, new ChildDefinition('hwi_oauth.authentication.entry_point.oauth'))
             ->addArgument($config['login_path'])
             ->addArgument($config['use_forward'])
         ;
@@ -259,13 +253,5 @@ class OAuthFactory extends AbstractFactory
                 ->end()
             ->end()
         ;
-    }
-
-    /**
-     * @return string
-     */
-    private function getDefinitionClassname()
-    {
-        return class_exists(ChildDefinition::class) ? ChildDefinition::class : DefinitionDecorator::class;
     }
 }


### PR DESCRIPTION
We can safely remove `DefinitionDecorator` as the upcoming 1.0 release focuses on Symfony 3.4|4.2