### PR TITLE
Bugfix | Fixed bundle controllers to not depend on container if possible

### DIFF
--- a/Controller/LoginController.php
+++ b/Controller/LoginController.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\Controller;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -23,11 +22,12 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+use Twig\Environment;
 
 /**
  * @author Alexander <iam.asm89@gmail.com>
  */
-final class LoginController extends AbstractController
+final class LoginController
 {
     /**
      * @var bool
@@ -59,11 +59,17 @@ final class LoginController extends AbstractController
      */
     private $requestStack;
 
+    /**
+     * @var Environment
+     */
+    private $twig;
+
     public function __construct(
         AuthenticationUtils $authenticationUtils,
         RouterInterface $router,
         AuthorizationCheckerInterface $authorizationChecker,
         RequestStack $requestStack,
+        Environment $twig,
         bool $connect,
         string $grantRule
     ) {
@@ -71,6 +77,7 @@ final class LoginController extends AbstractController
         $this->router = $router;
         $this->authorizationChecker = $authorizationChecker;
         $this->requestStack = $requestStack;
+        $this->twig = $twig;
         $this->connect = $connect;
         $this->grantRule = $grantRule;
     }
@@ -110,9 +117,9 @@ final class LoginController extends AbstractController
             $error = $error->getMessageKey();
         }
 
-        return $this->render('@HWIOAuth/Connect/login.html.twig', [
-            'error' => $error,
-        ]);
+        return new Response(
+            $this->twig->render('@HWIOAuth/Connect/login.html.twig', ['error' => $error])
+        );
     }
 
     private function getSession(): ?SessionInterface

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -10,10 +10,7 @@
             <argument type="service" id="hwi_oauth.resource_ownermap_locator" />
             <argument type="service" id="request_stack" />
 
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
-
+            <tag name="container.service_subscriber" />
             <tag name="controller.service_arguments" />
         </service>
 
@@ -22,13 +19,9 @@
             <argument type="service" id="router" />
             <argument type="service" id="security.authorization_checker" />
             <argument type="service" id="request_stack" />
+            <argument type="service" id="twig" />
             <argument>%hwi_oauth.connect%</argument>
             <argument>%hwi_oauth.grant_rule%</argument>
-
-            <call method="setContainer" />
-
-            <tag name="container.service_subscriber" />
-            <tag name="controller.service_arguments" />
         </service>
 
         <service id="HWI\Bundle\OAuthBundle\Controller\RedirectToServiceController" public="true">
@@ -38,8 +31,6 @@
             <argument>%hwi_oauth.target_path_parameter%</argument>
             <argument>%hwi_oauth.failed_use_referer%</argument>
             <argument>%hwi_oauth.use_referer%</argument>
-
-            <tag name="controller.service_arguments" />
         </service>
     </services>
 </container>

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -9,9 +9,18 @@
             <argument type="service" id="hwi_oauth.security.oauth_utils" />
             <argument type="service" id="hwi_oauth.resource_ownermap_locator" />
             <argument type="service" id="request_stack" />
+            <argument key="$enableConnect">%hwi_oauth.connect%</argument>
+            <argument key="$grantRule">%hwi_oauth.grant_rule%</argument>
+            <argument key="$failedUseReferer">%hwi_oauth.failed_use_referer%</argument>
+            <argument key="$failedAuthPath">%hwi_oauth.failed_auth_path%</argument>
+            <argument key="$enableConnectConfirmation">%hwi_oauth.connect.confirmation%</argument>
+            <argument key="$firewallNames">%hwi_oauth.firewall_names%</argument>
+
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
 
             <tag name="container.service_subscriber" />
-            <tag name="controller.service_arguments" />
         </service>
 
         <service id="HWI\Bundle\OAuthBundle\Controller\LoginController" public="true">

--- a/Tests/Controller/AbstractConnectControllerTest.php
+++ b/Tests/Controller/AbstractConnectControllerTest.php
@@ -39,11 +39,6 @@ use Symfony\Component\Templating\EngineInterface;
 abstract class AbstractConnectControllerTest extends TestCase
 {
     /**
-     * @var ConnectController
-     */
-    protected $controller;
-
-    /**
      * @var MockObject&AuthorizationCheckerInterface
      */
     protected $authorizationChecker;
@@ -182,15 +177,9 @@ abstract class AbstractConnectControllerTest extends TestCase
         $this->session = $this->createMock(SessionInterface::class);
         $this->request = Request::create('/');
         $this->request->setSession($this->session);
-
-        $this->controller = new ConnectController($this->oAuthUtils, $this->resourceOwnerMapLocator, $this->createMock(RequestStack::class));
-        $this->controller->setContainer($this->container);
     }
 
-    /**
-     * @return AccountNotLinkedException
-     */
-    protected function createAccountNotLinkedException()
+    protected function createAccountNotLinkedException(): AccountNotLinkedException
     {
         $accountNotLinked = new AccountNotLinkedException();
         $accountNotLinked->setResourceOwnerName('facebook');
@@ -199,12 +188,33 @@ abstract class AbstractConnectControllerTest extends TestCase
         return $accountNotLinked;
     }
 
-    protected function mockAuthorizationCheck($granted = true)
+    protected function mockAuthorizationCheck(bool $granted = true): void
     {
         $this->authorizationChecker->expects($this->once())
             ->method('isGranted')
             ->with('IS_AUTHENTICATED_REMEMBERED')
             ->willReturn($granted)
         ;
+    }
+
+    protected function createConnectController(
+        bool $connectEnabled = true,
+        bool $confirmConnect = true,
+        array $firewallNames = ['default']
+    ): ConnectController {
+        $controller = new ConnectController(
+            $this->oAuthUtils,
+            $this->resourceOwnerMapLocator,
+            $this->createMock(RequestStack::class),
+            $connectEnabled,
+            'IS_AUTHENTICATED_REMEMBERED',
+            true,
+            'fake_route',
+            $confirmConnect,
+            $firewallNames
+        );
+        $controller->setContainer($this->container);
+
+        return $controller;
     }
 }

--- a/Tests/Controller/ConnectControllerConnectServiceActionTest.php
+++ b/Tests/Controller/ConnectControllerConnectServiceActionTest.php
@@ -25,9 +25,8 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
     {
         $this->expectException(NotFoundHttpException::class);
 
-        $this->container->setParameter('hwi_oauth.connect', false);
-
-        $this->controller->connectServiceAction($this->request, 'facebook');
+        $controller = $this->createConnectController(false);
+        $controller->connectServiceAction($this->request, 'facebook');
     }
 
     public function testAlreadyConnected()
@@ -37,18 +36,18 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
 
         $this->mockAuthorizationCheck(false);
 
-        $this->controller->connectServiceAction($this->request, 'facebook');
+        $controller = $this->createConnectController();
+        $controller->connectServiceAction($this->request, 'facebook');
     }
 
     public function testUnknownResourceOwner()
     {
         $this->expectException(NotFoundHttpException::class);
 
-        $this->container->setParameter('hwi_oauth.firewall_names', []);
-
         $this->mockAuthorizationCheck();
 
-        $this->controller->connectServiceAction($this->request, 'unknown');
+        $controller = $this->createConnectController(true, true, []);
+        $controller->connectServiceAction($this->request, 'unknown');
     }
 
     public function testConnectConfirm()
@@ -85,7 +84,8 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->with('@HWIOAuth/Connect/connect_confirm.html.twig')
         ;
 
-        $this->controller->connectServiceAction($this->request, 'facebook');
+        $controller = $this->createConnectController();
+        $controller->connectServiceAction($this->request, 'facebook');
     }
 
     public function testConnectSuccess()
@@ -129,7 +129,8 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->with('@HWIOAuth/Connect/connect_success.html.twig')
         ;
 
-        $this->controller->connectServiceAction($this->request, 'facebook');
+        $controller = $this->createConnectController();
+        $controller->connectServiceAction($this->request, 'facebook');
     }
 
     public function testConnectNoConfirmation()
@@ -137,7 +138,6 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
         $key = time();
 
         $this->request->query->set('key', $key);
-        $this->container->setParameter('hwi_oauth.connect.confirmation', false);
 
         $this->mockAuthorizationCheck();
 
@@ -164,7 +164,8 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->with('@HWIOAuth/Connect/connect_success.html.twig')
         ;
 
-        $this->controller->connectServiceAction($this->request, 'facebook');
+        $controller = $this->createConnectController(true, false);
+        $controller->connectServiceAction($this->request, 'facebook');
     }
 
     public function testResourceOwnerHandle()
@@ -201,6 +202,7 @@ class ConnectControllerConnectServiceActionTest extends AbstractConnectControlle
             ->with('@HWIOAuth/Connect/connect_confirm.html.twig')
         ;
 
-        $this->controller->connectServiceAction($this->request, 'facebook');
+        $controller = $this->createConnectController();
+        $controller->connectServiceAction($this->request, 'facebook');
     }
 }

--- a/Tests/Controller/ConnectControllerRegistrationActionTest.php
+++ b/Tests/Controller/ConnectControllerRegistrationActionTest.php
@@ -30,9 +30,8 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
     {
         $this->expectException(NotFoundHttpException::class);
 
-        $this->container->setParameter('hwi_oauth.connect', false);
-
-        $this->controller->registrationAction($this->request, time());
+        $controller = $this->createConnectController(false);
+        $controller->registrationAction($this->request, time());
     }
 
     public function testAlreadyConnected()
@@ -42,7 +41,8 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
 
         $this->mockAuthorizationCheck();
 
-        $this->controller->registrationAction($this->request, time());
+        $controller = $this->createConnectController();
+        $controller->registrationAction($this->request, time());
     }
 
     public function testCannotRegisterBadError()
@@ -65,7 +65,8 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
             ->with('_hwi_oauth.registration_error.'.$key)
         ;
 
-        $this->controller->registrationAction($this->request, $key);
+        $controller = $this->createConnectController();
+        $controller->registrationAction($this->request, $key);
     }
 
     public function testFailedProcess()
@@ -104,7 +105,8 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
             ->with('@HWIOAuth/Connect/registration.html.twig')
         ;
 
-        $this->controller->registrationAction($this->request, $key);
+        $controller = $this->createConnectController();
+        $controller->registrationAction($this->request, $key);
     }
 
     public function test()
@@ -146,7 +148,8 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
             ->with('@HWIOAuth/Connect/registration_success.html.twig')
         ;
 
-        $this->controller->registrationAction($this->request, $key);
+        $controller = $this->createConnectController();
+        $controller->registrationAction($this->request, $key);
     }
 
     private function makeRegistrationForm(): void
@@ -156,11 +159,11 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
             ->method('getData')
             ->willReturn(new User());
 
-        $this->container->setParameter('hwi_oauth.fosub_enabled', true);
-
         if (!class_exists(FactoryInterface::class)) {
             $this->markTestSkipped('FOSUserBundle not installed.');
         }
+
+        $this->container->setParameter('hwi_oauth.fosub_enabled', true);
 
         $registrationFormFactory = $this->createMock(FactoryInterface::class);
         $registrationFormFactory->expects($this->any())

--- a/Tests/Controller/LoginControllerTest.php
+++ b/Tests/Controller/LoginControllerTest.php
@@ -15,7 +15,6 @@ use HWI\Bundle\OAuthBundle\Controller\LoginController;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -34,11 +33,6 @@ class LoginControllerTest extends TestCase
      * @var MockObject&AuthorizationCheckerInterface
      */
     private $authorizationChecker;
-
-    /**
-     * @var MockObject&ContainerInterface
-     */
-    private $container;
 
     /**
      * @var MockObject&Environment
@@ -75,24 +69,8 @@ class LoginControllerTest extends TestCase
         parent::setUp();
 
         $this->authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
-
         $this->twig = $this->createMock(Environment::class);
-
-        $this->container = $this->createMock(ContainerInterface::class);
-        $this->container->expects($this->any())
-            ->method('has')
-            ->willReturnMap([
-                ['templating', false],
-                ['twig', true],
-            ]);
-        $this->container->expects($this->any())
-            ->method('get')
-            ->willReturnMap([
-                ['twig', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $this->twig],
-            ]);
-
         $this->router = $this->createMock(RouterInterface::class);
-
         $this->session = $this->createMock(SessionInterface::class);
         $this->request = Request::create('/');
         $this->request->setSession($this->session);
@@ -220,16 +198,14 @@ class LoginControllerTest extends TestCase
 
     private function createController(bool $connect = true, string $grantRule = 'IS_AUTHENTICATED_REMEMBERED'): LoginController
     {
-        $controller = new LoginController(
+        return new LoginController(
             $this->authenticationUtils,
             $this->router,
             $this->authorizationChecker,
             $this->requestStack,
+            $this->twig,
             $connect,
             $grantRule
         );
-        $controller->setContainer($this->container);
-
-        return $controller;
     }
 }


### PR DESCRIPTION
This PR changes:
- removed dependency on `AbstractController` in `LoginController`,
- replaced dependency on parameters in `ConnectController` in favor of injecting them into `__construct()`