### PR TITLE
Fix serialization token test

### DIFF
--- a/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
+++ b/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
@@ -106,9 +106,15 @@ class OAuthTokenTest extends TestCase
 
     public function testSerializeTokenInException()
     {
-        $exception = new AccountNotLinkedException($this->token);
-        $str = serialize($exception);
+        $resourceOwnerName = 'github';
 
-        $this->assertEquals($exception, unserialize($str));
+        $exception = new AccountNotLinkedException();
+        $exception->setToken($this->token);
+        $exception->setResourceOwnerName($resourceOwnerName);
+
+        $processed = unserialize(serialize($exception));
+
+        $this->assertEquals($this->token, $processed->getToken());
+        $this->assertEquals($resourceOwnerName, $processed->getResourceOwnerName());
     }
 }


### PR DESCRIPTION
I've change the failing serialization test based on https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Security/Core/Tests/Exception/CustomUserMessageAuthenticationExceptionTest.php#L58