### PR TITLE
add a lazy twig extension that uses a runtime

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -165,6 +165,7 @@ final class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->scalarNode('target_path_parameter')->defaultNull()->end()
+                ->booleanNode('use_twig_runtime_extension')->defaultFalse()->end()
                 ->arrayNode('target_path_domains_whitelist')
                     ->defaultValue([])
                     ->prototype('scalar')->end()

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -47,11 +47,11 @@ final class HWIOAuthExtension extends Extension
         $loader->load('http_client.xml');
         $loader->load('oauth.xml');
         $loader->load('templating.xml');
-        $loader->load('twig.xml');
         $loader->load('util.xml');
 
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), $configs);
+        $this->loadTwigConfig($container, $config, $loader);
 
         $this->createHttplugClient($container, $config);
 
@@ -216,5 +216,17 @@ final class HWIOAuthExtension extends Extension
             $container->setParameter('hwi_oauth.fosub_enabled', false);
             $container->setParameter('hwi_oauth.connect', false);
         }
+    }
+
+    private function loadTwigConfig(ContainerBuilder $builder, array $config, XmlFileLoader $loader): void
+    {
+        if ($config['use_twig_runtime_extension'] === true) {
+            $loader->load('twig.xml');
+
+            return;
+        }
+
+        trigger_deprecation('hwi/oauth-bundle', '1.4.0', 'Not setting the configuration parameter "use_twig_runtime_extension" to true is deprecated.');
+        $loader->load('twig_deprecated.xml');
     }
 }

--- a/Resources/config/twig_deprecated.xml
+++ b/Resources/config/twig_deprecated.xml
@@ -5,11 +5,8 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="hwi_oauth.twig.extension.oauth.runtime" class="HWI\Bundle\OAuthBundle\Twig\Extension\OAuthRuntime">
+        <service id="hwi_oauth.twig.extension.oauth" class="HWI\Bundle\OAuthBundle\Twig\Extension\OAuthExtension">
             <argument type="service" id="hwi_oauth.templating.helper.oauth" />
-            <tag name="twig.runtime" />
-        </service>
-        <service id="hwi_oauth.twig.extension.oauth" class="HWI\Bundle\OAuthBundle\Twig\Extension\OAuthRuntimeExtension">
             <tag name="twig.extension" />
         </service>
     </services>

--- a/Twig/Extension/OAuthExtension.php
+++ b/Twig/Extension/OAuthExtension.php
@@ -19,6 +19,8 @@ use Twig\TwigFunction;
  * OAuthExtension.
  *
  * @author Joseph Bielawski <stloyd@gmail.com>
+ *
+ * @deprecated in favor of OAuthRuntimeExtension
  */
 final class OAuthExtension extends AbstractExtension
 {

--- a/Twig/Extension/OAuthRuntime.php
+++ b/Twig/Extension/OAuthRuntime.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace HWI\Bundle\OAuthBundle\Twig\Extension;
+
+use HWI\Bundle\OAuthBundle\Templating\Helper\OAuthHelper;
+use Twig\Extension\RuntimeExtensionInterface;
+
+class OAuthRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var OAuthHelper
+     */
+    private $helper;
+
+    public function __construct(OAuthHelper $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * @return array
+     */
+    public function getResourceOwners()
+    {
+        return $this->helper->getResourceOwners();
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    public function getLoginUrl($name)
+    {
+        return $this->helper->getLoginUrl($name);
+    }
+
+    /**
+     * @param string $name
+     * @param string $redirectUrl     Optional
+     * @param array  $extraParameters Optional
+     *
+     * @return string
+     */
+    public function getAuthorizationUrl($name, $redirectUrl = null, array $extraParameters = [])
+    {
+        return $this->helper->getAuthorizationUrl($name, $redirectUrl, $extraParameters);
+    }
+}

--- a/Twig/Extension/OAuthRuntimeExtension.php
+++ b/Twig/Extension/OAuthRuntimeExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace HWI\Bundle\OAuthBundle\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class OAuthRuntimeExtension extends AbstractExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('hwi_oauth_authorization_url', [OAuthRuntime::class, 'getAuthorizationUrl']),
+            new TwigFunction('hwi_oauth_login_url', [OAuthRuntime::class, 'getLoginUrl']),
+            new TwigFunction('hwi_oauth_resource_owners', [OAuthRuntime::class, 'getResourceOwners']),
+        ];
+    }
+
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'hwi_oauth';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,9 @@
         "php-http/httplug":               "^2.0",
         "php-http/client-common":         "^2.0",
         "php-http/message-factory":       "^1.0",
-        "php-http/discovery":             "^1.0"
+        "php-http/discovery":             "^1.0",
+        "twig/twig":                      "^1.35.0|^2.4.4|^3.0",
+        "symfony/deprecation-contracts":  "^2.4"
     },
 
     "require-dev": {
@@ -126,10 +128,6 @@
         "friendsofphp/php-cs-fixer":    "^2.0",
         "symfony/monolog-bundle":       "^3.4",
         "doctrine/doctrine-bundle":     "^2.0"
-    },
-
-    "conflict": {
-        "twig/twig":                    "<1.34"
     },
 
     "suggest": {


### PR DESCRIPTION
This adds a new lazy twig extension. See https://symfony.com/doc/current/templating/twig_extension.html#creating-lazy-loaded-twig-extensions

This has the benefit that not all the services are instantiated already when the twig environment is bootstrapped. Since on my app I rarely use the twig functions provided by this bundle this will speed things up for a lot of requests.

Todos:
- [ ] tests
- [ ] set parameter `use_twig_runtime_extension` to true on flex recipe 

@XWB WDYT about this?