### PR TITLE
Add scenario for missing state

### DIFF
--- a/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -150,9 +150,12 @@ class GenericOAuth2ResourceOwner extends AbstractResourceOwner
             return true;
         }
 
+        if (null === $csrfToken) {
+            throw new AuthenticationException('Given CSRF token is not valid.');
+        }
+
         try {
-            return null !== $csrfToken
-                && null !== $this->storage->fetch($this, urldecode($csrfToken), 'csrf_state');
+            return null !== $this->storage->fetch($this, urldecode($csrfToken), 'csrf_state');
         } catch (\InvalidArgumentException $e) {
             throw new AuthenticationException('Given CSRF token is not valid.');
         }

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -374,7 +374,7 @@ json;
     {
         $this->expectException(\Symfony\Component\Security\Core\Exception\AuthenticationException::class);
 
-        $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, array('csrf' => true));
+        $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, ['csrf' => true]);
 
         $resourceOwner->isCsrfTokenValid(null);
     }

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -370,6 +370,15 @@ json;
         $resourceOwner->isCsrfTokenValid('invalid_token');
     }
 
+    public function testCsrfTokenMissing()
+    {
+        $this->expectException(\Symfony\Component\Security\Core\Exception\AuthenticationException::class);
+
+        $resourceOwner = $this->createResourceOwner($this->resourceOwnerName, array('csrf' => true));
+
+        $resourceOwner->isCsrfTokenValid(null);
+    }
+
     public function testCustomResponseClass()
     {
         $class = CustomUserResponse::class;


### PR DESCRIPTION
There is no protection when the state parameter is empty, only if it's invalid. Although the function returns "false", there is no check for the return value, only the Exception thrown.

This allows attacker to perform account takeover via no CSRF protection.