### PR TITLE
[Docs] Update installation instructions

### DIFF
--- a/Resources/doc/1-setting_up_the_bundle.md
+++ b/Resources/doc/1-setting_up_the_bundle.md
@@ -3,7 +3,7 @@ Step 1: Setting up the bundle
 ### A) Add HWIOAuthBundle to your project
 
 ```bash
-composer require hwi/oauth-bundle php-http/guzzle6-adapter php-http/httplug-bundle
+composer require hwi/oauth-bundle php-http/guzzle6-adapter:^1.1 php-http/httplug-bundle
 ```
 
 Why `php-http/guzzle6-adapter`? We are decoupled from any HTTP messaging client thanks to [HTTPlug](http://httplug.io/).


### PR DESCRIPTION
Update installation instructions for version `0.6`.

Partially fixes https://github.com/hwi/HWIOAuthBundle/issues/1543, the other thing in that issue may be fixed changing the mandatory `firewall_names` parameter to optional, but I'm not sure what are the implications of that. I'll try to take a look if I can.