### PR TITLE
Added further compatibility with Symfony Security 5.3+

### DIFF
--- a/Security/Core/User/OAuthUser.php
+++ b/Security/Core/User/OAuthUser.php
@@ -36,6 +36,14 @@ class OAuthUser implements UserInterface
     /**
      * {@inheritdoc}
      */
+    public function getUserIdentifier()
+    {
+        return $this->username;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getRoles()
     {
         return ['ROLE_USER', 'ROLE_OAUTH_USER'];
@@ -62,7 +70,7 @@ class OAuthUser implements UserInterface
      */
     public function getUsername()
     {
-        return $this->username;
+        return $this->getUserIdentifier();
     }
 
     /**

--- a/Tests/Fixtures/User.php
+++ b/Tests/Fixtures/User.php
@@ -22,6 +22,11 @@ class User implements UserInterface
         return '1';
     }
 
+    public function getUserIdentifier()
+    {
+        return 'foo';
+    }
+
     public function getUsername()
     {
         return 'foo';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,8 @@
 <phpunit bootstrap="./Tests/bootstrap.php" colors="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
+        <!-- Allowing 4 deprecations related to changes in Symfony Security 5.3+ -->
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=4" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
This removes 2 deprecations related to:

```
Class "HWI\Bundle\OAuthBundle\Tests\Fixtures\User" should implement method "Symfony\Component\Security\Core\User\UserInterface::getUserIdentifier()": returns the identifier for this user (e.g. its username or e-mailaddress)
```

And marks the 4 as "acceptable" cause those are not an easy fix.