### PR TITLE
Added additional serialization methods to token in 0.6

### DIFF
--- a/Security/Core/Authentication/Token/OAuthToken.php
+++ b/Security/Core/Authentication/Token/OAuthToken.php
@@ -294,4 +294,43 @@ class OAuthToken extends AbstractToken
 
         parent::unserialize($parent);
     }
+
+    public function __serialize(): array
+    {
+        return [
+            $this->accessToken,
+            $this->rawToken,
+            $this->refreshToken,
+            $this->expiresIn,
+            $this->createdAt,
+            $this->resourceOwnerName,
+            \is_callable('parent::__serialize') ? parent::__serialize() : unserialize(parent::serialize()),
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        // add a few extra elements in the array to ensure that we have enough keys when un-serializing
+        // older data which does not include all properties.
+        $data = array_merge($data, array_fill(0, 4, null));
+
+        list(
+            $this->accessToken,
+            $this->rawToken,
+            $this->refreshToken,
+            $this->expiresIn,
+            $this->createdAt,
+            $this->resourceOwnerName,
+            $parent) = $data;
+
+        if (!$this->tokenSecret && isset($this->rawToken['oauth_token_secret'])) {
+            $this->tokenSecret = $this->rawToken['oauth_token_secret'];
+        }
+
+        if (\is_callable('parent::__serialize')) {
+            parent::__unserialize($parent);
+        } else {
+            parent::unserialize(serialize($parent));
+        }
+    }
 }


### PR DESCRIPTION
Hi, I need to use a lower version of the bundle for my SF 4.4 project due to some conflicts with other libraries. All works well except for these methods. They don't really do any harm in SF <4.3 and are really useful for when a higher SF version is needed.