### PR TITLE
Add functional test for ConnectController

### DIFF
--- a/Tests/App/AppKernel.php
+++ b/Tests/App/AppKernel.php
@@ -24,8 +24,10 @@ class AppKernel extends Kernel
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new \Symfony\Bundle\MonologBundle\MonologBundle(),
-            new \HWI\Bundle\OAuthBundle\HWIOAuthBundle(),
             new \Symfony\Bundle\TwigBundle\TwigBundle(),
+            new \FOS\UserBundle\FOSUserBundle(),
+            new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new \HWI\Bundle\OAuthBundle\HWIOAuthBundle(),
         ];
 
         return $bundles;

--- a/Tests/App/config.yml
+++ b/Tests/App/config.yml
@@ -9,6 +9,10 @@ framework:
         handler_id:  ~
         storage_id: session.storage.mock_file
         name: MOCKSESSID
+    translator: ~
+    form:
+        enabled: true
+    csrf_protection: ~
 
 monolog:
     handlers:
@@ -18,9 +22,12 @@ monolog:
             level: debug
 
 security:
+    encoders:
+        HWI\Bundle\OAuthBundle\Tests\Fixtures\FOSUser: sha512
     providers:
         HWI\Bundle\OAuthBundle\Tests\App\UserProvider:
             id: HWI\Bundle\OAuthBundle\Tests\App\UserProvider
+
     firewalls:
         login_area:
             pattern: ^/(login$|connect|login_hwi)
@@ -58,8 +65,26 @@ services:
 
     Http\Message\MessageFactory\GuzzleMessageFactory:
 
+doctrine:
+    dbal:
+        url: 'sqlite:///:memory:'
+    orm:
+        entity_managers:
+            default:
+                auto_mapping: true
+                mappings:
+                    App:
+                        is_bundle: false
+                        type: annotation
+                        dir: '%kernel.project_dir%/../Fixtures'
+                        prefix: 'HWI\Bundle\OAuthBundle\Tests\Fixtures'
+                        alias: HWI\Bundle\OAuthBundle\Tests\Fixtures
+
 hwi_oauth:
     connect: ~
+    fosub:
+        properties:
+            google: googleId
     http:
         client: Psr\Http\Client\ClientInterface
         message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
@@ -72,6 +97,16 @@ hwi_oauth:
             client_id:           'google_client_id'
             client_secret:       'google_client_secret'
             scope:               "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
+
+fos_user:
+    db_driver: orm
+    user_class: HWI\Bundle\OAuthBundle\Tests\Fixtures\FOSUser
+    firewall_name: secured_area
+    from_email:
+        address: "test@example.com"
+        sender_name: "test@example.com"
+    service:
+        mailer: 'fos_user.mailer.noop'
 
 twig:
     strict_variables: '%kernel.debug%'

--- a/Tests/Fixtures/CustomOAuthToken.php
+++ b/Tests/Fixtures/CustomOAuthToken.php
@@ -23,6 +23,6 @@ class CustomOAuthToken extends OAuthToken
             'ROLE_USER',
         ]);
 
-        $this->setUser(new User());
+        $this->setUser(new FOSUser());
     }
 }

--- a/Tests/Fixtures/FOSUser.php
+++ b/Tests/Fixtures/FOSUser.php
@@ -11,14 +11,38 @@
 
 namespace HWI\Bundle\OAuthBundle\Tests\Fixtures;
 
+use Doctrine\ORM\Mapping as ORM;
 use FOS\UserBundle\Model\User as BaseUser;
 
 /**
  * @author Alexander <iam.asm89@gmail.com>
+ * @ORM\Entity
  */
 class FOSUser extends BaseUser
 {
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
+    private $googleId;
+
     private $githubId;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->username = 'foo';
+        $this->email = 'foo@bar.com';
+        $this->password = 'secret';
+        $this->enabled = true;
+    }
 
     public function getId()
     {
@@ -57,5 +81,15 @@ class FOSUser extends BaseUser
     public function setGithubId($githubId)
     {
         $this->githubId = $githubId;
+    }
+
+    public function getGoogleId()
+    {
+        return $this->googleId;
+    }
+
+    public function setGoogleId($googleId)
+    {
+        $this->googleId = $googleId;
     }
 }

--- a/Tests/Functional/Controller/ConnectControllerTest.php
+++ b/Tests/Functional/Controller/ConnectControllerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\Functional\Controller;
+
+use Doctrine\ORM\Tools\SchemaTool;
+use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
+use HWI\Bundle\OAuthBundle\Tests\App\AppKernel;
+use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
+use Prophecy\Argument;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+final class ConnectControllerTest extends WebTestCase
+{
+    protected function setUp(): void
+    {
+        static::$class = AppKernel::class;
+    }
+
+    public static function getKernelClass(): string
+    {
+        return AppKernel::class;
+    }
+
+    public function testRegistration(): void
+    {
+        $mockResponse = $this->prophesize(ResponseInterface::class);
+        $mockResponse->getBody()
+            ->willReturn(json_encode(['access_token' => 'valid-access-token']));
+
+        $httpClient = $this->prophesize(ClientInterface::class);
+        $httpClient->sendRequest(Argument::type(RequestInterface::class))
+            ->shouldBeCalled()
+            ->willReturn($mockResponse->reveal());
+
+        $client = static::createClient();
+        $client->disableReboot();
+
+        $client->getContainer()->set(ClientInterface::class, $httpClient->reveal());
+
+        $key = 1;
+        $exception = new AccountNotLinkedException();
+        $exception->setResourceOwnerName('google');
+        $exception->setToken(new CustomOAuthToken());
+
+        $session = $client->getContainer()->get('session');
+        $session->set('_hwi_oauth.registration_error.'.$key, $exception);
+
+        $this->createDatabase($client);
+
+        $crawler = $client->request('GET', '/connect/registration/'.$key);
+
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode(), $response->getContent());
+        $this->assertSame(1, $crawler->filter('.hwi_oauth_registration_register')->count(), $response->getContent());
+
+        $form = $crawler->filter('form')->form();
+
+        $form['fos_user_registration_form[email]']->setValue('test@example.com');
+        $form['fos_user_registration_form[username]']->setValue('username');
+        $form['fos_user_registration_form[plainPassword][first]']->setValue('bar');
+        $form['fos_user_registration_form[plainPassword][second]']->setValue('bar');
+
+        $crawler = $client->submit($form);
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode(), $response->getContent());
+        $this->assertSame('Successfully registered and connected the account "foo"!', $crawler->filter('h3')->text(), $response->getContent());
+    }
+
+    public function testConnectService(): void
+    {
+        $client = static::createClient();
+        $client->disableReboot();
+
+        $mockResponse = $this->prophesize(ResponseInterface::class);
+        $httpClient = $this->prophesize(ClientInterface::class);
+        $mockResponse->getBody()
+            ->willReturn(json_encode(['name' => 'foo']));
+
+        $httpClient->sendRequest(Argument::any())
+            ->shouldBeCalled()
+            ->willReturn($mockResponse->reveal());
+        $client->getContainer()->set(ClientInterface::class, $httpClient->reveal());
+
+        $this->createDatabase($client);
+
+        $session = $client->getContainer()->get('session');
+        $key = 1;
+        $session->set('_hwi_oauth.connect_confirmation.'.$key, ['access_token' => 'valid-access-token']);
+        $this->logIn($client, $session);
+
+        $crawler = $client->request('GET', '/connect/service/google', [
+            'key' => $key,
+        ]);
+
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode(), $response->getContent());
+        $this->assertSame(1, $crawler->filter('.fos_user_registration_register')->count(), $response->getContent());
+
+        $form = $crawler->filter('form')->form();
+
+        $crawler = $client->submit($form);
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode(), $response->getContent());
+        $this->assertSame('Successfully connected the account "foo"!', $crawler->filter('h3')->text(), $response->getContent());
+    }
+
+    private function logIn(Client $client, SessionInterface $session): void
+    {
+        $firewallContext = 'hwi_context';
+        $token = new CustomOAuthToken();
+        $session->set('_security_'.$firewallContext, serialize($token));
+        $cookie = new Cookie($session->getName(), $session->getId());
+        $client->getCookieJar()->set($cookie);
+    }
+
+    private function createDatabase(Client $client): void
+    {
+        $entityManager = $client->getContainer()->get('doctrine.orm.entity_manager');
+
+        $metadata = $entityManager->getMetadataFactory()->getAllMetadata();
+        $schemaTool = new SchemaTool($entityManager);
+        $schemaTool->updateSchema($metadata);
+    }
+}

--- a/Tests/Security/Core/User/FOSUBUserProviderTest.php
+++ b/Tests/Security/Core/User/FOSUBUserProviderTest.php
@@ -80,11 +80,11 @@ class FOSUBUserProviderTest extends TestCase
     public function testConnectUserWithNoSetterThrowsException()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Could not determine access type for property "googleId".');
+        $this->expectExceptionMessage('Could not determine access type for property "facebookId".');
 
         $user = new FOSUser();
 
-        $userResponseMock = $this->createUserResponseMock(null, 'google');
+        $userResponseMock = $this->createUserResponseMock(null, 'facebook');
         $provider = $this->createFOSUBUserProvider();
 
         $provider->connect($user, $userResponseMock);
@@ -127,7 +127,7 @@ class FOSUBUserProviderTest extends TestCase
                 ->with($updateUser);
         }
 
-        return new FOSUBUserProvider($userManagerMock, ['github' => 'githubId', 'google' => 'googleId']);
+        return new FOSUBUserProvider($userManagerMock, ['github' => 'githubId', 'google' => 'googleId', 'facebook' => 'facebookId']);
     }
 
     protected function createResourceOwnerMock($resourceOwnerName = null)

--- a/composer.json
+++ b/composer.json
@@ -118,12 +118,14 @@
         "symfony/twig-bundle":          "^3.4|^4.2",
         "symfony/stopwatch":            "^3.4|^4.2",
         "symfony/phpunit-bridge":       "^3.4|^4.2",
-        "friendsofsymfony/user-bundle": "^2.0",
+        "symfony/translation":          "^3.4|^4.2",
+        "friendsofsymfony/user-bundle": "^2.1",
         "php-http/httplug-bundle":      "^1.7",
         "php-http/guzzle6-adapter":     "^2.0",
         "phpunit/phpunit":              "^6.5|^7.5",
         "friendsofphp/php-cs-fixer":    "^2.0",
-        "symfony/monolog-bundle": "^3.4"
+        "symfony/monolog-bundle":       "^3.4",
+        "doctrine/doctrine-bundle":     "^1.11"
     },
 
     "conflict": {


### PR DESCRIPTION
I added a couple of functional test for `ConnectController` to check that https://github.com/hwi/HWIOAuthBundle/pull/1537 works fine. Using FOSUserBundle has added some deprecations.