### PR TITLE
Fixes notice in AppleResourceOwner.php

### DIFF
--- a/OAuth/ResourceOwner/AppleResourceOwner.php
+++ b/OAuth/ResourceOwner/AppleResourceOwner.php
@@ -90,7 +90,7 @@ class AppleResourceOwner extends GenericOAuth2ResourceOwner
         $user_info = $request->request->get('user');
         $user_info = json_decode($user_info, true);
 
-        if (null !== $user_info) {
+        if (null !== $user_info && isset($user_info['name'])) {
             $response['firstName'] = $user_info['name']['firstName'];
             $response['lastName'] = $user_info['name']['lastName'];
         }


### PR DESCRIPTION
I got the error : 

> E_NOTICE: Undefined index: name

on line 94

Probably caused by my configuration that says : 

>             scope:          "email"

Instead of what is in the documentation : 

>            scope:          "name email"

With this it should work with both configurations.