### PR TITLE
Change default security firewall name to same as in Flex receipt

### DIFF
--- a/Resources/doc/2-configuring_resource_owners.md
+++ b/Resources/doc/2-configuring_resource_owners.md
@@ -12,7 +12,7 @@ To make this bundle work you need to add the following to your app/config/config
 
 hwi_oauth:
     # list of names of the firewalls in which this bundle is active, this setting MUST be set
-    firewall_names: [secured_area]
+    firewall_names: [main]
 
     # an optional setting to configure a query string parameter which can be used to redirect
     # the user after authentication, e.g. /connect/facebook?_destination=/my/destination will

--- a/Resources/doc/3-configuring_the_security_layer.md
+++ b/Resources/doc/3-configuring_the_security_layer.md
@@ -24,7 +24,7 @@ Additionally you will need to point the oauth firewall to the appropriate servic
 # app/config/security.yml
 security:
     firewalls:
-        secured_area:
+        main:
             anonymous: ~
             oauth:
                 resource_owners:

--- a/Resources/doc/bonus/facebook-connect.md
+++ b/Resources/doc/bonus/facebook-connect.md
@@ -10,7 +10,7 @@ This guide bases on Symfony 2.1+ and the [AcmeDemoBundle](https://github.com/sym
 # app/config/config.yml
 
 hwi_oauth:
-    firewall_names:        [secured_area]
+    firewall_names: [main]
     resource_owners:
         facebook:
             type:          facebook
@@ -45,8 +45,8 @@ facebook_login:
 
 firewalls:
     # ...
-    secured_area:
-        pattern:    ^/demo/secured/
+    main:
+        pattern: ^/demo/secured/
         oauth:
             resource_owners:
                 facebook:      /demo/secured/login_facebook

--- a/Resources/doc/internals/reference_configuration.md
+++ b/Resources/doc/internals/reference_configuration.md
@@ -65,7 +65,7 @@ hwi_oauth:
                 nickname:   username
 
     # list of firewall names the oauth bundle is active in
-    firewall_names: [secured_area]
+    firewall_names: [main]
 
     # optional target_path_parameter to provide an explicit return URL
     #target_path_parameter: _destination
@@ -108,7 +108,7 @@ security:
             id: fos_user.user_manager
 
     firewalls:
-        secured_area:
+        main:
             pattern:    ^/
             form_login:
                 provider: fos_userbundle

--- a/Resources/doc/internals/response_object_and_paths.md
+++ b/Resources/doc/internals/response_object_and_paths.md
@@ -18,7 +18,7 @@ But enough theory, here is example how to fetch user email & picture while using
 # app/config/config.yml
 
 hwi_oauth:
-    firewall_names:        [secured_area]
+    firewall_names: [main]
     resource_owners:
         facebook:
             type:          facebook
@@ -51,7 +51,7 @@ as described below:
 ```yaml
 # app/config/config.yml
 hwi_oauth:
-   firewall_names:        [secured_area]
+   firewall_names: [main]
    resource_owners:
        linkedin:
            type:          linkedin
@@ -79,7 +79,7 @@ owner into one! Check how this could look:
 ```yaml
 # app/config/config.yml
 hwi_oauth:
-   firewall_names:        [secured_area]
+   firewall_names: [main]
    resource_owners:
        linkedin:
            type:          vkontakte

--- a/Tests/App/config.yml
+++ b/Tests/App/config.yml
@@ -33,7 +33,7 @@ security:
             pattern: ^/(login$|connect|login_hwi)
             anonymous: true
             context: hwi_context
-        secured_area:
+        main:
             pattern: ^/
             oauth:
                 resource_owners:
@@ -88,9 +88,7 @@ hwi_oauth:
     http:
         client: Psr\Http\Client\ClientInterface
         message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
-    firewall_names:
-        - secured_area
-
+    firewall_names: [main]
     resource_owners:
         google:
             type:                google
@@ -101,7 +99,7 @@ hwi_oauth:
 fos_user:
     db_driver: orm
     user_class: HWI\Bundle\OAuthBundle\Tests\Fixtures\FOSUser
-    firewall_name: secured_area
+    firewall_name: main
     from_email:
         address: "test@example.com"
         sender_name: "test@example.com"

--- a/Tests/App/security.php
+++ b/Tests/App/security.php
@@ -18,7 +18,7 @@ if (method_exists(Security::class, 'getUser') && !class_exists(UserValueResolver
             'login_area' => [
                 'logout_on_user_change' => true,
             ],
-            'secured_area' => [
+            'main' => [
                 'logout_on_user_change' => true,
             ],
         ],

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -372,7 +372,7 @@ class HWIOAuthExtensionTest extends TestCase
     {
         $this->createEmptyConfiguration();
 
-        $this->assertParameter(['secured_area'], 'hwi_oauth.firewall_names');
+        $this->assertParameter(['main'], 'hwi_oauth.firewall_names');
         $this->assertParameter(null, 'hwi_oauth.target_path_parameter');
         $this->assertParameter(false, 'hwi_oauth.use_referer');
         $this->assertParameter(false, 'hwi_oauth.failed_use_referer');
@@ -564,7 +564,7 @@ class HWIOAuthExtensionTest extends TestCase
     protected function getEmptyConfig()
     {
         $yaml = <<<EOF
-firewall_names: [secured_area]
+firewall_names: [main]
 resource_owners:
     any_name:
         type:                github
@@ -581,7 +581,7 @@ EOF;
     protected function getFullConfig()
     {
         $yaml = <<<EOF
-firewall_names: [secured_area]
+firewall_names: [main]
 
 resource_owners:
     github:


### PR DESCRIPTION
This should reduce confusion between our docs & Symfony Flex receipt - refs: https://github.com/hwi/HWIOAuthBundle/issues/1677#issuecomment-753490294