### PR TITLE
Drop PHP 7.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.2'
           - '7.3'
           - '7.4'
           - '8.0'

--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,7 @@
     ],
 
     "require": {
-        "php":                            "^7.2 || ^8.0",
+        "php":                            "^7.3 || ^8.0",
         "symfony/framework-bundle":       "^4.4|^5.1",
         "symfony/security-bundle":        "^4.4|^5.1",
         "symfony/options-resolver":       "^4.4|^5.1",


### PR DESCRIPTION
PHP 7.2 is End of Life (EOL) for a long time so I think it's time to drop support for it.