### PR TITLE
Replace usage of `AbstractController` with proper traits usage

### DIFF
--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -6,9 +6,14 @@
 
     <services>
         <service id="HWI\Bundle\OAuthBundle\Controller\ConnectController" public="true">
-            <tag name="controller.service_arguments" />
             <argument type="service" id="hwi_oauth.security.oauth_utils" />
             <argument type="service" id="hwi_oauth.resource_ownermap_locator" />
+
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+
+            <tag name="controller.service_arguments" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
Trying to remove deprecation:
```
Auto-injection of the container for "HWI\Bundle\OAuthBundle\Controller\ConnectController" is deprecated since Symfony 4.2. Configure it as a service instead.
```