### PR TITLE
Add missing setContainer call to service container configuration for LoginController

### DIFF
--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -16,13 +16,15 @@
             <tag name="controller.service_arguments" />
         </service>
 
-        <service id="HWI\Bundle\OAuthBundle\Controller\LoginController" public="true" autowire="true">
+        <service id="HWI\Bundle\OAuthBundle\Controller\LoginController" public="true">
             <argument type="service" id="security.authentication_utils" />
             <argument type="service" id="router" />
             <argument type="service" id="security.authorization_checker" />
             <argument type="service" id="session" />
             <argument>%hwi_oauth.connect%</argument>
             <argument>%hwi_oauth.grant_rule%</argument>
+
+            <call method="setContainer" />
 
             <tag name="container.service_subscriber" />
             <tag name="controller.service_arguments" />

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -24,6 +24,10 @@
             <argument>%hwi_oauth.connect%</argument>
             <argument>%hwi_oauth.grant_rule%</argument>
 
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+
             <tag name="controller.service_arguments" />
         </service>
 

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -16,7 +16,7 @@
             <tag name="controller.service_arguments" />
         </service>
 
-        <service id="HWI\Bundle\OAuthBundle\Controller\LoginController" public="true">
+        <service id="HWI\Bundle\OAuthBundle\Controller\LoginController" public="true" autowire="true">
             <argument type="service" id="security.authentication_utils" />
             <argument type="service" id="router" />
             <argument type="service" id="security.authorization_checker" />
@@ -24,10 +24,7 @@
             <argument>%hwi_oauth.connect%</argument>
             <argument>%hwi_oauth.grant_rule%</argument>
 
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
-
+            <tag name="container.service_subscriber" />
             <tag name="controller.service_arguments" />
         </service>
 


### PR DESCRIPTION
This PR adds the `setContainer` call to service container configuration for `LoginController`.

As mentioned in https://github.com/hwi/HWIOAuthBundle/pull/1611#discussion_r384959036, I tested adding the `container.service_subscriber` tag.

This creates a service locator with the subscribed services of the `LoginController` (`AbstractController`), but the `setContainer` call isn't added with service locator by any other compiler pass than the `AutowirePass`. As the service locator is created with a hashed service id, you're not really able to reference it manually.