### PR TITLE
Make the testsuite green again

### DIFF
--- a/Tests/Controller/AbstractConnectControllerTest.php
+++ b/Tests/Controller/AbstractConnectControllerTest.php
@@ -20,7 +20,7 @@ use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapLocator;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;

--- a/Tests/Controller/LoginControllerTest.php
+++ b/Tests/Controller/LoginControllerTest.php
@@ -13,7 +13,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 
 use HWI\Bundle\OAuthBundle\Controller\LoginController;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;

--- a/Tests/Controller/RedirectToServiceControllerTest.php
+++ b/Tests/Controller/RedirectToServiceControllerTest.php
@@ -13,7 +13,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 
 use HWI\Bundle\OAuthBundle\Controller\RedirectToServiceController;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 


### PR DESCRIPTION
It fixes the wrong usage of Symfony TestCase, this TestCase was part of the internal Symfony test suite. It has been
removed with .gitattribute and is no more part of the Sf package. This
commit uses the standard PHPUnit TestCase instead.

It is part of the #SymfonyHackday .