### PR TITLE
Improvements for Auth0ResourceOwner to reduce regression in the future

### DIFF
--- a/OAuth/ResourceOwner/Auth0ResourceOwner.php
+++ b/OAuth/ResourceOwner/Auth0ResourceOwner.php
@@ -35,34 +35,6 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * {@inheritdoc}
      */
-    protected function doGetTokenRequest($url, array $parameters = [])
-    {
-        $parameters['client_id'] = $this->options['client_id'];
-        $parameters['client_secret'] = $this->options['client_secret'];
-
-        return $this->httpRequest(
-            $url,
-            http_build_query($parameters, '', '&'),
-            $this->getRequestHeaders(),
-            'POST'
-        );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function doGetUserInformationRequest($url, array $parameters = [])
-    {
-        return $this->httpRequest(
-            $url,
-            http_build_query($parameters, '', '&'),
-            $this->getRequestHeaders()
-        );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
@@ -97,16 +69,14 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
     }
 
     /**
-     * @param array $headers
-     *
-     * @return array
+     * {@inheritdoc}
      */
-    private function getRequestHeaders(array $headers = [])
+    protected function httpRequest($url, $content = null, array $headers = [], $method = null)
     {
         if (isset($this->options['auth0_client'])) {
             $headers['Auth0-Client'] = $this->options['auth0_client'];
         }
 
-        return $headers;
+        return parent::httpRequest($url, $content, $headers, $method);
     }
 }

--- a/Tests/OAuth/ResourceOwner/Auth0ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/Auth0ResourceOwnerTest.php
@@ -11,7 +11,10 @@
 
 namespace HWI\Bundle\OAuthBundle\Tests\OAuth\ResourceOwner;
 
+use Http\Discovery\MessageFactoryDiscovery;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\Auth0ResourceOwner;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Http\HttpUtils;
 
 class Auth0ResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
@@ -50,6 +53,59 @@ json;
         'authorization_url_csrf' => 'https://example.oauth0.com/authorize?auth0Client=eyJuYW1lIjoiSFdJT0F1dGhCdW5kbGUiLCJ2ZXJzaW9uIjoidW5rbm93biIsImVudmlyb25tZW50Ijp7Im5hbWUiOiJQSFAiLCJ2ZXJzaW9uIjoiRkFLRV9QSFBfVkVSU0lPTl9GT1JfVEVTVFMifX0=&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
     ];
 
+    /**
+     * Tests if {@see Auth0ResourceOwner::getAccessToken} would send the expected request to Auth0.
+     */
+    public function testGetAccessTokenSendsExpectedRequest(): void
+    {
+        $expectedRequestUri = 'https://example.oauth0.com/oauth/token';
+        $expectedRequestMethod = 'POST';
+        $expectedAuthorizationHeader = [
+            'Basic Y2xpZW50aWQ6Y2xpZW50c2VjcmV0',
+        ];
+        $expectedAuth0ClientRequestHeader = [
+            'eyJuYW1lIjoiSFdJT0F1dGhCdW5kbGUiLCJ2ZXJzaW9uIjoidW5rbm93biIsImVudmlyb25tZW50Ijp7Im5hbWUiOiJQSFAiLCJ2ZXJzaW9uIjoiRkFLRV9QSFBfVkVSU0lPTl9GT1JfVEVTVFMifX0=',
+        ];
+        $expectedRequestBodyContents = 'code=somecode&grant_type=authorization_code&redirect_uri=http%3A%2F%2Fredirect.to%2F';
+
+        $this->mockHttpClientSendRequestWithRequestAssertions(
+            $expectedRequestUri,
+            $expectedRequestMethod,
+            $expectedAuthorizationHeader,
+            $expectedAuth0ClientRequestHeader,
+            $expectedRequestBodyContents
+        );
+
+        $request = new Request(['code' => 'somecode']);
+
+        $this->resourceOwner->getAccessToken($request, 'http://redirect.to/');
+    }
+
+    /**
+     * Tests if {@see Auth0ResourceOwner::getUserInformation} would send the expected request to Auth0.
+     */
+    public function testGetUserInformationSendsExpectedRequest(): void
+    {
+        $expectedRequestUri = 'https://example.oauth0.com/userinfo';
+        $expectedRequestMethod = 'GET';
+        $expectedAuthorizationHeader = [
+            'Bearer token',
+        ];
+        $expectedAuth0ClientRequestHeader = [
+            'eyJuYW1lIjoiSFdJT0F1dGhCdW5kbGUiLCJ2ZXJzaW9uIjoidW5rbm93biIsImVudmlyb25tZW50Ijp7Im5hbWUiOiJQSFAiLCJ2ZXJzaW9uIjoiRkFLRV9QSFBfVkVSU0lPTl9GT1JfVEVTVFMifX0=',
+        ];
+
+        $this->mockHttpClientSendRequestWithRequestAssertions(
+            $expectedRequestUri,
+            $expectedRequestMethod,
+            $expectedAuthorizationHeader,
+            $expectedAuth0ClientRequestHeader,
+            ''
+        );
+
+        $this->resourceOwner->getUserInformation($this->tokenData);
+    }
+
     protected function setUpResourceOwner($name, HttpUtils $httpUtils, array $options)
     {
         $auth0Client = base64_encode(json_encode([
@@ -73,5 +129,61 @@ json;
         );
 
         return parent::setUpResourceOwner($name, $httpUtils, $options);
+    }
+
+    /**
+     * Mocks the {@see HttpClient::sendRequest} method with assertions on the request.
+     *
+     * @param string $expectedRequestUri
+     * @param string $expectedRequestMethod
+     * @param array  $expectedAuthorizationHeader
+     * @param array  $expectedAuth0ClientRequestHeader
+     * @param string $expectedRequestBodyContents
+     */
+    private function mockHttpClientSendRequestWithRequestAssertions(
+        string $expectedRequestUri,
+        string $expectedRequestMethod,
+        array $expectedAuthorizationHeader,
+        array $expectedAuth0ClientRequestHeader,
+        string $expectedRequestBodyContents
+    ): void {
+        $this->httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                $this->callback(function (RequestInterface $request) use ($expectedRequestUri, $expectedRequestMethod, $expectedAuthorizationHeader, $expectedAuth0ClientRequestHeader, $expectedRequestBodyContents) {
+                    $this->assertEquals($expectedRequestUri, $request->getUri());
+                    $this->assertSame(
+                        $expectedRequestMethod,
+                        $request->getMethod(),
+                        'The request should be send as POST request.'
+                    );
+                    $this->assertSame(
+                        $expectedAuthorizationHeader,
+                        $request->getHeader('Authorization'),
+                        'The Authorization header should be added to the request with the Base64 encoded client_id and client_secret.'
+                    );
+                    $this->assertSame(
+                        $expectedAuth0ClientRequestHeader,
+                        $request->getHeader('Auth0-Client'),
+                        'The Auth0-Client header should be added with the expected Base64 encoded version information.'
+                    );
+                    $this->assertSame(
+                        $expectedRequestBodyContents,
+                        $request->getBody()->getContents(),
+                        'The request body should contain the expected POST request variables.'
+                    );
+
+                    return true;
+                })
+            )
+            ->willReturnCallback(function (RequestInterface $request) {
+                return MessageFactoryDiscovery::find()
+                    ->createResponse(
+                        $this->httpResponseHttpCode,
+                        null,
+                        $request->withAddedHeader('Content-Type', 'application/json')->getHeaders(),
+                        '{"access_token": "code"}'
+                    );
+            });
     }
 }

--- a/Tests/OAuth/ResourceOwner/ResourceOwnerTestCase.php
+++ b/Tests/OAuth/ResourceOwner/ResourceOwnerTestCase.php
@@ -17,20 +17,21 @@ use Http\Discovery\MessageFactoryDiscovery;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 use HWI\Bundle\OAuthBundle\OAuth\RequestDataStorageInterface;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 
 abstract class ResourceOwnerTestCase extends TestCase
 {
-    /** @var \PHPUnit_Framework_MockObject_MockObject|HttpClient */
+    /** @var MockObject|HttpClient */
     protected $httpClient;
     protected $httpResponse;
     protected $httpResponseContentType;
     protected $httpResponseHttpCode = 200;
     protected $httpClientCalls;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject|RequestDataStorageInterface */
+    /** @var MockObject|RequestDataStorageInterface */
     protected $storage;
     protected $state = 'random';
     protected $csrf = false;


### PR DESCRIPTION
I noticed that the actual bug of the client ID and client secret not being sent was already fixed in #1594. Thanks for that! 😄 

With creating a temporary work-around for this issue, I created a fix involving less code overloading in the `Auth0ResourceOwner` class. Possibly reducing future regressions when changing the `GenericOAuth2ResourceOwner`.

I've also added tests to assert the requests that would be sent to Auth0.