### PR TITLE
docs: use HttpClient and Symfony Flex

### DIFF
--- a/Resources/doc/1-setting_up_the_bundle.md
+++ b/Resources/doc/1-setting_up_the_bundle.md
@@ -3,14 +3,19 @@ Step 1: Setting up the bundle
 ### A) Add HWIOAuthBundle to your project
 
 ```bash
-composer require hwi/oauth-bundle php-http/guzzle6-adapter php-http/httplug-bundle
+composer require hwi/oauth-bundle symfony/http-client nyholm/psr7 guzzlehttp/promises php-http/httplug-bundle
 ```
 
-Why `php-http/guzzle6-adapter`? We are decoupled from any HTTP messaging client thanks to [HTTPlug](http://httplug.io/).
+Why `symfony/http-client` and its dependencies? We are decoupled from any HTTP messaging client thanks to [HTTPlug](http://httplug.io/).
 
 Why `php-http/httplug-bundle`? This is the official [Symfony integration](https://packagist.org/packages/php-http/httplug-bundle) of HTTPlug.
 This makes it possible to provide the required HTTP client and message factory with ease.
 The dependency is optional but you will have to [provide your own services](internals/configuring_the_http_client.md) if you don't set it up.
+
+If you use a recent version of Symfony supporting [Symfony Flex](https://symfony.com/doc/current/quick_tour/flex_recipes.html), when prompted, accept to execute the recipes coming from the contrib repository.
+You'll see an error at the end of the process, it's intended. Continue straight to the second step: [configuring resource owners (Facebook, GitHub, Google, Windows Live and others](2-configuring_resource_owners.md) to fix it.
+
+If you use an old version of Symfony, follow the intructions provided in the next sections.
 
 ### B) Enable the bundle
 

--- a/Resources/doc/2-configuring_resource_owners.md
+++ b/Resources/doc/2-configuring_resource_owners.md
@@ -5,7 +5,10 @@ use in your application. These resource owners will be used in the oauth
 firewall. The bundle ships several pre-configured resource owners that need
 only a little configuration.
 
-To make this bundle work you need to add the following to your app/config/config.yml:
+If you use a recent version of Symfony, the configuration has automatically been generated
+in `config/packages/hwi_oauth.yaml`.
+
+Otherwise, to make this bundle work you need to add the following to your `app/config/config.yml`:
 
 ```yaml
 # app/config/config.yml


### PR DESCRIPTION
Explain how to install the bundle with recent versions of Symfony and switch to HttpClient instead of Guzzle.

Currently, there is a problem caused by Flex. See https://github.com/symfony/flex/issues/751.