### PR TITLE
[WindowsLive] Added client_id and client_secret to token request

### DIFF
--- a/OAuth/ResourceOwner/WindowsLiveResourceOwner.php
+++ b/OAuth/ResourceOwner/WindowsLiveResourceOwner.php
@@ -37,6 +37,9 @@ class WindowsLiveResourceOwner extends GenericOAuth2ResourceOwner
      */
     protected function doGetTokenRequest($url, array $parameters = [])
     {
+        $parameters['client_id'] = $this->options['client_id'];
+        $parameters['client_secret'] = $this->options['client_secret'];
+
         return parent::httpRequest($url, http_build_query($parameters, '', '&'));
     }
 


### PR DESCRIPTION
Fixes the problem that WL resource owner does not use generic method which handles usage of authorization header so token requests are failing as they do not contain **client_id** and **client_secret**. 