### PR TITLE
ConnectController cleanup

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -81,7 +81,7 @@ final class ConnectController extends AbstractController
     public function connectAction(Request $request)
     {
         $connect = $this->container->getParameter('hwi_oauth.connect');
-        $hasUser = $this->getUser() ? $this->isGranted($this->container->getParameter('hwi_oauth.grant_rule')) : false;
+        $hasUser = $this->isGranted($this->container->getParameter('hwi_oauth.grant_rule'));
 
         $error = $this->authenticationUtils->getLastAuthenticationError();
 

--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -89,10 +89,6 @@ final class ConnectController extends AbstractController
         if ($connect && !$hasUser && $error instanceof AccountNotLinkedException) {
             $key = time();
             $session = $request->getSession();
-            if (!$session->isStarted()) {
-                $session->start();
-            }
-
             $session->set('_hwi_oauth.registration_error.'.$key, $error);
 
             return $this->redirectToRoute('hwi_oauth_connect_registration', ['key' => $key]);
@@ -133,10 +129,6 @@ final class ConnectController extends AbstractController
         }
 
         $session = $request->getSession();
-        if (!$session->isStarted()) {
-            $session->start();
-        }
-
         $error = $session->get('_hwi_oauth.registration_error.'.$key);
         $session->remove('_hwi_oauth.registration_error.'.$key);
 
@@ -228,9 +220,6 @@ final class ConnectController extends AbstractController
         $resourceOwner = $this->getResourceOwnerByName($service);
 
         $session = $request->getSession();
-        if (!$session->isStarted()) {
-            $session->start();
-        }
 
         $key = $request->query->get('key', time());
 
@@ -305,11 +294,6 @@ final class ConnectController extends AbstractController
 
         // Check for a return path and store it before redirect
         if (null !== $session) {
-            // initialize the session for preventing SessionUnavailableException
-            if (!$session->isStarted()) {
-                $session->start();
-            }
-
             foreach ($this->container->getParameter('hwi_oauth.firewall_names') as $providerKey) {
                 $sessionKey = '_security.'.$providerKey.'.target_path';
                 $sessionKeyFailure = '_security.'.$providerKey.'.failed_target_path';

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -9,6 +9,7 @@
             <tag name="controller.service_arguments" />
             <argument type="service" id="hwi_oauth.security.oauth_utils" />
             <argument type="service" id="hwi_oauth.resource_ownermap_locator" />
+            <argument type="service" id="security.authentication_utils" />
         </service>
     </services>
 </container>

--- a/Tests/Controller/AbstractConnectControllerTest.php
+++ b/Tests/Controller/AbstractConnectControllerTest.php
@@ -26,12 +26,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Templating\EngineInterface;
 
 abstract class AbstractConnectControllerTest extends TestCase
@@ -173,7 +175,11 @@ abstract class AbstractConnectControllerTest extends TestCase
         $this->request = Request::create('/');
         $this->request->setSession($this->session);
 
-        $this->controller = new ConnectController($this->oAuthUtils, $this->resourceOwnerMapLocator);
+        $requestStack = new RequestStack();
+        $requestStack->push($this->request);
+        $authenticationUtils = new AuthenticationUtils($requestStack);
+
+        $this->controller = new ConnectController($this->oAuthUtils, $this->resourceOwnerMapLocator, $authenticationUtils);
         $this->controller->setContainer($this->container);
     }
 

--- a/Tests/Controller/ConnectControllerConnectActionTest.php
+++ b/Tests/Controller/ConnectControllerConnectActionTest.php
@@ -14,6 +14,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class ConnectControllerConnectActionTest extends AbstractConnectControllerTest
 {
@@ -77,13 +78,15 @@ class ConnectControllerConnectActionTest extends AbstractConnectControllerTest
 
     public function testRequestError()
     {
+        $authenticationException = new AuthenticationException();
+
         $this->request->attributes = new ParameterBag([
-            $this->getAuthenticationErrorKey() => new AccessDeniedException('You shall not pass the request.'),
+            $this->getAuthenticationErrorKey() => $authenticationException,
         ]);
 
         $this->twig->expects($this->once())
             ->method('render')
-            ->with('@HWIOAuth/Connect/login.html.twig', ['error' => 'You shall not pass the request.'])
+            ->with('@HWIOAuth/Connect/login.html.twig', ['error' => $authenticationException->getMessageKey()])
         ;
 
         $this->controller->connectAction($this->request);
@@ -97,15 +100,17 @@ class ConnectControllerConnectActionTest extends AbstractConnectControllerTest
             ->willReturn(true)
         ;
 
+        $authenticationException = new AuthenticationException();
+
         $this->session->expects($this->once())
             ->method('get')
             ->with($this->getAuthenticationErrorKey())
-            ->willReturn(new AccessDeniedException('You shall not pass the session.'))
+            ->willReturn($authenticationException)
         ;
 
         $this->twig->expects($this->once())
             ->method('render')
-            ->with('@HWIOAuth/Connect/login.html.twig', ['error' => 'You shall not pass the session.'])
+            ->with('@HWIOAuth/Connect/login.html.twig', ['error' => $authenticationException->getMessageKey()])
         ;
 
         $this->controller->connectAction($this->request);

--- a/Tests/Controller/ConnectControllerConnectActionTest.php
+++ b/Tests/Controller/ConnectControllerConnectActionTest.php
@@ -13,13 +13,14 @@ namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class ConnectControllerConnectActionTest extends AbstractConnectControllerTest
 {
     public function testLoginPage()
     {
+        $this->mockAuthorizationCheck();
+
         $this->container->setParameter('hwi_oauth.connect', true);
 
         $this->twig->expects($this->once())
@@ -36,36 +37,7 @@ class ConnectControllerConnectActionTest extends AbstractConnectControllerTest
             $this->getAuthenticationErrorKey() => $this->createAccountNotLinkedException(),
         ]);
 
-        $this->tokenStorage->expects($this->once())
-            ->method('getToken')
-            ->willReturn(new CustomOAuthToken())
-        ;
-
         $this->mockAuthorizationCheck(false);
-
-        $this->router->expects($this->once())
-            ->method('generate')
-            ->with('hwi_oauth_connect_registration')
-            ->willReturn('/')
-        ;
-
-        $this->controller->connectAction($this->request);
-    }
-
-    public function testRegistrationRedirectWithoutTokenStorage()
-    {
-        $this->request->attributes = new ParameterBag([
-            $this->getAuthenticationErrorKey() => $this->createAccountNotLinkedException(),
-        ]);
-
-        $this->tokenStorage->expects($this->once())
-            ->method('getToken')
-            ->willReturn(null)
-        ;
-
-        $this->authorizationChecker->expects($this->never())
-            ->method('isGranted')
-        ;
 
         $this->router->expects($this->once())
             ->method('generate')
@@ -78,6 +50,8 @@ class ConnectControllerConnectActionTest extends AbstractConnectControllerTest
 
     public function testRequestError()
     {
+        $this->mockAuthorizationCheck();
+
         $authenticationException = new AuthenticationException();
 
         $this->request->attributes = new ParameterBag([
@@ -94,6 +68,8 @@ class ConnectControllerConnectActionTest extends AbstractConnectControllerTest
 
     public function testSessionError()
     {
+        $this->mockAuthorizationCheck();
+
         $this->session->expects($this->once())
             ->method('has')
             ->with($this->getAuthenticationErrorKey())


### PR DESCRIPTION
The method `getLastAuthenticationError` 

```
public function getLastAuthenticationError($clearSession = true)
{
    $request = $this->getRequest();
    $session = $request->getSession();
    $authenticationException = null;

    if ($request->attributes->has(Security::AUTHENTICATION_ERROR)) {
        $authenticationException = $request->attributes->get(Security::AUTHENTICATION_ERROR);
    } elseif (null !== $session && $session->has(Security::AUTHENTICATION_ERROR)) {
        $authenticationException = $session->get(Security::AUTHENTICATION_ERROR);

        if ($clearSession) {
            $session->remove(Security::AUTHENTICATION_ERROR);
        }
    }

    return $authenticationException;
}
```

does the same thing (except one could return `null`, the other `''`) than:

```
protected function getErrorForRequest(Request $request)
{
    $authenticationErrorKey = Security::AUTHENTICATION_ERROR;

    if ($request->attributes->has($authenticationErrorKey)) {
        return $request->attributes->get($authenticationErrorKey);
    }

    $session = $request->getSession();
    if (null !== $session && $session->has($authenticationErrorKey)) {
        $error = $session->get($authenticationErrorKey);
        $session->remove($authenticationErrorKey);

        return $error;
    }

    return '';
}
```
I was also thinking about extracting the `connectAction` to a new controller since it also has its own routing file.

**UPDATE**

Removed this code: 
```
if (!$session->isStarted()) {
    $session->start();
}
```
According to Symfony [`Sessions are automatically started whenever you read, write or even check for the existence of data in the session.`](https://symfony.com/doc/3.4/session/avoid_session_start.html), so I guess there is no need to check if it exists anymore.
- I've change this:
```
- $hasUser = $this->getUser() ? $this->isGranted($this->grantRule) : false;
+ $hasUser = $this->isGranted($this->grantRule);
```
Also [according to Symfony](https://symfony.com/doc/3.4/security.html#always-check-if-the-user-is-logged-in):
```
// yay! Use this to see if the user is logged in
if (!$this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY')) {
    throw $this->createAccessDeniedException();
}
// equivalent shortcut:
// $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');

// boo :(. Never check for the User object to see if they're logged in
if ($this->getUser()) {

}
```
`The point is this: always check to see if the user is logged in before using the User object, and use the  isGranted() method...`

I think it's easier to check changes first and then split