### PR TITLE
Make OAuth2 Authorization optional

### DIFF
--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -220,7 +220,7 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
             'attr_name' => 'access_token',
             'use_commas_in_scope' => false,
             'use_bearer_authorization' => true,
-            'use_authorization_to_get_token' => true,
+            'use_authorization_to_get_token' => false,
         ]);
 
         $resolver->setDefined('revoke_token_url');

--- a/OAuth/ResourceOwner/TwitchResourceOwner.php
+++ b/OAuth/ResourceOwner/TwitchResourceOwner.php
@@ -52,7 +52,6 @@ class TwitchResourceOwner extends GenericOAuth2ResourceOwner
             'access_token_url' => 'https://id.twitch.tv/oauth2/token',
             'infos_url' => 'https://api.twitch.tv/helix/users',
             'use_bearer_authorization' => false,
-            'use_authorization_to_get_token' => false,
         ]);
     }
 }

--- a/OAuth/ResourceOwner/VkontakteResourceOwner.php
+++ b/OAuth/ResourceOwner/VkontakteResourceOwner.php
@@ -82,7 +82,6 @@ class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
             'authorization_url' => 'https://oauth.vk.com/authorize',
             'access_token_url' => 'https://oauth.vk.com/access_token',
             'infos_url' => 'https://api.vk.com/method/users.get',
-            'use_authorization_to_get_token' => false,
 
             'api_version' => '5.73',
 


### PR DESCRIPTION
It looks like https://github.com/hwi/HWIOAuthBundle/commit/f0d6b9ef10421131fb71ea1b9a51efc0e00b20af introduced a BC break. This could be fixed by making the HTTP Basic authentication optional.