### PR TITLE
Optional Twig dependency for LoginController

### DIFF
--- a/Controller/LoginController.php
+++ b/Controller/LoginController.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Controller;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,7 +27,7 @@ use Twig\Environment;
 /**
  * @author Alexander <iam.asm89@gmail.com>
  */
-final class LoginController
+final class LoginController extends AbstractController
 {
     /**
      * @var bool

--- a/Controller/LoginController.php
+++ b/Controller/LoginController.php
@@ -121,8 +121,8 @@ final class LoginController extends AbstractController
             $error = $error->getMessageKey();
         }
 
-        return new Response($this->twig->render('@HWIOAuth/Connect/login.html.twig', [
+        return $this->render('@HWIOAuth/Connect/login.html.twig', [
             'error' => $error,
-        ]));
+        ]);
     }
 }

--- a/Controller/LoginController.php
+++ b/Controller/LoginController.php
@@ -22,7 +22,6 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
-use Twig\Environment;
 
 /**
  * @author Alexander <iam.asm89@gmail.com>
@@ -45,11 +44,6 @@ final class LoginController extends AbstractController
     private $authenticationUtils;
 
     /**
-     * @var Environment
-     */
-    private $twig;
-
-    /**
      * @var RouterInterface
      */
     private $router;
@@ -66,7 +60,6 @@ final class LoginController extends AbstractController
 
     public function __construct(
         AuthenticationUtils $authenticationUtils,
-        Environment $twig,
         RouterInterface $router,
         AuthorizationCheckerInterface $authorizationChecker,
         SessionInterface $session,
@@ -74,7 +67,6 @@ final class LoginController extends AbstractController
         string $grantRule
     ) {
         $this->authenticationUtils = $authenticationUtils;
-        $this->twig = $twig;
         $this->router = $router;
         $this->authorizationChecker = $authorizationChecker;
         $this->session = $session;

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -18,13 +18,12 @@
 
         <service id="HWI\Bundle\OAuthBundle\Controller\LoginController" public="true">
             <argument type="service" id="security.authentication_utils" />
-            <argument type="service" id="twig" />
             <argument type="service" id="router" />
             <argument type="service" id="security.authorization_checker" />
             <argument type="service" id="session" />
             <argument>%hwi_oauth.connect%</argument>
             <argument>%hwi_oauth.grant_rule%</argument>
-                   
+
             <tag name="controller.service_arguments" />
         </service>
 
@@ -34,7 +33,7 @@
             <argument>%hwi_oauth.target_path_parameter%</argument>
             <argument>%hwi_oauth.failed_use_referer%</argument>
             <argument>%hwi_oauth.use_referer%</argument>
-                   
+
             <tag name="controller.service_arguments" />
         </service>
     </services>

--- a/Tests/Controller/LoginControllerTest.php
+++ b/Tests/Controller/LoginControllerTest.php
@@ -214,7 +214,6 @@ class LoginControllerTest extends TestCase
     {
         $controller = new LoginController(
             $this->authenticationUtils,
-            $this->twig,
             $this->router,
             $this->authorizationChecker,
             $this->session,

--- a/Tests/Controller/LoginControllerTest.php
+++ b/Tests/Controller/LoginControllerTest.php
@@ -13,6 +13,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 
 use HWI\Bundle\OAuthBundle\Controller\LoginController;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,27 +30,27 @@ use Twig\Environment;
 class LoginControllerTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|AuthorizationCheckerInterface
+     * @var MockObject|AuthorizationCheckerInterface
      */
     private $authorizationChecker;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Environment
+     * @var MockObject|Environment
      */
     private $twig;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|RouterInterface
+     * @var MockObject|RouterInterface
      */
     private $router;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|AuthenticationUtils
+     * @var MockObject|AuthenticationUtils
      */
     private $authenticationUtils;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|SessionInterface
+     * @var MockObject|SessionInterface
      */
     private $session;
 


### PR DESCRIPTION
Currently the `symfony/twig-bundle` is only a development requirement of this bundle. Though, because the Twig `Environment` is injected into the `LoginController` has become requirement and compiling the Symfony service container in an application fails when Twig is not installed.

This is currently the case for our application, which isn't using the `LoginController`.

This PR changes the Twig requirement back to an optional requirement of the bundle by the using Symfony's `AbstractController` (and it's service subscribing).