### PR TITLE
UsernameNotFoundException refix

### DIFF
--- a/Security/Core/Exception/AccountNotLinkedException.php
+++ b/Security/Core/Exception/AccountNotLinkedException.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\Security\Core\Exception;
 
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 
 class AccountNotLinkedException extends UsernameNotFoundException implements OAuthAwareExceptionInterface
@@ -130,7 +129,7 @@ class AccountNotLinkedException extends UsernameNotFoundException implements OAu
      */
     private function serializationFromParent(): array
     {
-        if (method_exists(AuthenticationException::class, '__serialize')) {
+        if (method_exists(UsernameNotFoundException::class, '__serialize')) {
             return parent::__serialize();
         }
 
@@ -142,7 +141,7 @@ class AccountNotLinkedException extends UsernameNotFoundException implements OAu
      */
     private function unserializationFromParent(array $parentData): void
     {
-        if (method_exists(AuthenticationException::class, '__unserialize')) {
+        if (method_exists(UsernameNotFoundException::class, '__unserialize')) {
             parent::__unserialize($parentData);
         } else {
             parent::unserialize(serialize($parentData));

--- a/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
+++ b/Tests/Security/Core/Authentication/Token/OAuthTokenTest.php
@@ -113,7 +113,7 @@ class OAuthTokenTest extends TestCase
         $exception->setResourceOwnerName($resourceOwnerName);
 
         // Symfony < 4.3 BC layer.
-        if (method_exists($exception, 'serialize')) {
+        if (method_exists($exception, '__serialize')) {
             $processed = new AccountNotLinkedException();
             $processed->__unserialize($exception->__serialize());
         } else {


### PR DESCRIPTION
Now check if exist method of UsernameNotFoundException and is not necessary use of AuthenticationException.

And change test to check method __serialize instead of serialize.