### PR TITLE
Support for multiple OAuth2 state parameters

### DIFF
--- a/OAuth/Exception/StateRetrievalException.php
+++ b/OAuth/Exception/StateRetrievalException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth\Exception;
+
+final class StateRetrievalException extends \InvalidArgumentException
+{
+    /**
+     * @param string $key The provided string key
+     *
+     * @return self
+     */
+    public static function forKey(string $key): self
+    {
+        return new static(sprintf('No value found in state for key [%s]', $key));
+    }
+}

--- a/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Helper\NonceGenerator;
 use HWI\Bundle\OAuthBundle\Security\OAuthErrorHandler;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Psr\Http\Message\ResponseInterface;
@@ -34,7 +35,7 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
         $parameters = array_merge([
             'oauth_consumer_key' => $this->options['client_id'],
             'oauth_timestamp' => time(),
-            'oauth_nonce' => $this->generateNonce(),
+            'oauth_nonce' => NonceGenerator::generate(),
             'oauth_version' => '1.0',
             'oauth_signature_method' => $this->options['signature_method'],
             'oauth_token' => $accessToken['oauth_token'],
@@ -88,7 +89,7 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
         $parameters = array_merge([
             'oauth_consumer_key' => $this->options['client_id'],
             'oauth_timestamp' => time(),
-            'oauth_nonce' => $this->generateNonce(),
+            'oauth_nonce' => NonceGenerator::generate(),
             'oauth_version' => '1.0',
             'oauth_signature_method' => $this->options['signature_method'],
             'oauth_token' => $requestToken['oauth_token'],
@@ -146,7 +147,7 @@ class GenericOAuth1ResourceOwner extends AbstractResourceOwner
         $parameters = array_merge([
             'oauth_consumer_key' => $this->options['client_id'],
             'oauth_timestamp' => $timestamp,
-            'oauth_nonce' => $this->generateNonce(),
+            'oauth_nonce' => NonceGenerator::generate(),
             'oauth_version' => '1.0',
             'oauth_callback' => $redirectUri,
             'oauth_signature_method' => $this->options['signature_method'],

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Helper\NonceGenerator;
 use HWI\Bundle\OAuthBundle\Security\OAuthErrorHandler;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
@@ -59,18 +60,14 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
     public function getAuthorizationUrl($redirectUri, array $extraParameters = [])
     {
         if ($this->options['csrf']) {
-            if (null === $this->state) {
-                $this->state = $this->generateNonce();
-            }
-
-            $this->storage->save($this, $this->state, 'csrf_state');
+            $this->handleCsrfToken();
         }
 
         $parameters = array_merge([
             'response_type' => 'code',
             'client_id' => $this->options['client_id'],
             'scope' => $this->options['scope'],
-            'state' => $this->state ? urlencode($this->state) : null,
+            'state' => $this->state->encode() ?: null,
             'redirect_uri' => $redirectUri,
         ], $extraParameters);
 
@@ -166,7 +163,6 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
     protected function doGetTokenRequest($url, array $parameters = [])
     {
         $headers = [];
-
         if ($this->options['use_authorization_to_get_token']) {
             if ($this->options['client_secret']) {
                 $headers['Authorization'] = 'Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret']);
@@ -176,9 +172,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
             $parameters['client_secret'] = $this->options['client_secret'];
         }
 
-        $query = http_build_query($parameters, '', '&');
-
-        return $this->httpRequest($url, $query, $headers);
+        return $this->httpRequest($url, http_build_query($parameters, '', '&'), $headers);
     }
 
     /**
@@ -250,5 +244,14 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
         $headers += ['Content-Type' => 'application/x-www-form-urlencoded'];
 
         return parent::httpRequest($url, $content, $headers, $method);
+    }
+
+    private function handleCsrfToken(): void
+    {
+        if (null === $this->state->getCsrfToken()) {
+            $this->state->setCsrfToken(NonceGenerator::generate());
+        }
+
+        $this->storage->save($this, $this->state->getCsrfToken(), 'csrf_state');
     }
 }

--- a/OAuth/ResourceOwner/JiraResourceOwner.php
+++ b/OAuth/ResourceOwner/JiraResourceOwner.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Helper\NonceGenerator;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\OptionsResolver\Options;
@@ -43,7 +44,7 @@ class JiraResourceOwner extends GenericOAuth1ResourceOwner
         $parameters = array_merge([
             'oauth_consumer_key' => $this->options['client_id'],
             'oauth_timestamp' => time(),
-            'oauth_nonce' => $this->generateNonce(),
+            'oauth_nonce' => NonceGenerator::generate(),
             'oauth_version' => '1.0',
             'oauth_signature_method' => $this->options['signature_method'],
             'oauth_token' => $accessToken['oauth_token'],
@@ -62,7 +63,7 @@ class JiraResourceOwner extends GenericOAuth1ResourceOwner
         $url = $this->normalizeUrl($this->options['infos_url'], ['username' => $content['name']]);
 
         // Regenerate nonce & signature as URL was changed
-        $parameters['oauth_nonce'] = $this->generateNonce();
+        $parameters['oauth_nonce'] = NonceGenerator::generate();
         $parameters['oauth_signature'] = OAuthUtils::signRequest(
             'GET',
             $url,

--- a/OAuth/ResourceOwnerInterface.php
+++ b/OAuth/ResourceOwnerInterface.php
@@ -11,6 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth;
 
+use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -29,7 +30,7 @@ interface ResourceOwnerInterface
      * @param array $accessToken     The access token
      * @param array $extraParameters An array of parameters to add to the url
      *
-     * @throws \HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException
+     * @throws HttpTransportException
      *
      * @return UserResponseInterface the wrapped response interface
      */
@@ -52,7 +53,7 @@ interface ResourceOwnerInterface
      * @param string      $redirectUri     The uri to redirect the client back to
      * @param array       $extraParameters An array of parameters to add to the url
      *
-     * @throws \HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException
+     * @throws HttpTransportException
      *
      * @return array The access token
      */
@@ -115,4 +116,15 @@ interface ResourceOwnerInterface
      * @param array  $extraParameters An array of parameters to add to the url
      */
     public function refreshAccessToken($refreshToken, array $extraParameters = []);
+
+    /**
+     * @return StateInterface
+     */
+    public function getState(): StateInterface;
+
+    /**
+     * @param string $key
+     * @param string $value
+     */
+    public function addStateParameter(string $key, string $value): void;
 }

--- a/OAuth/State/State.php
+++ b/OAuth/State/State.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth\State;
+
+use HWI\Bundle\OAuthBundle\OAuth\Exception\StateRetrievalException;
+use HWI\Bundle\OAuthBundle\OAuth\StateInterface;
+use InvalidArgumentException;
+use Symfony\Component\Config\Definition\Exception\DuplicateKeyException;
+
+final class State implements StateInterface
+{
+    public const DEFAULT_KEY = 'state';
+    public const CSRF_TOKEN_KEY = 'csrf_token';
+
+    /**
+     * @var array
+     */
+    private $values = [];
+
+    /**
+     * @param string|array<string,string>|null The state parameter as a string or assoc array
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct($parameters)
+    {
+        if (!\is_array($parameters)) {
+            $parameters = $this->parseStringParameter($parameters);
+        }
+
+        if (!$this->isAssociatedArray($parameters)) {
+            throw new InvalidArgumentException('Constructor argument should be a non-empty, associative array');
+        }
+
+        foreach ($parameters as $key => $value) {
+            $this->add($key, $value);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add(string $key, string $value): void
+    {
+        if (isset($this->values[$key])) {
+            throw new DuplicateKeyException(sprintf('State key [%s] is already set.', $key));
+        }
+
+        $this->values[$key] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(string $key): ?string
+    {
+        if (!isset($this->values[$key])) {
+            throw StateRetrievalException::forKey($key);
+        }
+
+        return $this->values[$key];
+    }
+
+    public function setCsrfToken(string $token): void
+    {
+        $this->values[self::CSRF_TOKEN_KEY] = $token;
+    }
+
+    public function getAll(): array
+    {
+        return $this->values;
+    }
+
+    public function getCsrfToken(): ?string
+    {
+        return isset($this->values[self::CSRF_TOKEN_KEY]) ? $this->values[self::CSRF_TOKEN_KEY] : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Encodes the array of values to a string so it can be stored in a query parameter.
+     * Returns the plain value if only the default key or CSRF token has been set.
+     */
+    public function encode(): string
+    {
+        if ($this->isOnlyExistentKey(self::DEFAULT_KEY)) {
+            return urlencode($this->values[self::DEFAULT_KEY]);
+        }
+
+        if ($this->isOnlyExistentKey(self::CSRF_TOKEN_KEY)) {
+            return urlencode($this->values[self::CSRF_TOKEN_KEY]);
+        }
+
+        return urlencode(self::encodeArray($this->values));
+    }
+
+    /**
+     * @param string $queryParameter The state query parameter string
+     *
+     * @return array<string,string>
+     */
+    private function parseStringParameter(string $queryParameter = null): array
+    {
+        $urlDecoded = urldecode($queryParameter);
+        $values = json_decode(base64_decode($urlDecoded), 1);
+
+        if (null === $values) {
+            $values[self::DEFAULT_KEY] = $urlDecoded;
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param array $array The array to encode
+     *
+     * @return string The encoded array
+     */
+    private static function encodeArray(array $array): string
+    {
+        return base64_encode(json_encode($array));
+    }
+
+    /**
+     * Checks if a given key is set in the values array,
+     * and if it's the only key present.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    private function isOnlyExistentKey(string $key): bool
+    {
+        return isset($this->values[$key]) && 1 === \count($this->values);
+    }
+
+    private function isAssociatedArray(?array $array): bool
+    {
+        if ([] === $array) {
+            return false;
+        }
+
+        return array_keys($array) !== range(0, \count($array) - 1);
+    }
+}

--- a/OAuth/StateInterface.php
+++ b/OAuth/StateInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth;
+
+use HWI\Bundle\OAuthBundle\OAuth\Exception\StateRetrievalException;
+use Symfony\Component\Config\Definition\Exception\DuplicateKeyException;
+
+interface StateInterface
+{
+    /**
+     * @param string $key   The key to store a value to
+     * @param string $value The value to store
+     *
+     * @throws DuplicateKeyException
+     */
+    public function add(string $key, string $value);
+
+    /**
+     * @param string $key
+     *
+     * @return string The value set to this key
+     *
+     * @throws StateRetrievalException
+     */
+    public function get(string $key): ?string;
+
+    public function getAll(): array;
+
+    public function setCsrfToken(string $token): void;
+
+    public function getCsrfToken(): ?string;
+
+    public function encode(): string;
+}

--- a/Resources/doc/1-setting_up_the_bundle.md
+++ b/Resources/doc/1-setting_up_the_bundle.md
@@ -21,11 +21,11 @@ Enable the bundle in the kernel:
 
 public function registerBundles()
 {
-    $bundles = array(
+    $bundles = [
         // ...
         new Http\HttplugBundle\HttplugBundle(), // If you require the php-http/httplug-bundle package.
         new HWI\Bundle\OAuthBundle\HWIOAuthBundle(),
-    );
+    ];
 }
 ```
 

--- a/Resources/doc/2-configuring_resource_owners.md
+++ b/Resources/doc/2-configuring_resource_owners.md
@@ -90,6 +90,11 @@ hwi_oauth:
 ### CSRF protection
 
 Set the _csrf_ option to **true** in the resource owner's configuration in order to protect your users from [CSRF](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)) attacks.
+This will be round-tripped to your application in the `state` parameter. 
+
+Other types of state can be configured under the `state` key, either as a single string or key/value pairs. State can
+also be passed directly in the `state` query parameter of your request, provided they don't override the configured keys
+and are json and base64 encoded, as can be seen in `OAuth/State/State`.
 ```yaml
 # app/config/config.yml
 hwi_oauth:
@@ -100,6 +105,9 @@ hwi_oauth:
             client_secret:       <client_secret>
             options:
                 csrf: true
+                state: 
+                  some: parameter
+                  some-other: parameter
 ```
 
 ### Continue to the next step!

--- a/Resources/doc/internals/reference_configuration.md
+++ b/Resources/doc/internals/reference_configuration.md
@@ -14,6 +14,9 @@ hwi_oauth:
             scope:               "user:email"
             options:
                 csrf:            true
+                state:
+                  some:          parameter
+                  some-other:     parameter
 
         google:
             type:                google

--- a/Security/Helper/NonceGenerator.php
+++ b/Security/Helper/NonceGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Security\Helper;
+
+final class NonceGenerator
+{
+    private function __construct()
+    {
+    }
+
+    public static function generate(): string
+    {
+        return md5(microtime(true).uniqid('', true));
+    }
+}

--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Security;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use HWI\Bundle\OAuthBundle\OAuth\State\State;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -104,12 +105,17 @@ class OAuthUtils
     public function getAuthorizationUrl(Request $request, $name, $redirectUrl = null, array $extraParameters = [])
     {
         $resourceOwner = $this->getResourceOwner($name);
+
         if (null === $redirectUrl) {
             if (!$this->connect || !$this->authorizationChecker->isGranted($this->grantRule)) {
                 $redirectUrl = $this->httpUtils->generateUri($request, $this->getResourceOwnerCheckPath($name));
             } else {
                 $redirectUrl = $this->getServiceAuthUrl($request, $resourceOwner);
             }
+        }
+
+        if ($request->query->has('state')) {
+            $this->addQueryParameterToState($request->query->get('state'), $resourceOwner);
         }
 
         return $resourceOwner->getAuthorizationUrl($redirectUrl, $extraParameters);
@@ -281,5 +287,21 @@ class OAuthUtils
         }
 
         return null;
+    }
+
+    /**
+     * @param string|null            $queryParameter The query parameter to parse and add to the State
+     * @param ResourceOwnerInterface $resourceOwner  The resource owner holding the state to be added to
+     */
+    private function addQueryParameterToState(?string $queryParameter, ResourceOwnerInterface $resourceOwner): void
+    {
+        if (null === $queryParameter) {
+            return;
+        }
+
+        $additionalState = new State($queryParameter);
+        foreach ($additionalState->getAll() as $key => $value) {
+            $resourceOwner->addStateParameter($key, $value);
+        }
     }
 }

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -16,6 +16,7 @@ use Http\HttplugBundle\HttplugBundle;
 use HWI\Bundle\OAuthBundle\DependencyInjection\HWIOAuthExtension;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\MyCustomProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Parser;
 
@@ -58,7 +59,7 @@ class HWIOAuthExtensionTest extends TestCase
 
     public function testConfigurationThrowsExceptionUnlessFirewallNameSet()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $loader = new HWIOAuthExtension();
         $config = $this->getEmptyConfig();
@@ -69,7 +70,7 @@ class HWIOAuthExtensionTest extends TestCase
 
     public function testConfigurationThrowsExceptionUnlessResourceOwnersSet()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $loader = new HWIOAuthExtension();
         $config = $this->getEmptyConfig();
@@ -80,7 +81,7 @@ class HWIOAuthExtensionTest extends TestCase
 
     public function testConfigurationThrowsExceptionUnlessClientIdSet()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $loader = new HWIOAuthExtension();
         $config = $this->getEmptyConfig();
@@ -91,7 +92,7 @@ class HWIOAuthExtensionTest extends TestCase
 
     public function testConfigurationThrowsExceptionUnlessClientSecretSet()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $loader = new HWIOAuthExtension();
         $config = $this->getEmptyConfig();
@@ -102,7 +103,7 @@ class HWIOAuthExtensionTest extends TestCase
 
     public function testConfigurationThrowsExceptionWhenPathIsEmpty()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $loader = new HWIOAuthExtension();
         $config = $this->getEmptyConfig();
@@ -115,7 +116,7 @@ class HWIOAuthExtensionTest extends TestCase
 
     public function testConfigurationThrowsExceptionWhenUnknownResourceOwnerIsCalled()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $loader = new HWIOAuthExtension();
         $config = $this->getEmptyConfig();
@@ -135,7 +136,7 @@ class HWIOAuthExtensionTest extends TestCase
      */
     public function testConfigurationThrowsExceptionResourceOwnerRequiresSomeOptions($invalidConfig)
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $loader = new HWIOAuthExtension();
         $config = $this->getEmptyConfig();
@@ -148,7 +149,7 @@ class HWIOAuthExtensionTest extends TestCase
 
     public function testConfigurationThrowsExceptionWhenServiceHasSomePaths()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $loader = new HWIOAuthExtension();
         $config = $this->getEmptyConfig();
@@ -163,20 +164,18 @@ class HWIOAuthExtensionTest extends TestCase
 
     public function testConfigurationThrowsExceptionWhenServiceHasMoreOptions()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $loader = new HWIOAuthExtension();
         $config = $this->getEmptyConfig();
         $config['resource_owners']['some_service']['client_id'] = 'client_id';
 
         $loader->load([$config], $this->containerBuilder);
-
-        $this->addToAssertionCount(1);
     }
 
     public function testConfigurationThrowsExceptionWhenServiceHasClass()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Invalid configuration for path "hwi_oauth.resource_owners.new_resourceowner": You should set at least the \'type\', \'client_id\' and the \'client_secret\' of a resource owner.');
 
         $loader = new HWIOAuthExtension();
@@ -184,13 +183,11 @@ class HWIOAuthExtensionTest extends TestCase
         $config['resource_owners']['new_resourceowner']['class'] = 'My\Class';
 
         $loader->load([$config], $this->containerBuilder);
-
-        $this->addToAssertionCount(1);
     }
 
     public function testConfigurationThrowsExceptionWhenServiceHasClassAndWrongType()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Invalid configuration for path "hwi_oauth.resource_owners.new_resourceowner": If you\'re setting a \'class\', you must provide a \'oauth1\' or \'oauth2\' type');
 
         $loader = new HWIOAuthExtension();
@@ -201,8 +198,6 @@ class HWIOAuthExtensionTest extends TestCase
         $config['resource_owners']['new_resourceowner']['client_secret'] = 'foo';
 
         $loader->load([$config], $this->containerBuilder);
-
-        $this->addToAssertionCount(1);
     }
 
     public function testConfigurationPassValidOAuth1()
@@ -228,7 +223,7 @@ class HWIOAuthExtensionTest extends TestCase
 
         $loader->load([$config], $this->containerBuilder);
 
-        $this->addToAssertionCount(1);
+        $this->assertAlias('security.user_checker', 'hwi_oauth.user_checker');
     }
 
     public function testConfigurationPassValidOAuth2WithPaths()
@@ -253,7 +248,7 @@ class HWIOAuthExtensionTest extends TestCase
 
         $loader->load([$config], $this->containerBuilder);
 
-        $this->addToAssertionCount(1);
+        $this->assertAlias('security.user_checker', 'hwi_oauth.user_checker');
     }
 
     public function testConfigurationPassValidOAuth1WithClass()
@@ -280,7 +275,7 @@ class HWIOAuthExtensionTest extends TestCase
 
         $loader->load([$config], $this->containerBuilder);
 
-        $this->addToAssertionCount(1);
+        $this->assertAlias('security.user_checker', 'hwi_oauth.user_checker');
     }
 
     public function testConfigurationPassValidOAuth2WithClassOnly()
@@ -298,7 +293,7 @@ class HWIOAuthExtensionTest extends TestCase
 
         $loader->load([$config], $this->containerBuilder);
 
-        $this->addToAssertionCount(1);
+        $this->assertAlias('security.user_checker', 'hwi_oauth.user_checker');
     }
 
     public function testConfigurationPassValidOAuth2WithPathsAndClass()
@@ -324,7 +319,7 @@ class HWIOAuthExtensionTest extends TestCase
 
         $loader->load([$config], $this->containerBuilder);
 
-        $this->addToAssertionCount(1);
+        $this->assertAlias('security.user_checker', 'hwi_oauth.user_checker');
     }
 
     public function testConfigurationPassValidOAuth2WithDeepPaths()
@@ -349,7 +344,7 @@ class HWIOAuthExtensionTest extends TestCase
 
         $loader->load([$config], $this->containerBuilder);
 
-        $this->addToAssertionCount(1);
+        $this->assertAlias('security.user_checker', 'hwi_oauth.user_checker');
     }
 
     public function testConfigurationPassValidOAuth2WithResponseClass()
@@ -370,7 +365,7 @@ class HWIOAuthExtensionTest extends TestCase
 
         $loader->load([$config], $this->containerBuilder);
 
-        $this->addToAssertionCount(1);
+        $this->assertAlias('security.user_checker', 'hwi_oauth.user_checker');
     }
 
     public function testConfigurationLoadDefaults()
@@ -515,7 +510,7 @@ class HWIOAuthExtensionTest extends TestCase
 
     public function testCreateResourceOwnerServiceWithWrongClass()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Class "HWI\\Bundle\\OAuthBundle\\Tests\\DependencyInjection\\MyWrongCustomProvider" must implement interface "HWI\\Bundle\\OAuthBundle\\OAuth\\ResourceOwnerInterface".');
 
         $extension = new HWIOAuthExtension();

--- a/Tests/Fixtures/MyCustomProvider.php
+++ b/Tests/Fixtures/MyCustomProvider.php
@@ -12,6 +12,8 @@
 namespace HWI\Bundle\OAuthBundle\Tests\Fixtures;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use HWI\Bundle\OAuthBundle\OAuth\State\State;
+use HWI\Bundle\OAuthBundle\OAuth\StateInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class MyCustomProvider implements ResourceOwnerInterface
@@ -53,6 +55,15 @@ class MyCustomProvider implements ResourceOwnerInterface
     }
 
     public function refreshAccessToken($refreshToken, array $extraParameters = [])
+    {
+    }
+
+    public function getState(): StateInterface
+    {
+        return new State(null);
+    }
+
+    public function addStateParameter(string $key, string $value): void
     {
     }
 }

--- a/Tests/OAuth/ResourceOwner/AmazonResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/AmazonResourceOwnerTest.php
@@ -31,8 +31,5 @@ json;
         'email' => 'email',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=profile&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=profile&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=profile';
 }

--- a/Tests/OAuth/ResourceOwner/Auth0ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/Auth0ResourceOwnerTest.php
@@ -45,10 +45,7 @@ json;
         'profilepicture' => 'picture',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'https://example.oauth0.com/authorize?auth0Client=eyJuYW1lIjoiSFdJT0F1dGhCdW5kbGUiLCJ2ZXJzaW9uIjoidW5rbm93biIsImVudmlyb25tZW50Ijp7Im5hbWUiOiJQSFAiLCJ2ZXJzaW9uIjoiRkFLRV9QSFBfVkVSU0lPTl9GT1JfVEVTVFMifX0=&response_type=code&client_id=clientid&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'https://example.oauth0.com/authorize?auth0Client=eyJuYW1lIjoiSFdJT0F1dGhCdW5kbGUiLCJ2ZXJzaW9uIjoidW5rbm93biIsImVudmlyb25tZW50Ijp7Im5hbWUiOiJQSFAiLCJ2ZXJzaW9uIjoiRkFLRV9QSFBfVkVSU0lPTl9GT1JfVEVTVFMifX0=&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'https://example.oauth0.com/authorize?auth0Client=eyJuYW1lIjoiSFdJT0F1dGhCdW5kbGUiLCJ2ZXJzaW9uIjoidW5rbm93biIsImVudmlyb25tZW50Ijp7Im5hbWUiOiJQSFAiLCJ2ZXJzaW9uIjoiRkFLRV9QSFBfVkVSU0lPTl9GT1JfVEVTVFMifX0=&response_type=code&client_id=clientid';
 
     protected function setUpResourceOwner($name, HttpUtils $httpUtils, array $options)
     {

--- a/Tests/OAuth/ResourceOwner/AzureResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/AzureResourceOwnerTest.php
@@ -40,17 +40,8 @@ json;
         'profilepicture' => null,
     ];
 
-    protected $expectedUrls = [
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&resource=https%3A%2F%2Fgraph.windows.net',
-    ];
-
-    public function testGetAuthorizationUrl()
-    {
-        $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&resource=https%3A%2F%2Fgraph.windows.net',
-            $this->resourceOwner->getAuthorizationUrl('http://redirect.to/')
-        );
-    }
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid';
+    protected $redirectUrlPart = '&redirect_uri=http%3A%2F%2Fredirect.to%2F&resource=https%3A%2F%2Fgraph.windows.net';
 
     public function testGetUserInformation()
     {

--- a/Tests/OAuth/ResourceOwner/DisqusResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/DisqusResourceOwnerTest.php
@@ -32,8 +32,5 @@ json;
         'realname' => 'response.name',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read';
 }

--- a/Tests/OAuth/ResourceOwner/GeniusResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GeniusResourceOwnerTest.php
@@ -71,8 +71,5 @@ json;
         'profilepicture' => 'response.user.avatar.medium.url',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=me&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=me&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=me';
 }

--- a/Tests/OAuth/ResourceOwner/GitLabResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GitLabResourceOwnerTest.php
@@ -18,10 +18,7 @@ class GitLabResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
     protected $resourceOwnerClass = GitLabResourceOwner::class;
     protected $httpClientCalls = 1;
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read_user&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read_user&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read_user';
 
     public function testRevokeToken()
     {

--- a/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
@@ -34,10 +34,8 @@ json;
         'profilepicture' => 'picture',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile';
+    protected $redirectUrlPart = '&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline';
 
     public function testInvalidAccessTypeOptionValueThrowsException()
     {
@@ -63,7 +61,8 @@ json;
 
     public function testRequestVisibleActions()
     {
-        $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['request_visible_actions' => 'http://schemas.google.com/AddActivity']);
+        $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['request_visible_actions' => 'http://schemas.google.com/AddActivity']
+        );
 
         $this->assertEquals(
             $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&request_visible_actions=http%3A%2F%2Fschemas.google.com%2FAddActivity',

--- a/Tests/OAuth/ResourceOwner/KeycloakResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/KeycloakResourceOwnerTest.php
@@ -27,10 +27,8 @@ class KeycloakResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
       'attr_name' => 'access_token',
     ];
 
-    protected $expectedUrls = [
-      'authorization_url' => 'http://keycloak.auth/auth/realms/example/protocol/openid-connect/auth?response_type=code&client_id=clientid&scope=name%2Cemail&redirect_uri=http%3A%2F%2Fredirect.to%2F&approval_prompt=auto',
-      'authorization_url_csrf' => 'http://keycloak.auth/auth/realms/example/protocol/openid-connect/auth?response_type=code&client_id=clientid&scope=name%2Cemail&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&approval_prompt=auto',
-    ];
+    protected $authorizationUrlBasePart = 'http://keycloak.auth/auth/realms/example/protocol/openid-connect/auth?response_type=code&client_id=clientid&scope=name%2Cemail';
+    protected $redirectUrlPart = '&redirect_uri=http%3A%2F%2Fredirect.to%2F&approval_prompt=auto';
 
     protected $resourceOwnerClass = KeycloakResourceOwner::class;
 }

--- a/Tests/OAuth/ResourceOwner/LinkedinResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/LinkedinResourceOwnerTest.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\LinkedinResourceOwner;
+use HWI\Bundle\OAuthBundle\OAuth\Response\AbstractUserResponse;
 
 class LinkedinResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {
@@ -50,9 +51,7 @@ json;
     ];
     protected $csrf = true;
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=r_liteprofile+r_emailaddress&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=r_liteprofile+r_emailaddress';
 
     protected $httpClientCalls = 1;
 
@@ -71,7 +70,7 @@ json;
 
         $this->mockHttpClient($this->userResponse, 'application/json; charset=utf-8');
 
-        /** @var $userResponse \HWI\Bundle\OAuthBundle\OAuth\Response\AbstractUserResponse */
+        /** @var $userResponse AbstractUserResponse */
         $userResponse = $this->resourceOwner->getUserInformation($this->tokenData);
 
         $this->assertEquals('1', $userResponse->getUsername());

--- a/Tests/OAuth/ResourceOwner/PaypalResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/PaypalResourceOwnerTest.php
@@ -34,8 +34,5 @@ json;
         'realname' => 'name',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=openid+email&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=openid+email&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=openid+email';
 }

--- a/Tests/OAuth/ResourceOwner/RedditResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/RedditResourceOwnerTest.php
@@ -25,9 +25,7 @@ json;
 
     protected $csrf = true;
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=identity&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=identity';
 
     protected $paths = [
         'identifier' => 'id',

--- a/Tests/OAuth/ResourceOwner/SlackResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/SlackResourceOwnerTest.php
@@ -32,8 +32,5 @@ json;
         'nickname' => 'user',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=identify&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=identify&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=identify';
 }

--- a/Tests/OAuth/ResourceOwner/SoundcloudResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/SoundcloudResourceOwnerTest.php
@@ -24,10 +24,7 @@ class SoundcloudResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 }
 json;
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=non-expiring&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=non-expiring&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=non-expiring';
 
     protected $paths = [
         'identifier' => 'id',

--- a/Tests/OAuth/ResourceOwner/StackExchangeResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/StackExchangeResourceOwnerTest.php
@@ -36,10 +36,7 @@ json;
         'profilepicture' => 'items.0.profile_image',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=no_expiry&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=no_expiry&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=no_expiry';
 
     protected function setUpResourceOwner($name, HttpUtils $httpUtils, array $options)
     {

--- a/Tests/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/ThirtySevenSignalsResourceOwnerTest.php
@@ -34,8 +34,6 @@ json;
         'email' => 'identity.email_address',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&redirect_uri=http%3A%2F%2Fredirect.to%2F&type=web_server',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&type=web_server',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid';
+    protected $redirectUrlPart = '&redirect_uri=http%3A%2F%2Fredirect.to%2F&type=web_server';
 }

--- a/Tests/OAuth/ResourceOwner/ToshlResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/ToshlResourceOwnerTest.php
@@ -35,10 +35,6 @@ json;
         'email' => 'email',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
-
     public function testRevokeToken()
     {
         $this->httpResponseHttpCode = 204;

--- a/Tests/OAuth/ResourceOwner/VkontakteResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/VkontakteResourceOwnerTest.php
@@ -31,8 +31,5 @@ json;
         'realname' => 'response.user_name',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=email&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=email&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=email';
 }

--- a/Tests/OAuth/ResourceOwner/WindowsLiveResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/WindowsLiveResourceOwnerTest.php
@@ -29,8 +29,5 @@ json;
         'realname' => 'name',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=wl.signin&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=wl.signin&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=wl.signin';
 }

--- a/Tests/OAuth/ResourceOwner/WunderlistResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/WunderlistResourceOwnerTest.php
@@ -31,8 +31,5 @@ json;
         'realname' => 'data.name',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid';
 }

--- a/Tests/OAuth/ResourceOwner/YoutubeResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/YoutubeResourceOwnerTest.php
@@ -32,10 +32,8 @@ json;
         'profilepicture' => 'picture',
     ];
 
-    protected $expectedUrls = [
-        'authorization_url' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=read&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline',
-    ];
+    protected $authorizationUrlBasePart = 'http://user.auth/?test=2&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly';
+    protected $redirectUrlPart = '&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline';
 
     public function testInvalidAccessTypeOptionValueThrowsException()
     {
@@ -61,7 +59,8 @@ json;
 
     public function testRequestVisibleActions()
     {
-        $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['request_visible_actions' => 'http://schemas.google.com/AddActivity']);
+        $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['request_visible_actions' => 'http://schemas.google.com/AddActivity']
+        );
 
         $this->assertEquals(
             $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&request_visible_actions=http%3A%2F%2Fschemas.google.com%2FAddActivity',

--- a/Tests/OAuth/State/StateTest.php
+++ b/Tests/OAuth/State/StateTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware.Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\OAuth\State;
+
+use HWI\Bundle\OAuthBundle\OAuth\Exception\StateRetrievalException;
+use HWI\Bundle\OAuthBundle\OAuth\State\State;
+use HWI\Bundle\OAuthBundle\Security\Helper\NonceGenerator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\DuplicateKeyException;
+
+final class StateTest extends TestCase
+{
+    public const TEST_VALUES = [
+        'foo' => 'bar',
+        'bar' => 'baz',
+        'foobar' => 'foobaz',
+    ];
+
+    public function testConstructorWithEncodedParameter()
+    {
+        $state = new State($this->encodeArray(self::TEST_VALUES));
+
+        foreach (self::TEST_VALUES as $key => $value) {
+            self::assertEquals($value, $state->get($key));
+        }
+    }
+
+    public function testConstructorWithSingleValue()
+    {
+        $state = new State('random');
+        self::assertEquals('random', $state->get('state'));
+    }
+
+    public function testConstructorWithArrayParameter()
+    {
+        $state = new State(self::TEST_VALUES);
+
+        foreach (self::TEST_VALUES as $key => $value) {
+            self::assertEquals($value, $state->get($key));
+        }
+    }
+
+    public function testFromEncodedParameterWithInvalidFormat()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $values = ['some', 'indexed', 'array'];
+
+        new State($this->encodeArray($values));
+    }
+
+    public function testGetNonExistentValue()
+    {
+        $this->expectException(StateRetrievalException::class);
+
+        $state = new State($this->encodeArray(self::TEST_VALUES));
+        $state->get('baz');
+    }
+
+    public function testAdd()
+    {
+        $state = new State($this->encodeArray(self::TEST_VALUES));
+
+        $state->add('baz', 'foo');
+        self::assertEquals('foo', $state->get('baz'));
+    }
+
+    public function testAddDuplicateKey()
+    {
+        $this->expectException(DuplicateKeyException::class);
+
+        $state = new State($this->encodeArray(self::TEST_VALUES));
+        $state->add('foo', 'foobar');
+    }
+
+    public function testEncode()
+    {
+        $expectedParameter = $this->encodeArray(self::TEST_VALUES);
+        $state = new State($expectedParameter);
+
+        self::assertEquals($expectedParameter, $state->encode());
+    }
+
+    public function testEncodeOnlyValue()
+    {
+        $state = new State('random');
+        self::assertEquals('random', $state->encode());
+    }
+
+    public function testEncodeEmptyValue()
+    {
+        $state = new State(null);
+        self::assertEmpty($state->encode());
+    }
+
+    public function testSetCsrfTokenSetsProvidedToken()
+    {
+        $token = NonceGenerator::generate();
+
+        $state = new State(null);
+        self::assertNull($state->getCsrfToken());
+
+        $state->setCsrfToken($token);
+        self::assertEquals($token, $state->getCsrfToken());
+    }
+
+    private function encodeArray(array $array): string
+    {
+        return urlencode(base64_encode(json_encode($array)));
+    }
+}

--- a/Tests/Security/OAuthUtilsTest.php
+++ b/Tests/Security/OAuthUtilsTest.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Tests\Security;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use HWI\Bundle\OAuthBundle\OAuth\State\State;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use PHPUnit\Framework\TestCase;
@@ -50,7 +51,7 @@ class OAuthUtilsTest extends TestCase
         $redirect = 'https://api.instagram.com/oauth/authorize?redirect='.rawurlencode($url);
 
         $utils = new OAuthUtils($this->getHttpUtils($url), $this->getAutorizationChecker(true, $this->grantRule), true, $this->grantRule);
-        $utils->addResourceOwnerMap($this->getMap($url, $redirect, true));
+        $utils->addResourceOwnerMap($this->getMap($url, $redirect, true, false));
 
         $this->assertEquals(
             $redirect,
@@ -60,6 +61,30 @@ class OAuthUtilsTest extends TestCase
         $this->assertEquals(
             'instagram',
             $request->attributes->get('service')
+        );
+    }
+
+    public function testGetAuthorizationUrlWithStateQueryParameters()
+    {
+        $parameters = ['foo' => 'bar', 'foobar' => 'foobaz'];
+        $state = new State($parameters);
+
+        $url = 'http://localhost:8080/login/check-instagram';
+        $redirect = 'https://api.instagram.com/oauth/authorize?redirect='.rawurlencode($url);
+
+        $request = $this->getRequest($url.'?state='.$state->encode());
+        $resource = $this->getMockBuilder(ResourceOwnerInterface::class)->getMock();
+
+        $utils = new OAuthUtils($this->getHttpUtils($url), $this->getAutorizationChecker(false, $this->grantRule), true, $this->grantRule);
+        $utils->addResourceOwnerMap($this->getMap($url, $redirect, false, false, $resource));
+
+        $resource->expects($this->exactly(2))
+            ->method('addStateParameter')
+            ->withConsecutive(['foo', 'bar'], ['foobar', 'foobaz']);
+
+        $this->assertEquals(
+            $redirect,
+            $utils->getAuthorizationUrl($request, 'instagram')
         );
     }
 
@@ -162,9 +187,9 @@ class OAuthUtilsTest extends TestCase
         return Request::create($url, 'get', [], [], [], ['SERVER_PORT' => 8080]);
     }
 
-    private function getMap($url, $redirect, $hasUser = false, $hasOneRedirectUrl = false)
+    private function getMap($url, $redirect, $hasUser = false, $hasOneRedirectUrl = false, $resource = null)
     {
-        $resource = $this->createMock(ResourceOwnerInterface::class);
+        $resource = null !== $resource ? $resource : $this->createMock(ResourceOwnerInterface::class);
 
         $resource
             ->expects($this->once())

--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,7 @@
 
     "require": {
         "php":                            "^7.1",
+        "ext-json":                       "*",
         "symfony/framework-bundle":       "^3.4|^4.2",
         "symfony/security-bundle":        "^3.4|^4.2",
         "symfony/options-resolver":       "^3.4|^4.2",
@@ -122,7 +123,7 @@
         "php-http/guzzle6-adapter":     "^2.0",
         "phpunit/phpunit":              "^6.5|^7.5",
         "friendsofphp/php-cs-fixer":    "^2.0",
-        "symfony/monolog-bundle": "^3.4"
+        "symfony/monolog-bundle":       "^3.4"
     },
 
     "conflict": {


### PR DESCRIPTION
Currently the bundle only supports passing a CSRF token in the state
parameter. We should be able to pass more than just that in the state
parameter, such as any other type of state we want to round-trip back to
the application.

This value object supports passing a single value for CSRF tokens OR
state, or several values in an encoded array. It does the conversion to
and from encoded array/string.

Replaces & finishes #1456.