### PR TITLE
Update code standard

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -26,7 +26,6 @@ return (new PhpCsFixer\Config())
         'php_unit_set_up_tear_down_visibility' => true,
         'native_function_invocation' => ['include' => ['@compiler_optimized'], 'scope' => 'namespaced'],
         'array_syntax' => ['syntax' => 'short'],
-        'no_superfluous_phpdoc_tags' => false,
     ))
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -150,10 +150,6 @@ final class HWIOAuthExtension extends Extension
         return 'hwi_oauth';
     }
 
-    /**
-     * @param ContainerBuilder $container
-     * @param array            $config
-     */
     protected function createHttplugClient(ContainerBuilder $container, array $config)
     {
         $httpClientId = $config['http']['client'];
@@ -173,9 +169,6 @@ final class HWIOAuthExtension extends Extension
 
     /**
      * Check of the connect controllers etc should be enabled.
-     *
-     * @param ContainerBuilder $container
-     * @param array            $config
      *
      * @throws \Symfony\Component\DependencyInjection\Exception\BadMethodCallException
      * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException

--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -100,9 +100,6 @@ class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
     /**
      * Set user information from form.
      *
-     * @param UserInterface         $user
-     * @param UserResponseInterface $userInformation
-     *
      * @return UserInterface
      */
     protected function setUserInformation(UserInterface $user, UserResponseInterface $userInformation)

--- a/OAuth/Exception/StateRetrievalException.php
+++ b/OAuth/Exception/StateRetrievalException.php
@@ -15,8 +15,6 @@ final class StateRetrievalException extends \InvalidArgumentException
 {
     /**
      * @param string $key The provided string key
-     *
-     * @return self
      */
     public static function forKey(string $key): self
     {

--- a/OAuth/RequestDataStorage/SessionStorage.php
+++ b/OAuth/RequestDataStorage/SessionStorage.php
@@ -29,9 +29,6 @@ class SessionStorage implements RequestDataStorageInterface
      */
     private $session;
 
-    /**
-     * @param SessionInterface $session
-     */
     public function __construct(SessionInterface $session)
     {
         $this->session = $session;
@@ -76,9 +73,8 @@ class SessionStorage implements RequestDataStorageInterface
     /**
      * Key to for fetching or saving a token.
      *
-     * @param ResourceOwnerInterface $resourceOwner
-     * @param string                 $key
-     * @param string                 $type
+     * @param string $key
+     * @param string $type
      *
      * @return string
      */
@@ -103,8 +99,6 @@ class SessionStorage implements RequestDataStorageInterface
 
     /**
      * @param array|string|object $value
-     *
-     * @return string
      */
     private function getStorageKey($value): string
     {

--- a/OAuth/RequestDataStorageInterface.php
+++ b/OAuth/RequestDataStorageInterface.php
@@ -29,20 +29,16 @@ interface RequestDataStorageInterface
     /**
      * Fetch a request data from the storage.
      *
-     * @param ResourceOwnerInterface $resourceOwner
-     * @param string                 $key
-     * @param string                 $type
-     *
-     * @return mixed
+     * @param string $key
+     * @param string $type
      */
     public function fetch(ResourceOwnerInterface $resourceOwner, $key, $type = 'token');
 
     /**
      * Save a request data to the storage.
      *
-     * @param ResourceOwnerInterface $resourceOwner
-     * @param array|string|object    $value
-     * @param string                 $type
+     * @param array|string|object $value
+     * @param string              $type
      */
     public function save(ResourceOwnerInterface $resourceOwner, $value, $type = 'token');
 }

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -272,7 +272,6 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
 
     /**
      * @param string $url
-     * @param array  $parameters
      *
      * @return string
      */
@@ -328,8 +327,6 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
     /**
      * Get the 'parsed' content based on the response headers.
      *
-     * @param ResponseInterface $rawResponse
-     *
      * @return array
      */
     protected function getResponseContent(ResponseInterface $rawResponse)
@@ -350,7 +347,6 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
 
     /**
      * @param string $url
-     * @param array  $parameters
      *
      * @throws HttpTransportException
      *
@@ -360,7 +356,6 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
 
     /**
      * @param string $url
-     * @param array  $parameters
      *
      * @throws HttpTransportException
      *
@@ -370,8 +365,6 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
 
     /**
      * Configure the option resolver.
-     *
-     * @param OptionsResolver $resolver
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\AccessException
      * @throws \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException

--- a/OAuth/ResourceOwner/DropboxResourceOwner.php
+++ b/OAuth/ResourceOwner/DropboxResourceOwner.php
@@ -36,9 +36,6 @@ class DropboxResourceOwner extends GenericOAuth2ResourceOwner
     /**
      * Dropbox API v2 requires a POST request to simply get user info!
      *
-     * @param array $accessToken
-     * @param array $extraParameters
-     *
      * @return UserResponseInterface
      */
     public function getUserInformation(array $accessToken,

--- a/OAuth/ResourceOwnerInterface.php
+++ b/OAuth/ResourceOwnerInterface.php
@@ -91,8 +91,6 @@ interface ResourceOwnerInterface
     /**
      * Checks whether the class can handle the request.
      *
-     * @param HttpRequest $request
-     *
      * @return bool
      */
     public function handles(HttpRequest $request);
@@ -106,8 +104,6 @@ interface ResourceOwnerInterface
 
     /**
      * Add extra paths to the configuration.
-     *
-     * @param array $paths
      */
     public function addPaths(array $paths);
 
@@ -117,19 +113,9 @@ interface ResourceOwnerInterface
      */
     public function refreshAccessToken($refreshToken, array $extraParameters = []);
 
-    /**
-     * @return StateInterface
-     */
     public function getState(): StateInterface;
 
-    /**
-     * @param StateInterface|null $state
-     */
     public function storeState(StateInterface $state = null);
 
-    /**
-     * @param string $key
-     * @param string $value
-     */
     public function addStateParameter(string $key, string $value): void;
 }

--- a/OAuth/Response/LinkedinUserResponse.php
+++ b/OAuth/Response/LinkedinUserResponse.php
@@ -62,8 +62,6 @@ class LinkedinUserResponse extends PathUserResponse
      * https://docs.microsoft.com/en-us/linkedin/shared/references/v2/object-types#multilocalestring.
      *
      * @param $path
-     *
-     * @return mixed
      */
     protected function getPreferredLocaleValue($path)
     {

--- a/OAuth/Response/PathUserResponse.php
+++ b/OAuth/Response/PathUserResponse.php
@@ -101,8 +101,6 @@ class PathUserResponse extends AbstractUserResponse
 
     /**
      * Configure the paths.
-     *
-     * @param array $paths
      */
     public function setPaths(array $paths)
     {
@@ -156,7 +154,6 @@ class PathUserResponse extends AbstractUserResponse
 
     /**
      * @param string $steps
-     * @param array  $data
      *
      * @return string|null
      */

--- a/OAuth/Response/SensioConnectUserResponse.php
+++ b/OAuth/Response/SensioConnectUserResponse.php
@@ -122,9 +122,8 @@ class SensioConnectUserResponse extends AbstractUserResponse
     }
 
     /**
-     * @param string      $query
-     * @param \DOMElement $element
-     * @param string      $nodeType
+     * @param string $query
+     * @param string $nodeType
      *
      * @return mixed|null
      */
@@ -152,8 +151,6 @@ class SensioConnectUserResponse extends AbstractUserResponse
 
     /**
      * @param string $value
-     *
-     * @return mixed
      */
     protected function sanitizeValue($value)
     {

--- a/OAuth/Response/UserResponseInterface.php
+++ b/OAuth/Response/UserResponseInterface.php
@@ -104,8 +104,6 @@ interface UserResponseInterface extends ResponseInterface
 
     /**
      * Set the raw token data from the request.
-     *
-     * @param OAuthToken $token
      */
     public function setOAuthToken(OAuthToken $token);
 

--- a/OAuth/ResponseInterface.php
+++ b/OAuth/ResponseInterface.php
@@ -43,8 +43,6 @@ interface ResponseInterface
 
     /**
      * Set the resource owner for the response.
-     *
-     * @param ResourceOwnerInterface $resourceOwner
      */
     public function setResourceOwner(ResourceOwnerInterface $resourceOwner);
 }

--- a/OAuth/State/State.php
+++ b/OAuth/State/State.php
@@ -155,10 +155,6 @@ final class State implements StateInterface
     /**
      * Checks if a given key is set in the values array,
      * and if it's the only key present.
-     *
-     * @param string $key
-     *
-     * @return bool
      */
     private function isOnlyExistentKey(string $key): bool
     {

--- a/OAuth/StateInterface.php
+++ b/OAuth/StateInterface.php
@@ -25,19 +25,12 @@ interface StateInterface extends \Serializable
     public function add(string $key, string $value);
 
     /**
-     * @param string $key
-     *
      * @return string The value set to this key
      *
      * @throws StateRetrievalException
      */
     public function get(string $key): ?string;
 
-    /**
-     * @param string $key
-     *
-     * @return bool
-     */
     public function has(string $key): bool;
 
     /**

--- a/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -55,7 +55,6 @@ class OAuthProvider implements AuthenticationProviderInterface
      * @param OAuthAwareUserProviderInterface $userProvider     User provider
      * @param ResourceOwnerMapInterface       $resourceOwnerMap Resource owner map
      * @param UserCheckerInterface            $userChecker      User checker
-     * @param TokenStorageInterface           $tokenStorage
      */
     public function __construct(OAuthAwareUserProviderInterface $userProvider, ResourceOwnerMapInterface $resourceOwnerMap, UserCheckerInterface $userChecker, TokenStorageInterface $tokenStorage)
     {
@@ -123,9 +122,6 @@ class OAuthProvider implements AuthenticationProviderInterface
     }
 
     /**
-     * @param TokenInterface         $expiredToken
-     * @param ResourceOwnerInterface $resourceOwner
-     *
      * @return OAuthToken|TokenInterface
      */
     protected function refreshToken(TokenInterface $expiredToken, ResourceOwnerInterface $resourceOwner)

--- a/Security/Core/Exception/OAuthAwareExceptionInterface.php
+++ b/Security/Core/Exception/OAuthAwareExceptionInterface.php
@@ -58,8 +58,6 @@ interface OAuthAwareExceptionInterface
 
     /**
      * Set the token.
-     *
-     * @param TokenInterface $token
      */
     public function setToken(TokenInterface $token);
 

--- a/Security/Core/User/EntityUserProvider.php
+++ b/Security/Core/User/EntityUserProvider.php
@@ -137,8 +137,6 @@ class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProvide
     }
 
     /**
-     * @param array $criteria
-     *
      * @return object
      */
     protected function findUser(array $criteria)

--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -113,9 +113,6 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
 
     /**
      * Disconnects a user.
-     *
-     * @param UserInterface         $user
-     * @param UserResponseInterface $response
      */
     public function disconnect(UserInterface $user, UserResponseInterface $response)
     {
@@ -160,8 +157,6 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
 
     /**
      * Gets the property for the response.
-     *
-     * @param UserResponseInterface $response
      *
      * @return string
      *

--- a/Security/Core/User/OAuthAwareUserProviderInterface.php
+++ b/Security/Core/User/OAuthAwareUserProviderInterface.php
@@ -25,8 +25,6 @@ interface OAuthAwareUserProviderInterface
     /**
      * Loads the user by a given UserResponseInterface object.
      *
-     * @param UserResponseInterface $response
-     *
      * @return UserInterface
      *
      * @throws UsernameNotFoundException if the user is not found

--- a/Security/Http/EntryPoint/OAuthEntryPoint.php
+++ b/Security/Http/EntryPoint/OAuthEntryPoint.php
@@ -48,10 +48,8 @@ class OAuthEntryPoint implements AuthenticationEntryPointInterface
     protected $useForward;
 
     /**
-     * @param HttpKernelInterface $kernel
-     * @param HttpUtils           $httpUtils
-     * @param string              $loginPath
-     * @param bool                $useForward
+     * @param string $loginPath
+     * @param bool   $useForward
      */
     public function __construct(HttpKernelInterface $kernel, HttpUtils $httpUtils, $loginPath, $useForward = false)
     {

--- a/Security/Http/Firewall/OAuthListener.php
+++ b/Security/Http/Firewall/OAuthListener.php
@@ -38,17 +38,11 @@ class OAuthListener extends AbstractAuthenticationListener
      */
     private $checkPaths;
 
-    /**
-     * @param ResourceOwnerMapInterface $resourceOwnerMap
-     */
     public function setResourceOwnerMap(ResourceOwnerMapInterface $resourceOwnerMap)
     {
         $this->resourceOwnerMap = $resourceOwnerMap;
     }
 
-    /**
-     * @param array $checkPaths
-     */
     public function setCheckPaths(array $checkPaths)
     {
         $this->checkPaths = $checkPaths;

--- a/Security/Http/ResourceOwnerMapInterface.php
+++ b/Security/Http/ResourceOwnerMapInterface.php
@@ -40,8 +40,6 @@ interface ResourceOwnerMapInterface
     /**
      * Gets the appropriate resource owner for a request.
      *
-     * @param Request $request
-     *
      * @return array|null
      */
     public function getResourceOwnerByRequest(Request $request);

--- a/Security/Http/ResourceOwnerMapLocator.php
+++ b/Security/Http/ResourceOwnerMapLocator.php
@@ -21,30 +21,16 @@ final class ResourceOwnerMapLocator
      */
     private $resourceOwnerMaps = [];
 
-    /**
-     * @param string                    $firewallId
-     * @param ResourceOwnerMapInterface $resourceOwnerMap
-     */
     public function add(string $firewallId, ResourceOwnerMapInterface $resourceOwnerMap): void
     {
         $this->resourceOwnerMaps[$firewallId] = $resourceOwnerMap;
     }
 
-    /**
-     * @param string $firewallId
-     *
-     * @return bool
-     */
     public function has(string $firewallId): bool
     {
         return isset($this->resourceOwnerMaps[$firewallId]);
     }
 
-    /**
-     * @param string $firewallId
-     *
-     * @return ResourceOwnerMapInterface
-     */
     public function get(string $firewallId): ResourceOwnerMapInterface
     {
         return $this->resourceOwnerMaps[$firewallId];

--- a/Security/OAuthErrorHandler.php
+++ b/Security/OAuthErrorHandler.php
@@ -34,8 +34,6 @@ final class OAuthErrorHandler
     ];
 
     /**
-     * @param Request $request
-     *
      * @throws AuthenticationException
      */
     public static function handleOAuthError(Request $request)

--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -55,10 +55,8 @@ class OAuthUtils
     protected $authorizationChecker;
 
     /**
-     * @param HttpUtils                     $httpUtils
-     * @param AuthorizationCheckerInterface $authorizationChecker
-     * @param bool                          $connect
-     * @param string                        $grantRule
+     * @param bool   $connect
+     * @param string $grantRule
      */
     public function __construct(
         HttpUtils $httpUtils,
@@ -72,9 +70,6 @@ class OAuthUtils
         $this->grantRule = $grantRule;
     }
 
-    /**
-     * @param ResourceOwnerMapInterface $ownerMap
-     */
     public function addResourceOwnerMap(ResourceOwnerMapInterface $ownerMap)
     {
         $this->ownerMaps[] = $ownerMap;
@@ -95,10 +90,9 @@ class OAuthUtils
     }
 
     /**
-     * @param Request $request
-     * @param string  $name
-     * @param string  $redirectUrl     Optional
-     * @param array   $extraParameters Optional
+     * @param string $name
+     * @param string $redirectUrl     Optional
+     * @param array  $extraParameters Optional
      *
      * @return string
      */
@@ -122,9 +116,6 @@ class OAuthUtils
     }
 
     /**
-     * @param Request                $request
-     * @param ResourceOwnerInterface $resourceOwner
-     *
      * @return string
      */
     public function getServiceAuthUrl(Request $request, ResourceOwnerInterface $resourceOwner)
@@ -142,8 +133,7 @@ class OAuthUtils
     }
 
     /**
-     * @param Request $request
-     * @param string  $name
+     * @param string $name
      *
      * @return string
      */

--- a/Templating/Helper/OAuthHelper.php
+++ b/Templating/Helper/OAuthHelper.php
@@ -31,10 +31,6 @@ class OAuthHelper extends Helper
      */
     private $requestStack;
 
-    /**
-     * @param OAuthUtils   $oauthUtils
-     * @param RequestStack $requestStack
-     */
     public function __construct(OAuthUtils $oauthUtils, RequestStack $requestStack)
     {
         $this->oauthUtils = $oauthUtils;

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -675,7 +675,6 @@ EOF;
     }
 
     /**
-     * @param mixed  $value
      * @param string $key
      */
     private function assertParameter($value, $key)

--- a/Tests/OAuth/ResourceOwner/Auth0ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/Auth0ResourceOwnerTest.php
@@ -130,12 +130,6 @@ json;
 
     /**
      * Mocks the {@see HttpClient::sendRequest} method with assertions on the request.
-     *
-     * @param string $expectedRequestUri
-     * @param string $expectedRequestMethod
-     * @param array  $expectedAuthorizationHeader
-     * @param array  $expectedAuth0ClientRequestHeader
-     * @param string $expectedRequestBodyContents
      */
     private function mockHttpClientSendRequestWithRequestAssertions(
         string $expectedRequestUri,

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -395,10 +395,7 @@ json;
     }
 
     /**
-     * @param string         $name
-     * @param array          $options
-     * @param array          $paths
-     * @param StateInterface $state   Optional
+     * @param StateInterface $state Optional
      *
      * @throws \ReflectionException
      *

--- a/Tests/OAuth/ResourceOwner/ResourceOwnerTestCase.php
+++ b/Tests/OAuth/ResourceOwner/ResourceOwnerTestCase.php
@@ -80,9 +80,7 @@ abstract class ResourceOwnerTestCase extends TestCase
     }
 
     /**
-     * @param string    $name
-     * @param HttpUtils $httpUtils
-     * @param array     $options
+     * @param string $name
      *
      * @return \HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface
      */

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -320,8 +320,6 @@ class OAuthProviderTest extends TestCase
     /**
      * Symfony < 4.3 BC layer.
      *
-     * @param TokenInterface $token
-     *
      * @return array
      */
     private function getRoleNames(TokenInterface $token)

--- a/Twig/Extension/OAuthExtension.php
+++ b/Twig/Extension/OAuthExtension.php
@@ -27,9 +27,6 @@ final class OAuthExtension extends AbstractExtension
      */
     protected $helper;
 
-    /**
-     * @param OAuthHelper $helper
-     */
     public function __construct(OAuthHelper $helper)
     {
         $this->helper = $helper;

--- a/Util/DomainWhitelist.php
+++ b/Util/DomainWhitelist.php
@@ -21,19 +21,11 @@ class DomainWhitelist
      */
     private $targetPathDomainsWhiteList;
 
-    /**
-     * @param array $targetPathDomainsWhiteList
-     */
     public function __construct(array $targetPathDomainsWhiteList)
     {
         $this->targetPathDomainsWhiteList = $targetPathDomainsWhiteList;
     }
 
-    /**
-     * @param string $targetUrl
-     *
-     * @return bool
-     */
     public function isValidTargetUrl(string $targetUrl): bool
     {
         if (0 === \count($this->targetPathDomainsWhiteList)) {


### PR DESCRIPTION
We can follow the @Symfony rule set.

```
@Symfony

    Using the @Symfony rule set will enable the no_superfluous_phpdoc_tags rule with the config below:

    ['allow_mixed' => true, 'allow_unused_params' => true]
```