### PR TITLE
Add first_name & last_name in AzureResourceOwner

### DIFF
--- a/OAuth/ResourceOwner/AzureResourceOwner.php
+++ b/OAuth/ResourceOwner/AzureResourceOwner.php
@@ -26,6 +26,8 @@ class AzureResourceOwner extends GenericOAuth2ResourceOwner
     protected $paths = [
         'identifier' => 'sub',
         'nickname' => 'unique_name',
+        'lastname' => 'family_name',
+        'firstname' => 'given_name',
         'realname' => ['given_name', 'family_name'],
         'email' => ['upn', 'email'],
         'profilepicture' => null,

--- a/Tests/OAuth/ResourceOwner/AzureResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/AzureResourceOwnerTest.php
@@ -65,6 +65,8 @@ json;
 
         $this->assertEquals('1', $userResponse->getUsername());
         $this->assertEquals('Dummy Tester', $userResponse->getRealName());
+        $this->assertEquals('Dummy', $userResponse->getFirstName());
+        $this->assertEquals('Tester', $userResponse->getLastName());
         $this->assertEquals('dummy123', $userResponse->getNickname());
         $this->assertNull($userResponse->getRefreshToken());
         $this->assertNull($userResponse->getExpiresIn());
@@ -88,6 +90,8 @@ json;
         $this->assertInstanceOf($class, $userResponse);
         $this->assertEquals('foo666', $userResponse->getUsername());
         $this->assertEquals('foo', $userResponse->getNickname());
+        $this->assertEquals('foo', $userResponse->getFirstName());
+        $this->assertEquals('BAR', $userResponse->getLastName());
         $this->assertEquals('token', $userResponse->getAccessToken());
         $this->assertNull($userResponse->getRefreshToken());
         $this->assertNull($userResponse->getExpiresIn());


### PR DESCRIPTION
I just added possibility to get FirstName & LastName from UserResponseInterface.
Data already exists (`realname` is a concat of `given_name` and `family_name`)