### PR TITLE
Tend to green tests

### DIFF
--- a/Tests/App/config.yml
+++ b/Tests/App/config.yml
@@ -110,5 +110,6 @@ fos_user:
 
 twig:
     strict_variables: '%kernel.debug%'
+    exception_controller: ~
     paths:
         '%kernel.project_dir%/templates': 'Acme'

--- a/Tests/Controller/ConnectControllerConnectServiceActionTest.php
+++ b/Tests/Controller/ConnectControllerConnectServiceActionTest.php
@@ -11,8 +11,11 @@
 
 namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 
+use HWI\Bundle\OAuthBundle\Event\FilterUserResponseEvent;
+use HWI\Bundle\OAuthBundle\Event\GetResponseUserEvent;
 use HWI\Bundle\OAuthBundle\HWIOAuthEvents;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\Form\FormInterface;
 
 class ConnectControllerConnectServiceActionTest extends AbstractConnectControllerTest
@@ -73,10 +76,16 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
         ;
 
         $this->eventDispatcher->expects($this->once())->method('dispatch');
-        $this->eventDispatcher->expects($this->at(0))
-            ->method('dispatch')
-            ->with(HWIOAuthEvents::CONNECT_INITIALIZE)
-        ;
+
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            $this->eventDispatcher->expects($this->at(0))
+                ->method('dispatch')
+                ->with($this->isInstanceOf(GetResponseUserEvent::class), HWIOAuthEvents::CONNECT_INITIALIZE);
+        } else {
+            $this->eventDispatcher->expects($this->at(0))
+                ->method('dispatch')
+                ->with(HWIOAuthEvents::CONNECT_INITIALIZE);
+        }
 
         $this->twig->expects($this->once())
             ->method('render')
@@ -116,14 +125,21 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
         ;
 
         $this->eventDispatcher->expects($this->exactly(2))->method('dispatch');
-        $this->eventDispatcher->expects($this->at(0))
-            ->method('dispatch')
-            ->with(HWIOAuthEvents::CONNECT_CONFIRMED)
-        ;
-        $this->eventDispatcher->expects($this->at(1))
-            ->method('dispatch')
-            ->with(HWIOAuthEvents::CONNECT_COMPLETED)
-        ;
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            $this->eventDispatcher->expects($this->at(0))
+                ->method('dispatch')
+                ->with($this->isInstanceOf(GetResponseUserEvent::class), HWIOAuthEvents::CONNECT_CONFIRMED);
+            $this->eventDispatcher->expects($this->at(1))
+                ->method('dispatch')
+                ->with($this->isInstanceOf(FilterUserResponseEvent::class), HWIOAuthEvents::CONNECT_COMPLETED);
+        } else {
+            $this->eventDispatcher->expects($this->at(0))
+                ->method('dispatch')
+                ->with(HWIOAuthEvents::CONNECT_CONFIRMED);
+            $this->eventDispatcher->expects($this->at(1))
+                ->method('dispatch')
+                ->with(HWIOAuthEvents::CONNECT_COMPLETED);
+        }
 
         $this->twig->expects($this->once())
             ->method('render')
@@ -154,14 +170,26 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
         ;
 
         $this->eventDispatcher->expects($this->exactly(2))->method('dispatch');
-        $this->eventDispatcher->expects($this->at(0))
-            ->method('dispatch')
-            ->with(HWIOAuthEvents::CONNECT_CONFIRMED)
-        ;
-        $this->eventDispatcher->expects($this->at(1))
-            ->method('dispatch')
-            ->with(HWIOAuthEvents::CONNECT_COMPLETED)
-        ;
+
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            $this->eventDispatcher->expects($this->at(0))
+                ->method('dispatch')
+                ->with($this->isInstanceOf(GetResponseUserEvent::class), HWIOAuthEvents::CONNECT_CONFIRMED)
+            ;
+            $this->eventDispatcher->expects($this->at(1))
+                ->method('dispatch')
+                ->with($this->isInstanceOf(FilterUserResponseEvent::class), HWIOAuthEvents::CONNECT_COMPLETED)
+            ;
+        } else {
+            $this->eventDispatcher->expects($this->at(0))
+                ->method('dispatch')
+                ->with(HWIOAuthEvents::CONNECT_CONFIRMED)
+            ;
+            $this->eventDispatcher->expects($this->at(1))
+                ->method('dispatch')
+                ->with(HWIOAuthEvents::CONNECT_COMPLETED)
+            ;
+        }
 
         $this->twig->expects($this->once())
             ->method('render')

--- a/Tests/Fixtures/FOSUser.php
+++ b/Tests/Fixtures/FOSUser.php
@@ -56,7 +56,7 @@ class FOSUser extends BaseUser
 
     public function getRoles()
     {
-        return [];
+        return ['ROLE_USER'];
     }
 
     public function getPassword()

--- a/Tests/Fixtures/User.php
+++ b/Tests/Fixtures/User.php
@@ -29,7 +29,7 @@ class User implements UserInterface
 
     public function getRoles()
     {
-        return [];
+        return ['ROLE_USER'];
     }
 
     public function getPassword()


### PR DESCRIPTION
Add roles in tests users

Symfony changed in 4.4 and now does not authorize users without roles. (and it's weird it was ok before)

#SymfonyHackday

-----------------------------------------------------

Sorry the testsuite can't be green because we're dependent to FOSUser [which triggers deprecation notices](https://github.com/FriendsOfSymfony/FOSUserBundle/pull/2942#issuecomment-557803851). And btw I'm not sure it's a great idea to test such integration.