### PR TITLE
Extended state parameter support to be persistent when returned from the resource owner

### DIFF
--- a/OAuth/RequestDataStorage/SessionStorage.php
+++ b/OAuth/RequestDataStorage/SessionStorage.php
@@ -48,7 +48,7 @@ class SessionStorage implements RequestDataStorageInterface
         }
 
         // request tokens are one time use only
-        if (in_array($type, ['token', 'csrf_state'])) {
+        if (\in_array($type, ['token', 'csrf_state'])) {
             $this->session->remove($key);
         }
 
@@ -70,7 +70,7 @@ class SessionStorage implements RequestDataStorageInterface
             $key = $this->generateKey($resourceOwner, $this->getStorageKey($value), $type);
         }
 
-        if (is_object($value)) {
+        if (\is_object($value)) {
             $value = serialize($value);
         }
 
@@ -100,7 +100,7 @@ class SessionStorage implements RequestDataStorageInterface
     {
         if (\is_array($value)) {
             $storageKey = reset($value);
-        } else if (is_object($value)) {
+        } elseif (\is_object($value)) {
             $storageKey = \get_class($value);
         } else {
             $storageKey = $value;

--- a/OAuth/RequestDataStorage/SessionStorage.php
+++ b/OAuth/RequestDataStorage/SessionStorage.php
@@ -70,11 +70,7 @@ class SessionStorage implements RequestDataStorageInterface
             $key = $this->generateKey($resourceOwner, $this->getStorageKey($value), $type);
         }
 
-        if (\is_object($value)) {
-            $value = serialize($value);
-        }
-
-        $this->session->set($key, $value);
+        $this->session->set($key, $this->getStorageValue($value));
     }
 
     /**
@@ -89,6 +85,20 @@ class SessionStorage implements RequestDataStorageInterface
     protected function generateKey(ResourceOwnerInterface $resourceOwner, $key, $type)
     {
         return sprintf('_hwi_oauth.%s.%s.%s.%s', $resourceOwner->getName(), $resourceOwner->getOption('client_id'), $type, $key);
+    }
+
+    /**
+     * @param array|string|object $value
+     *
+     * @return array|string
+     */
+    private function getStorageValue($value)
+    {
+        if (\is_object($value)) {
+            $value = serialize($value);
+        }
+
+        return $value;
     }
 
     /**

--- a/OAuth/RequestDataStorageInterface.php
+++ b/OAuth/RequestDataStorageInterface.php
@@ -33,7 +33,7 @@ interface RequestDataStorageInterface
      * @param string                 $key
      * @param string                 $type
      *
-     * @return array
+     * @return mixed
      */
     public function fetch(ResourceOwnerInterface $resourceOwner, $key, $type = 'token');
 
@@ -41,7 +41,7 @@ interface RequestDataStorageInterface
      * Save a request data to the storage.
      *
      * @param ResourceOwnerInterface $resourceOwner
-     * @param array|string           $value
+     * @param array|string|object    $value
      * @param string                 $type
      */
     public function save(ResourceOwnerInterface $resourceOwner, $value, $type = 'token');

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -195,7 +195,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      */
     public function storeState(StateInterface $state = null): void
     {
-        if (null === $state || 0 === !\count($state->getAll())) {
+        if (null === $state || 0 === \count($state->getAll())) {
             return;
         }
 

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -195,7 +195,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      */
     public function storeState(StateInterface $state = null): void
     {
-        if (null === $state) {
+        if (null === $state || 0 === !\count($state->getAll())) {
             return;
         }
 

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -169,7 +169,11 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
         }
 
         // lazy-loading for stored states
-        $storedData = $this->storage->fetch($this, State::class, 'state');
+        try {
+            $storedData = $this->storage->fetch($this, State::class, 'state');
+        } catch (\Throwable $e) {
+            $storedData = null;
+        }
         if (null !== $storedData && false !== $storedState = unserialize($storedData)) {
             foreach ($storedState->getAll() as $key => $value) {
                 $this->addStateParameter($key, $value);

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -72,6 +72,11 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
     protected $storage;
 
     /**
+     * @var bool
+     */
+    private $stateLoaded = false;
+
+    /**
      * @param HttpMethodsClient           $httpClient Httplug client
      * @param HttpUtils                   $httpUtils  Http utils
      * @param array                       $options    Options for the resource owner
@@ -159,6 +164,19 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      */
     public function getState(): StateInterface
     {
+        if ($this->stateLoaded) {
+            return $this->state;
+        }
+
+        // lazy-loading for stored states
+        $storedData = $this->storage->fetch($this, State::class, 'state');
+        if (null !== $storedData && false !== $storedState = unserialize($storedData)) {
+            foreach ($storedState->getAll() as $key => $value) {
+                $this->addStateParameter($key, $value);
+            }
+        }
+        $this->stateLoaded = true;
+
         return $this->state;
     }
 
@@ -167,7 +185,21 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      */
     public function addStateParameter(string $key, string $value): void
     {
-        $this->state->add($key, $value);
+        if (!$this->state->has($key)) {
+            $this->state->add($key, $value);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storeState(StateInterface $state = null): void
+    {
+        if (null === $state) {
+            return;
+        }
+
+        $this->storage->save($this, $state, 'state');
     }
 
     /**

--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -151,7 +151,8 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
         }
 
         try {
-            return null !== $this->storage->fetch($this, urldecode($csrfToken), 'csrf_state');
+            return null !== $csrfToken
+                && null !== $this->storage->fetch($this, urldecode($csrfToken), 'csrf_state');
         } catch (\InvalidArgumentException $e) {
             throw new AuthenticationException('Given CSRF token is not valid.');
         }

--- a/OAuth/ResourceOwnerInterface.php
+++ b/OAuth/ResourceOwnerInterface.php
@@ -123,6 +123,11 @@ interface ResourceOwnerInterface
     public function getState(): StateInterface;
 
     /**
+     * @param StateInterface|null $state
+     */
+    public function storeState(StateInterface $state = null);
+
+    /**
      * @param string $key
      * @param string $value
      */

--- a/OAuth/State/State.php
+++ b/OAuth/State/State.php
@@ -112,14 +112,6 @@ final class State implements StateInterface
             return null;
         }
 
-        if ($this->isOnlyExistentKey(self::DEFAULT_KEY)) {
-            return urlencode($this->values[self::DEFAULT_KEY]);
-        }
-
-        if ($this->isOnlyExistentKey(self::CSRF_TOKEN_KEY)) {
-            return urlencode($this->values[self::CSRF_TOKEN_KEY]);
-        }
-
         $encoded = urlencode($this->encodeValues());
 
         return '' !== $encoded ? $encoded : null;

--- a/OAuth/State/State.php
+++ b/OAuth/State/State.php
@@ -28,7 +28,7 @@ final class State implements StateInterface
 
     /**
      * @param string|array<string,string>|null $parameters The state parameter as a string or assoc array
-     * @param bool $keepCsrf                               Whether to keep the CSRF token in the state or not
+     * @param bool                             $keepCsrf   Whether to keep the CSRF token in the state or not
      *
      * @throws InvalidArgumentException
      */
@@ -44,7 +44,7 @@ final class State implements StateInterface
             }
 
             foreach ($parameters as $key => $value) {
-                if (false === $keepCsrf && $key === self::CSRF_TOKEN_KEY) {
+                if (false === $keepCsrf && self::CSRF_TOKEN_KEY === $key) {
                     continue;
                 }
                 $this->add($key, $value);
@@ -81,7 +81,7 @@ final class State implements StateInterface
      */
     public function has(string $key): bool
     {
-        return array_key_exists($key, $this->values);
+        return \array_key_exists($key, $this->values);
     }
 
     public function setCsrfToken(string $token): void
@@ -123,6 +123,16 @@ final class State implements StateInterface
         $encoded = urlencode($this->encodeValues());
 
         return '' !== $encoded ? $encoded : null;
+    }
+
+    public function serialize(): ?string
+    {
+        return serialize($this->values);
+    }
+
+    public function unserialize($serialized): void
+    {
+        $this->values = unserialize($serialized);
     }
 
     /**
@@ -170,15 +180,5 @@ final class State implements StateInterface
         }
 
         return array_keys($array) !== range(0, \count($array) - 1);
-    }
-
-    public function serialize(): ?string
-    {
-        return serialize($this->values);
-    }
-
-    public function unserialize($serialized): void
-    {
-        $this->values = unserialize($serialized);
     }
 }

--- a/OAuth/StateInterface.php
+++ b/OAuth/StateInterface.php
@@ -14,7 +14,7 @@ namespace HWI\Bundle\OAuthBundle\OAuth;
 use HWI\Bundle\OAuthBundle\OAuth\Exception\StateRetrievalException;
 use Symfony\Component\Config\Definition\Exception\DuplicateKeyException;
 
-interface StateInterface
+interface StateInterface extends \Serializable
 {
     /**
      * @param string $key   The key to store a value to
@@ -32,6 +32,13 @@ interface StateInterface
      * @throws StateRetrievalException
      */
     public function get(string $key): ?string;
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function has(string $key): bool;
 
     /**
      * @return array<string, string>

--- a/Security/Http/ResourceOwnerMap.php
+++ b/Security/Http/ResourceOwnerMap.php
@@ -88,7 +88,6 @@ class ResourceOwnerMap implements ContainerAwareInterface, ResourceOwnerMapInter
         /** @var ResourceOwnerInterface $resourceOwner */
         $resourceOwner = $this->container->get('hwi_oauth.resource_owner.'.$name);
 
-
         return $resourceOwner;
     }
 

--- a/Security/Http/ResourceOwnerMap.php
+++ b/Security/Http/ResourceOwnerMap.php
@@ -11,6 +11,8 @@
 
 namespace HWI\Bundle\OAuthBundle\Security\Http;
 
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use HWI\Bundle\OAuthBundle\OAuth\State\State;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -83,7 +85,11 @@ class ResourceOwnerMap implements ContainerAwareInterface, ResourceOwnerMapInter
             return null;
         }
 
-        return $this->container->get('hwi_oauth.resource_owner.'.$name);
+        /** @var ResourceOwnerInterface $resourceOwner */
+        $resourceOwner = $this->container->get('hwi_oauth.resource_owner.'.$name);
+
+
+        return $resourceOwner;
     }
 
     /**
@@ -93,7 +99,14 @@ class ResourceOwnerMap implements ContainerAwareInterface, ResourceOwnerMapInter
     {
         foreach ($this->resourceOwners as $name => $checkPath) {
             if ($this->httpUtils->checkRequestPath($request, $checkPath)) {
-                return [$this->getResourceOwnerByName($name), $checkPath];
+                $resourceOwner = $this->getResourceOwnerByName($name);
+
+                // save the round-tripped state to the resource owner
+                if (null !== $resourceOwner) {
+                    $resourceOwner->storeState(new State($request->get('state'), false));
+                }
+
+                return [$resourceOwner, $checkPath];
             }
         }
 

--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -297,8 +297,8 @@ class OAuthUtils
     }
 
     /**
-     * @param string|array<string, string>|null            $queryParameter The query parameter to parse and add to the State
-     * @param ResourceOwnerInterface $resourceOwner  The resource owner holding the state to be added to
+     * @param string|array<string, string>|null $queryParameter The query parameter to parse and add to the State
+     * @param ResourceOwnerInterface            $resourceOwner  The resource owner holding the state to be added to
      */
     private function addQueryParameterToState($queryParameter, ResourceOwnerInterface $resourceOwner): void
     {

--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -297,10 +297,10 @@ class OAuthUtils
     }
 
     /**
-     * @param string|null            $queryParameter The query parameter to parse and add to the State
+     * @param string|array<string, string>|null            $queryParameter The query parameter to parse and add to the State
      * @param ResourceOwnerInterface $resourceOwner  The resource owner holding the state to be added to
      */
-    private function addQueryParameterToState(?string $queryParameter, ResourceOwnerInterface $resourceOwner): void
+    private function addQueryParameterToState($queryParameter, ResourceOwnerInterface $resourceOwner): void
     {
         if (null === $queryParameter) {
             return;

--- a/Tests/Fixtures/MyCustomProvider.php
+++ b/Tests/Fixtures/MyCustomProvider.php
@@ -66,4 +66,8 @@ class MyCustomProvider implements ResourceOwnerInterface
     public function addStateParameter(string $key, string $value): void
     {
     }
+
+    public function storeState(StateInterface $state = null)
+    {
+    }
 }

--- a/Tests/OAuth/RequestDataStorage/SessionStorageTest.php
+++ b/Tests/OAuth/RequestDataStorage/SessionStorageTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\OAuth\RequestDataStorage;
+
+use HWI\Bundle\OAuthBundle\OAuth\RequestDataStorage\SessionStorage;
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class SessionStorageTest extends TestCase
+{
+    /**
+     * @var MockObject|SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var MockObject|ResourceOwnerInterface
+     */
+    private $resourceOwner;
+
+    /**
+     * @var SessionStorage
+     */
+    private $storage;
+
+    protected function setUp(): void
+    {
+        $this->session = $this->createMock(SessionInterface::class);
+        $this->resourceOwner = $this->createMock(ResourceOwnerInterface::class);
+        $this->resourceOwner->method('getName')->willReturn('resource_owner_name');
+        $this->resourceOwner->method('getOption')->with('client_id')->willReturn('client_id');
+
+        $this->storage = new SessionStorage($this->session);
+    }
+
+    public function testSaveTokenWithoutOAuthTokenPassedThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid request token.');
+        $this->storage->save($this->resourceOwner, [], 'token');
+    }
+
+    public function testSaveOAuthToken(): void
+    {
+        $key = '_hwi_oauth.resource_owner_name.client_id.token.oauth_token';
+        $this->session
+            ->expects(self::once())
+            ->method('set')
+            ->with($key, ['oauth_token' => 'oauth_token']);
+
+        $this->storage->save($this->resourceOwner, ['oauth_token' => 'oauth_token'], 'token');
+    }
+
+    public function testSaveStringValue(): void
+    {
+        $key = '_hwi_oauth.resource_owner_name.client_id.csrf_state.csrf_token';
+        $this->session
+            ->expects(self::once())
+            ->method('set')
+            ->with($key, 'csrf_token');
+
+        $this->storage->save($this->resourceOwner, 'csrf_token', 'csrf_state');
+    }
+
+    public function testSaveArrayValue(): void
+    {
+        $key = '_hwi_oauth.resource_owner_name.client_id.type.value';
+        $this->session
+            ->expects(self::once())
+            ->method('set')
+            ->with($key, ['value']);
+
+        $this->storage->save($this->resourceOwner, ['value'], 'type');
+    }
+
+    public function testSaveObjectValue(): void
+    {
+        $class = new \stdClass();
+        $key = '_hwi_oauth.resource_owner_name.client_id.type.stdClass';
+        $this->session
+            ->expects(self::once())
+            ->method('set')
+            ->with($key, serialize($class));
+
+        $this->storage->save($this->resourceOwner, $class, 'type');
+    }
+
+    public function testFetchUnavailableKeyThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No data available in storage.');
+        $this->storage->fetch($this->resourceOwner, 'not-existing-key', 'token');
+    }
+
+    public function testFetchTokenIsOneTimeUseOnly(): void
+    {
+        $key = '_hwi_oauth.resource_owner_name.client_id.token.oauth_token';
+        $this->session
+            ->expects(self::once())
+            ->method('get')
+            ->with($key)
+            ->willReturn('oauth_token');
+        $this->session
+            ->expects(self::once())
+            ->method('remove')
+            ->with($key);
+
+        $this->storage->fetch($this->resourceOwner, 'oauth_token', 'token');
+    }
+
+    public function testFetchOtherThenToken(): void
+    {
+        $class = new \stdClass();
+        $key = '_hwi_oauth.resource_owner_name.client_id.state.stdClass';
+        $this->session
+            ->expects(self::once())
+            ->method('get')
+            ->with($key)
+            ->willReturn(serialize($class));
+        $this->session
+            ->expects(self::never())
+            ->method('remove')
+            ->with($key);
+
+        $data = $this->storage->fetch($this->resourceOwner, get_class($class), 'state');
+        self::assertEquals(serialize($class), $data);
+    }
+}

--- a/Tests/OAuth/RequestDataStorage/SessionStorageTest.php
+++ b/Tests/OAuth/RequestDataStorage/SessionStorageTest.php
@@ -133,7 +133,7 @@ class SessionStorageTest extends TestCase
             ->method('remove')
             ->with($key);
 
-        $data = $this->storage->fetch($this->resourceOwner, get_class($class), 'state');
+        $data = $this->storage->fetch($this->resourceOwner, \get_class($class), 'state');
         self::assertEquals(serialize($class), $data);
     }
 }

--- a/Tests/OAuth/ResourceOwner/AppleResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/AppleResourceOwnerTest.php
@@ -69,7 +69,7 @@ json;
         $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['display' => 'popup']);
 
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=name+email&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&response_mode=form_post',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=name+email&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&response_mode=form_post',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }

--- a/Tests/OAuth/ResourceOwner/DailymotionResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/DailymotionResourceOwnerTest.php
@@ -34,7 +34,7 @@ json;
         $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['display' => 'popup']);
 
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&display=popup',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&display=popup',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }

--- a/Tests/OAuth/ResourceOwner/DropboxResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/DropboxResourceOwnerTest.php
@@ -27,7 +27,7 @@ class DropboxResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
     public function testGetAuthorizationUrl()
     {
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F',
             $this->resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }

--- a/Tests/OAuth/ResourceOwner/FacebookResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/FacebookResourceOwnerTest.php
@@ -50,7 +50,7 @@ json;
         $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['auth_type' => 'rerequest']);
 
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&auth_type=rerequest',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&auth_type=rerequest',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }
@@ -60,7 +60,7 @@ json;
         $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['display' => 'popup', 'auth_type' => 'rerequest']);
 
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&display=popup&auth_type=rerequest',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&display=popup&auth_type=rerequest',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }
@@ -70,7 +70,7 @@ json;
         $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['display' => 'popup']);
 
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&display=popup',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&display=popup',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -148,15 +148,13 @@ json;
                 ->method('save')
                 ->with($resourceOwner, $state->getCsrfToken(), 'csrf_state');
 
-            $expectedUrl = $this->getExpectedAuthorizationUrlWithState($state->getCsrfToken());
+            $expectedUrl = $this->getExpectedAuthorizationUrlWithState($state->encode());
         }
 
         $this->assertEquals(
             $expectedUrl,
             $resourceOwner->getAuthorizationUrl('http://redirect.to/', $this->authorizationUrlParams)
         );
-
-        $this->state = 'random';
     }
 
     public function testGetState()
@@ -194,9 +192,11 @@ json;
             ->with($resourceOwner, $nonce, 'csrf_state');
 
         $this->assertEquals(
-            $this->getExpectedAuthorizationUrlWithState($nonce),
+            $this->getExpectedAuthorizationUrlWithState($state->encode()),
             $resourceOwner->getAuthorizationUrl('http://redirect.to/', $this->authorizationUrlParams)
         );
+
+        $this->state = $state->encode();
     }
 
     public function testGetAccessToken()
@@ -378,7 +378,8 @@ json;
 
     protected function getExpectedAuthorizationUrlWithState($stateParameter)
     {
-        return $this->authorizationUrlBasePart.'&state='.$stateParameter.$this->redirectUrlPart;
+        // urlencode state parameter since AbstractResourceOwner::normalizeUrl() http_build_query method encodes them again
+        return $this->authorizationUrlBasePart.'&state='.urlencode($stateParameter).$this->redirectUrlPart;
     }
 
     /**

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -159,6 +159,26 @@ json;
         $this->state = 'random';
     }
 
+    public function testGetState()
+    {
+        $stateParams = ['initial_state_param_1' => 'value'];
+        if (!$this->csrf) {
+            $initialState = new State($stateParams);
+        } else {
+            $initialState = new State(array_merge($stateParams, ['csrf_token' => NonceGenerator::generate()]));
+        }
+
+        $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, [], [], $initialState);
+        $this->storage->expects($this->once())
+            ->method('fetch')
+            ->with($resourceOwner, State::class, 'state')
+            ->willReturn(serialize(new State(['state' => 'some-state'])));
+
+        $state = $resourceOwner->getState();
+        self::assertEquals($state->get('initial_state_param_1'), 'value');
+        self::assertEquals($state->get('state'), 'some-state');
+    }
+
     public function testGetAuthorizationUrlWithEnabledCsrf()
     {
         if ($this->csrf) {

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -177,6 +177,18 @@ json;
         self::assertEquals($state->get('state'), 'some-state');
     }
 
+    public function testGetStateWithoutStoredValues()
+    {
+        $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, [], [], new State(null));
+        $this->storage->expects($this->once())
+            ->method('fetch')
+            ->with($resourceOwner, State::class, 'state')
+            ->willThrowException(new \InvalidArgumentException('No data available in storage.'));
+
+        $state = $resourceOwner->getState();
+        self::assertEmpty($state->getAll());
+    }
+
     public function testGetAuthorizationUrlWithEnabledCsrf()
     {
         if ($this->csrf) {

--- a/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GoogleResourceOwnerTest.php
@@ -54,7 +54,7 @@ json;
     public function testGetAuthorizationUrl()
     {
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline',
             $this->resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }
@@ -65,7 +65,7 @@ json;
         );
 
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&request_visible_actions=http%3A%2F%2Fschemas.google.com%2FAddActivity',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&request_visible_actions=http%3A%2F%2Fschemas.google.com%2FAddActivity',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }
@@ -75,7 +75,7 @@ json;
         $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['approval_prompt' => 'force']);
 
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&approval_prompt=force',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&approval_prompt=force',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }
@@ -84,13 +84,13 @@ json;
     {
         $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['hd' => 'mycollege.edu']);
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&hd=mycollege.edu',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&hd=mycollege.edu',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
 
         $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['hd' => 'mycollege.edu, mycollege.org']);
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&hd=mycollege.edu&mycollege.org',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&hd=mycollege.edu&mycollege.org',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }

--- a/Tests/OAuth/ResourceOwner/HubicResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/HubicResourceOwnerTest.php
@@ -43,7 +43,7 @@ class HubicResourceOwnerTest extends GenericOAuth2ResourceOwnerTest
     public function testGetAuthorizationUrl()
     {
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F',
             $this->resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }

--- a/Tests/OAuth/ResourceOwner/ResourceOwnerTestCase.php
+++ b/Tests/OAuth/ResourceOwner/ResourceOwnerTestCase.php
@@ -33,7 +33,7 @@ abstract class ResourceOwnerTestCase extends TestCase
 
     /** @var MockObject|RequestDataStorageInterface */
     protected $storage;
-    protected $state = 'random';
+    protected $state = 'eyJzdGF0ZSI6InJhbmRvbSJ9';
     protected $csrf = false;
 
     protected $options = [];

--- a/Tests/OAuth/ResourceOwner/YoutubeResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/YoutubeResourceOwnerTest.php
@@ -52,7 +52,7 @@ json;
     public function testGetAuthorizationUrl()
     {
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline',
             $this->resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }
@@ -63,7 +63,7 @@ json;
         );
 
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&request_visible_actions=http%3A%2F%2Fschemas.google.com%2FAddActivity',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&request_visible_actions=http%3A%2F%2Fschemas.google.com%2FAddActivity',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }
@@ -73,7 +73,7 @@ json;
         $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['approval_prompt' => 'force']);
 
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&approval_prompt=force',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&approval_prompt=force',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }
@@ -82,7 +82,7 @@ json;
     {
         $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['hd' => 'mycollege.edu']);
         $this->assertEquals(
-            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly&state=random&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&hd=mycollege.edu',
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.readonly&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&access_type=offline&hd=mycollege.edu',
             $resourceOwner->getAuthorizationUrl('http://redirect.to/')
         );
     }

--- a/Tests/OAuth/State/StateTest.php
+++ b/Tests/OAuth/State/StateTest.php
@@ -34,6 +34,12 @@ final class StateTest extends TestCase
         }
     }
 
+    public function testConstructorWithNull()
+    {
+        $state = new State(null);
+        self::assertCount(0, $state->getAll());
+    }
+
     public function testConstructorWithSingleValue()
     {
         $state = new State('random');
@@ -47,6 +53,24 @@ final class StateTest extends TestCase
         foreach (self::TEST_VALUES as $key => $value) {
             self::assertEquals($value, $state->get($key));
         }
+    }
+
+    public function testConstructorWithArrayParameterWithoutKeepingCSRFToken()
+    {
+        $state = new State(array_merge(self::TEST_VALUES, ['csrf_token' => 'csrf']), false);
+
+        foreach (self::TEST_VALUES as $key => $value) {
+            self::assertEquals($value, $state->get($key));
+        }
+        self::assertArrayNotHasKey('csrf_token', $state->getAll());
+    }
+
+    public function testItCanBeSerializedAndUnserialized()
+    {
+        $state = new State(self::TEST_VALUES);
+        $unserialized = unserialize(serialize($state));
+
+        self::assertEquals($state, $unserialized);
     }
 
     public function testFromEncodedParameterWithInvalidFormat()
@@ -72,6 +96,12 @@ final class StateTest extends TestCase
 
         $state->add('baz', 'foo');
         self::assertEquals('foo', $state->get('baz'));
+    }
+
+    public function testHas()
+    {
+        $state = new State($this->encodeArray(self::TEST_VALUES));
+        self::assertTrue($state->has('foo'));
     }
 
     public function testAddDuplicateKey()
@@ -121,6 +151,12 @@ final class StateTest extends TestCase
 
         $state->setCsrfToken($token);
         self::assertEquals($token, $state->getCsrfToken());
+    }
+
+    public function testGetAllKeepingCSRFToken()
+    {
+        $state = new State(array_merge(self::TEST_VALUES, ['csrf_token' => 'csrf']), false);
+        self::assertArrayNotHasKey('csrf_token', $state->getAll());
     }
 
     private function encodeArray(array $array): string

--- a/Tests/OAuth/State/StateTest.php
+++ b/Tests/OAuth/State/StateTest.php
@@ -127,12 +127,6 @@ final class StateTest extends TestCase
         self::assertNull($state->encode());
     }
 
-    public function testEncodeOnlyValue()
-    {
-        $state = new State('random');
-        self::assertEquals('random', $state->encode());
-    }
-
     public function testEncodeEmptyValue()
     {
         $state = new State(null);


### PR DESCRIPTION
I've made a number of fixes to the state parameter support, the most important being the persistence after receiving the state parameters back from the OAuth2 resource owner.

I've also added tests for the `SessionStorage` with this opportunity.