### PR TITLE
Fix controller syntax in routing files

### DIFF
--- a/Resources/config/routing/connect.xml
+++ b/Resources/config/routing/connect.xml
@@ -5,10 +5,10 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="hwi_oauth_connect_service" path="/service/{service}">
-        <default key="_controller">hwi_oauth.controller::connectServiceAction</default>
+        <default key="_controller">hwi_oauth.controller:connectServiceAction</default>
     </route>
 
     <route id="hwi_oauth_connect_registration" path="/registration/{key}">
-        <default key="_controller">hwi_oauth.controller::registrationAction</default>
+        <default key="_controller">hwi_oauth.controller:registrationAction</default>
     </route>
 </routes>

--- a/Resources/config/routing/login.xml
+++ b/Resources/config/routing/login.xml
@@ -5,6 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="hwi_oauth_connect" path="/">
-        <default key="_controller">hwi_oauth.controller::connectAction</default>
+        <default key="_controller">hwi_oauth.controller:connectAction</default>
     </route>
 </routes>

--- a/Resources/config/routing/redirect.xml
+++ b/Resources/config/routing/redirect.xml
@@ -5,6 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="hwi_oauth_service_redirect" path="/{service}">
-        <default key="_controller">hwi_oauth.controller::redirectToServiceAction</default>
+        <default key="_controller">hwi_oauth.controller:redirectToServiceAction</default>
     </route>
 </routes>


### PR DESCRIPTION
As reported in #1522, this bundle routing is currently broken.

Symfony supports two syntax for the _controller key in routing files:
* `FQCN::action`
* or `service_name:action`

It appears both syntax have been mixed up together: the first syntax
only works when the service name is a FQCN, whereas the controller
service is currently named using a custom string (non-FQCN).