### PR TITLE
Use "access_token" instead of "id_token" in Azure

### DIFF
--- a/OAuth/ResourceOwner/AzureResourceOwner.php
+++ b/OAuth/ResourceOwner/AzureResourceOwner.php
@@ -50,7 +50,7 @@ class AzureResourceOwner extends GenericOAuth2ResourceOwner
     public function getUserInformation(array $accessToken, array $extraParameters = [])
     {
         // from http://stackoverflow.com/a/28748285/624544
-        list(, $jwt) = explode('.', (array_key_exists('id_token', $accessToken) ? $accessToken['id_token'] : $accessToken['access_token']), 3);
+        list(, $jwt) = explode('.', (\array_key_exists('id_token', $accessToken) ? $accessToken['id_token'] : $accessToken['access_token']), 3);
 
         // if the token was urlencoded, do some fixes to ensure that it is valid base64 encoded
         $jwt = str_replace(['-', '_'], ['+', '/'], $jwt);

--- a/OAuth/ResourceOwner/AzureResourceOwner.php
+++ b/OAuth/ResourceOwner/AzureResourceOwner.php
@@ -50,7 +50,7 @@ class AzureResourceOwner extends GenericOAuth2ResourceOwner
     public function getUserInformation(array $accessToken, array $extraParameters = [])
     {
         // from http://stackoverflow.com/a/28748285/624544
-        list(, $jwt) = explode('.', $accessToken['id_token'], 3);
+        list(, $jwt) = explode('.', (array_key_exists('id_token', $accessToken) ? $accessToken['id_token'] : $accessToken['access_token']), 3);
 
         // if the token was urlencoded, do some fixes to ensure that it is valid base64 encoded
         $jwt = str_replace(['-', '_'], ['+', '/'], $jwt);


### PR DESCRIPTION
Quick solution for issue #1629 with compatibility for both "id_token" and "access_token".

Reference:
 - https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
 - https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens