### PR TITLE
Fill username when throwing UsernameNotFoundException

### DIFF
--- a/Security/Core/User/EntityUserProvider.php
+++ b/Security/Core/User/EntityUserProvider.php
@@ -73,7 +73,10 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
     {
         $user = $this->findUser(['username' => $username]);
         if (!$user) {
-            throw new UsernameNotFoundException(sprintf("User '%s' not found.", $username));
+            $exception = new UsernameNotFoundException(sprintf("User '%s' not found.", $username));
+            $exception->setUsername($username);
+
+            throw $exception;
         }
 
         return $user;
@@ -92,7 +95,10 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
 
         $username = $response->getUsername();
         if (null === $user = $this->findUser([$this->properties[$resourceOwnerName] => $username])) {
-            throw new UsernameNotFoundException(sprintf("User '%s' not found.", $username));
+            $exception = new UsernameNotFoundException(sprintf("User '%s' not found.", $username));
+            $exception->setUsername($username);
+
+            throw $exception;
         }
 
         return $user;
@@ -110,8 +116,13 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
         }
 
         $userId = $accessor->getValue($user, $identifier);
+        $username = $user->getUsername();
+
         if (null === $user = $this->findUser([$identifier => $userId])) {
-            throw new UsernameNotFoundException(sprintf('User with ID "%d" could not be reloaded.', $userId));
+            $exception = new UsernameNotFoundException(sprintf('User with ID "%d" could not be reloaded.', $userId));
+            $exception->setUsername($username);
+
+            throw $exception;
         }
 
         return $user;

--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -136,8 +136,13 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
         }
 
         $userId = $this->accessor->getValue($user, $identifier);
+        $username = $user->getUsername();
+
         if (null === $user = $this->userManager->findUserBy([$identifier => $userId])) {
-            throw new UsernameNotFoundException(sprintf('User with ID "%d" could not be reloaded.', $userId));
+            $exception = new UsernameNotFoundException(sprintf('User with ID "%d" could not be reloaded.', $userId));
+            $exception->setUsername($username);
+
+            throw $exception;
         }
 
         return $user;

--- a/Tests/Fixtures/FOSUser.php
+++ b/Tests/Fixtures/FOSUser.php
@@ -20,6 +20,11 @@ class FOSUser extends BaseUser
 {
     private $githubId;
 
+    public function getId()
+    {
+        return 1;
+    }
+
     public function getUsername()
     {
         return 'foo';

--- a/Tests/Security/Core/User/EntityUserProviderTest.php
+++ b/Tests/Security/Core/User/EntityUserProviderTest.php
@@ -20,7 +20,6 @@ use HWI\Bundle\OAuthBundle\Security\Core\User\EntityUserProvider;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\User;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 class EntityUserProviderTest extends TestCase
 {
@@ -95,7 +94,7 @@ class EntityUserProviderTest extends TestCase
             $this->fail('Failed asserting exception');
         } catch (\RuntimeException $e) {
             $this->assertInstanceOf(UsernameNotFoundException::class, $e);
-            $this->assertSame("User with ID \"1\" could not be reloaded.", $e->getMessage());
+            $this->assertSame('User with ID "1" could not be reloaded.', $e->getMessage());
             $this->assertSame('foo', $e->getUsername());
         }
     }

--- a/Tests/Security/Core/User/FOSUBUserProviderTest.php
+++ b/Tests/Security/Core/User/FOSUBUserProviderTest.php
@@ -105,7 +105,7 @@ class FOSUBUserProviderTest extends TestCase
             $this->fail('Failed asserting exception');
         } catch (\RuntimeException $e) {
             $this->assertInstanceOf(UsernameNotFoundException::class, $e);
-            $this->assertSame("User with ID \"1\" could not be reloaded.", $e->getMessage());
+            $this->assertSame('User with ID "1" could not be reloaded.', $e->getMessage());
             $this->assertSame('foo', $e->getUsername());
         }
     }

--- a/Tests/Security/Core/User/FOSUBUserProviderTest.php
+++ b/Tests/Security/Core/User/FOSUBUserProviderTest.php
@@ -17,6 +17,7 @@ use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\User\FOSUBUserProvider;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\FOSUser;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 
 class FOSUBUserProviderTest extends TestCase
 {
@@ -87,6 +88,26 @@ class FOSUBUserProviderTest extends TestCase
         $provider = $this->createFOSUBUserProvider();
 
         $provider->connect($user, $userResponseMock);
+    }
+
+    public function testRefreshUserThrowsExceptionWhenUserIsNull()
+    {
+        $userManagerMock = $this->createMock(UserManagerInterface::class);
+        $userManagerMock->expects($this->once())
+            ->method('findUserBy')
+            ->willReturn(null);
+
+        $provider = new FOSUBUserProvider($userManagerMock, []);
+
+        try {
+            $provider->refreshUser(new FOSUser());
+
+            $this->fail('Failed asserting exception');
+        } catch (\RuntimeException $e) {
+            $this->assertInstanceOf(UsernameNotFoundException::class, $e);
+            $this->assertSame("User with ID \"1\" could not be reloaded.", $e->getMessage());
+            $this->assertSame('foo', $e->getUsername());
+        }
     }
 
     protected function createFOSUBUserProvider($user = null, $updateUser = null)


### PR DESCRIPTION
The bundle doesn't fill the property `username` when code throwing the `Symfony\Component\Security\Core\Exception\UsernameNotFoundException`.