### PR TITLE
fix issue when there is no authentication token available

### DIFF
--- a/Controller/LoginController.php
+++ b/Controller/LoginController.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Twig\Environment;
 
@@ -100,7 +101,11 @@ final class LoginController
      */
     public function connectAction(Request $request): Response
     {
-        $hasUser = $this->authorizationChecker->isGranted($this->grantRule);
+        try {
+            $hasUser = $this->authorizationChecker->isGranted($this->grantRule);
+        } catch (AuthenticationCredentialsNotFoundException $exception) {
+            $hasUser = false;
+        }
 
         $error = $this->authenticationUtils->getLastAuthenticationError();
 

--- a/Tests/Controller/LoginControllerTest.php
+++ b/Tests/Controller/LoginControllerTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
@@ -79,6 +80,24 @@ class LoginControllerTest extends TestCase
     public function testLoginPage()
     {
         $this->mockAuthorizationCheck();
+
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with('@HWIOAuth/Connect/login.html.twig')
+        ;
+
+        $controller = $this->createController();
+
+        $controller->connectAction($this->request);
+    }
+
+    public function testLoginPageWithoutToken()
+    {
+        $this->authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willThrowException(new AuthenticationCredentialsNotFoundException())
+        ;
 
         $this->twig->expects($this->once())
             ->method('render')
@@ -157,7 +176,7 @@ class LoginControllerTest extends TestCase
         $controller->connectAction($this->request);
     }
 
-    protected function mockAuthorizationCheck($granted = true)
+    private function mockAuthorizationCheck($granted = true)
     {
         $this->authorizationChecker->expects($this->once())
             ->method('isGranted')


### PR DESCRIPTION
While testing the master branch on one of my applications I noticed this issue on the login route:

![error](https://user-images.githubusercontent.com/921145/72161999-6e45e300-33c1-11ea-8462-6d23041aec73.png)

The provided patch fixed this issue.