### PR TITLE
Make firewall_names not mandatory

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -160,7 +160,6 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('firewall_names')
                     ->isRequired()
-                    ->requiresAtLeastOneElement()
                     ->prototype('scalar')->end()
                 ->end()
                 ->scalarNode('target_path_parameter')->defaultNull()->end()

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -54,10 +54,6 @@ final class HWIOAuthExtension extends Extension
 
         $this->createHttplugClient($container, $config);
 
-        // set current firewall
-        if (empty($config['firewall_names'])) {
-            throw new InvalidConfigurationException('The child node "firewall_names" at path "hwi_oauth" must be configured.');
-        }
         $container->setParameter('hwi_oauth.firewall_names', $config['firewall_names']);
 
         // set target path parameter


### PR DESCRIPTION
I have to take a deeper look at the code to see which are the implications of this. The idea is to be able to install the bundle and do not fail (https://github.com/hwi/HWIOAuthBundle/issues/1553).

If this is ok, the recipe should be change so [`main` is not added to `firewall_names`](https://github.com/symfony/recipes-contrib/blob/master/hwi/oauth-bundle/0.6/config/packages/hwi_oauth.yaml#L3) and I guess the [post-install](https://github.com/symfony/recipes-contrib/blob/master/hwi/oauth-bundle/0.6/post-install.txt) should be updated to tell the user to add the firewall name.

But as I said, I don't know if this is possible.