### PR TITLE
Do not use an old refresh token, if a newer one is there

### DIFF
--- a/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -135,7 +135,9 @@ class OAuthProvider implements AuthenticationProviderInterface
         }
 
         $token = new OAuthToken($resourceOwner->refreshAccessToken($expiredToken->getRefreshToken()));
-        $token->setRefreshToken($expiredToken->getRefreshToken());
+        if (!$token->getRefreshToken()) {
+            $token->setRefreshToken($expiredToken->getRefreshToken());
+        }
         $this->tokenStorage->setToken($token);
 
         return $token;

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -214,7 +214,7 @@ class OAuthProviderTest extends TestCase
         $oauthTokenMock->expects($this->exactly(2))
             ->method('getResourceOwnerName')
             ->willReturn('github');
-        $oauthTokenMock->expects($this->exactly(3))
+        $oauthTokenMock->expects($this->exactly(2))
             ->method('getRefreshToken')
             ->willReturn($expiredToken['refresh_token']);
 


### PR DESCRIPTION
We are working with Keycloak SSO. With each refresh token request is a new access token received and it already contains one more recent refresh token. Please do not overwrite this.