### PR TITLE
Fix azure urls

### DIFF
--- a/OAuth/ResourceOwner/AzureResourceOwner.php
+++ b/OAuth/ResourceOwner/AzureResourceOwner.php
@@ -42,22 +42,6 @@ class AzureResourceOwner extends GenericOAuth2ResourceOwner
 
     /**
      * {@inheritdoc}
-     */
-    public function getAuthorizationUrl($redirectUri, array $extraParameters = [])
-    {
-        return parent::getAuthorizationUrl($redirectUri, $extraParameters + ['resource' => $this->options['resource']]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function refreshAccessToken($refreshToken, array $extraParameters = [])
-    {
-        return parent::refreshAccessToken($refreshToken, $extraParameters + ['resource' => $this->options['resource']]);
-    }
-
-    /**
-     * {@inheritdoc}
      *
      * @throws \InvalidArgumentException
      */
@@ -96,13 +80,10 @@ class AzureResourceOwner extends GenericOAuth2ResourceOwner
     {
         parent::configureOptions($resolver);
 
-        $resolver->setRequired(['resource']);
-
         $resolver->setDefaults([
             'infos_url' => 'https://graph.microsoft.com/v1.0/me',
-            'authorization_url' => 'https://login.windows.net/%s/oauth2/authorize',
-            'access_token_url' => 'https://login.windows.net/%s/oauth2/token',
-
+            'authorization_url' => 'https://login.microsoftonline.com/%s/oauth2/v2.0/authorize',
+            'access_token_url' => 'https://login.microsoftonline.com/%s/oauth2/v2.0/token',
             'application' => 'common',
             'api_version' => 'v1.0',
             'csrf' => true,

--- a/Resources/doc/resource_owners/azure.md
+++ b/Resources/doc/resource_owners/azure.md
@@ -1,12 +1,12 @@
 Step 2x: Setup Azure
 ====================
 First you will have to register your application with Azure.
-Just follow the steps as described here: http://blogs.msdn.com/b/aadgraphteam/archive/2013/05/17/using-oauth-2-0-authorization-code-grant-for-delegated-access-of-directory-via-aad-graph.aspx
+Just follow the steps as described here: https://docs.microsoft.com/en-us/azure/active-directory/saas-apps/openidoauth-tutorial
 
-More details on the Azure and OAuth can be found here https://msdn.microsoft.com/en-us/library/azure/dn645542.aspx and for Azure Active Directory here https://msdn.microsoft.com/en-us/library/azure/hh974476.aspx
+More details on the Azure and OAuth can be found here https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols
 
 Next configure a resource owner of type `azure` with appropriate `client_id`,
-`client_secret`, and `resource`. You can also specify which `application` it
+`client_secret`. You can also specify which `application` it
 should target (`common` by default)
 
 ```yaml
@@ -20,7 +20,6 @@ hwi_oauth:
             client_secret: <client_secret>
 
             options:
-                resource:    https://graph.windows.net
                 application: common
 ```
 

--- a/Tests/OAuth/ResourceOwner/AzureResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/AzureResourceOwnerTest.php
@@ -41,13 +41,13 @@ json;
     ];
 
     protected $expectedUrls = [
-        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&resource=https%3A%2F%2Fgraph.windows.net',
+        'authorization_url_csrf' => 'http://user.auth/?test=2&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
     ];
 
     public function testGetAuthorizationUrl()
     {
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&resource=https%3A%2F%2Fgraph.windows.net',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
             $this->resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }
@@ -109,19 +109,5 @@ json;
         } catch (HttpTransportException $e) {
             $this->assertSame($exception, $e->getPrevious());
         }
-    }
-
-    protected function setUpResourceOwner($name, HttpUtils $httpUtils, array $options)
-    {
-        return parent::setUpResourceOwner(
-            $name,
-            $httpUtils,
-            array_merge(
-                [
-                    'resource' => 'https://graph.windows.net',
-                ],
-                $options
-            )
-        );
     }
 }

--- a/Tests/OAuth/ResourceOwner/AzureResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/AzureResourceOwnerTest.php
@@ -15,7 +15,6 @@ use Http\Client\Exception\TransferException;
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\AzureResourceOwner;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomUserResponse;
-use Symfony\Component\Security\Http\HttpUtils;
 
 class AzureResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
 {


### PR DESCRIPTION
This will fix azure `authorization_url` and `access_token_url` and remove the `resource` parameter (could not find any ref in the current azure ad docs of this parameter).
I am currently using this fix to authenticate users from Azure AD. The URLs in this fix can be found [in the aure AD documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols).