### PR TITLE
Auth0 sends user identifier in 'sub', not 'user_id'

### DIFF
--- a/OAuth/ResourceOwner/Auth0ResourceOwner.php
+++ b/OAuth/ResourceOwner/Auth0ResourceOwner.php
@@ -25,7 +25,7 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
      * {@inheritdoc}
      */
     protected $paths = [
-        'identifier' => 'user_id',
+        'identifier' => 'sub',
         'nickname' => 'nickname',
         'realname' => 'name',
         'email' => 'email',


### PR DESCRIPTION
This simple patch has the Auth0 Resource Owner use the value in 'sub' for the user identifier.  Auth0 does not use 'user_id'.