### PR TITLE
Apple SignIn Base

### DIFF
--- a/OAuth/ResourceOwner/AppleResourceOwner.php
+++ b/OAuth/ResourceOwner/AppleResourceOwner.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
+
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\OAuthErrorHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * AppleResourceOwner.
+ *
+ * @author Geoffrey Bachelet <geoffrey.bachelet@gmail.com>
+ */
+class AppleResourceOwner extends GenericOAuth2ResourceOwner
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUserInformation(array $accessToken, array $extraParameters = array())
+    {
+        $response = $this->getUserResponse();
+        $response->setData($accessToken);
+        $response->setResourceOwner($this);
+        $response->setOAuthToken(new OAuthToken($accessToken));
+        return $response;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAccessToken(Request $request, $redirectUri, array $extraParameters = array())
+    {
+        OAuthErrorHandler::handleOAuthError($request);
+
+        $parameters = array_merge(array(
+            'code' => $request->request->get('code'),
+            'grant_type' => 'authorization_code',
+            'client_id' => $this->options['client_id'],
+            'client_secret' => $this->options['client_secret'],
+            'redirect_uri' => $redirectUri,
+        ), $extraParameters);
+
+        $response = $this->doGetTokenRequest($this->options['access_token_url'], $parameters);
+        $response = $this->getResponseContent($response);
+
+        $this->validateResponseContent($response);
+
+        $user = $request->request->get('user', []);
+        if(!is_object($user))
+            $user = json_decode($user, true);
+        $data = self::jwt_decode($response['id_token']);
+        $response['id'] = $data['sub'];
+        $response['firstname'] = $user['name']['firstName'] ?? null;
+        $response['lastname'] = $user['name']['lastName'] ?? null;
+        $response['realname'] = ($user['name']['firstName'] ?? null).' '.($user['name']['lastName'] ?? null);
+        $response['nickname'] = str_replace(' ', '.', ($user['name']['firstName'] ?? null).'.'.($user['name']['lastName'] ?? null));
+        $response['name'] = str_replace(' ', '.', ($user['name']['firstName'] ?? null).'.'.($user['name']['lastName'] ?? null));
+        $response['email'] = $user['email'] ?? null;
+
+        return $response;
+    }
+
+    private static function jwt_decode($jwt)
+    {
+        $tks = explode('.', $jwt);
+        list($headb64, $bodyb64, $cryptob64) = $tks;
+        return json_decode(self::urlsafeB64Decode($bodyb64), true);
+    }
+
+    private static function urlsafeB64Decode($input)
+    {
+        $remainder = strlen($input) % 4;
+        if ($remainder) {
+            $padlen = 4 - $remainder;
+            $input .= str_repeat('=', $padlen);
+        }
+        return base64_decode(strtr($input, '-_', '+/'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handles(Request $request)
+    {
+        return $request->request->has('code');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults([
+            'authorization_url' => 'https://appleid.apple.com/auth/authorize',
+            'access_token_url' => 'https://appleid.apple.com/auth/token',
+            'revoke_token_url' => '',
+            'infos_url' => '',
+            'use_commas_in_scope' => false,
+            'display' => null,
+            'type' => 'oauth2',
+            'user_response_class' => 'HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse',
+            'scope' => 'name email',
+            'appsecret_proof' => false,
+        ]);
+    }
+}

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -9,6 +9,7 @@
         <parameter key="hwi_oauth.resource_owner.oauth2.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner</parameter>
         
         <parameter key="hwi_oauth.resource_owner.amazon.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\AmazonResourceOwner</parameter>
+        <parameter key="hwi_oauth.resource_owner.apple.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\AppleResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.asana.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\AsanaResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.auth0.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\Auth0ResourceOwner</parameter>
         <parameter key="hwi_oauth.resource_owner.azure.class">HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\AzureResourceOwner</parameter>

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "security",
 
         "amazon",
+        "apple",
         "asana",
         "auth0",
         "azure",


### PR DESCRIPTION
I copied the custom resource owner I made on my own project to handle Apple Sign In.
Feel free to improve or to use in your own project. ;)

Informations : 
 - Apple doesn't seem to have an 'userinfos' endpoint but they send some on the request body of the redirect_uri, but only when the user have to authorise the app ( On the first time they use it, or after the user deleted permissions for this app on his apple account ). 
 - I didn't found any revoke_token_url or any way to do so.