### PR TITLE
[Linkedin] Fix getPreferredLocaleValue when value for path is not array

### DIFF
--- a/OAuth/Response/LinkedinUserResponse.php
+++ b/OAuth/Response/LinkedinUserResponse.php
@@ -68,6 +68,9 @@ class LinkedinUserResponse extends PathUserResponse
     protected function getPreferredLocaleValue($path)
     {
         $multiLocaleString = $this->getValueForPath($path);
+        if (\is_array($multiLocaleString) === false) {
+            return $multiLocaleString;
+        }
 
         $locale = '';
         if (isset($multiLocaleString['preferredLocale'])) {


### PR DESCRIPTION
Hi,

The protected method getPreferredLocaleValue in LinkedinUserResponse assumes that the parent getValueForPath will return an array but this value could be null too.

This check is more permissive in case the getValueForPath return a string too.