### PR TITLE
Fix : Twitch Resource Owner

### DIFF
--- a/OAuth/ResourceOwner/TwitchResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitchResourceOwner.php
@@ -34,14 +34,6 @@ class TwitchResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritdoc}
      */
-    protected function doGetTokenRequest($url, array $parameters = [])
-    {
-        return $this->httpRequest($url, http_build_query($parameters, '', '&'), [], 'POST');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function doGetUserInformationRequest($url, array $parameters = [])
     {
         // Twitch require to pass the OAuth token as 'oauth_token' instead of 'access_token'
@@ -60,6 +52,7 @@ class TwitchResourceOwner extends GenericOAuth2ResourceOwner
             'access_token_url' => 'https://api.twitch.tv/kraken/oauth2/token',
             'infos_url' => 'https://api.twitch.tv/kraken/user',
             'use_bearer_authorization' => false,
+            'use_authorization_to_get_token' => false,
         ]);
     }
 }


### PR DESCRIPTION
The resource owner of twitch was no longer working. 
I got a 400 error on the response of the access_token.

The correction allows to use natively the doGetTokenRequest method of GenericOAuth2ResourceOwner class which uses the client_id and the client_secret.