### PR TITLE
Customizing the CONNECT_COMPLETED response

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -342,6 +342,10 @@ final class ConnectController extends AbstractController
         $event = new FilterUserResponseEvent($currentUser, $request, $response);
         $this->dispatch($event, HWIOAuthEvents::CONNECT_COMPLETED);
 
+        if (null !== $event->getResponse()) {
+            return $event->getResponse();
+        }
+
         return $response;
     }
 


### PR DESCRIPTION
Accepting the response from the event listener associated with HWIOAuthEvents::CONNECT_COMPLETED whenever it's set instead of always using the @HWIOAuth/Connect/connect_success.html.twig template rendering

No worries about what will be the response because it'll be cast by the setResponse() method which will fire an exception in case a bad response format was set