### PR TITLE
Maintain | Remove leftover Symfony 4.3 BC layer

### DIFF
--- a/Security/Core/Exception/AccountNotLinkedException.php
+++ b/Security/Core/Exception/AccountNotLinkedException.php
@@ -107,20 +107,4 @@ class AccountNotLinkedException extends UsernameNotFoundException implements OAu
     {
         $this->resourceOwnerName = $resourceOwnerName;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function serialize()
-    {
-        return serialize($this->__serialize());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function unserialize($str)
-    {
-        $this->__unserialize((array) unserialize((string) $str));
-    }
 }


### PR DESCRIPTION
```
  1x: Implementing the "HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException::serialize()" method is deprecated since Symfony 4.3, implement the __serialize() and __unserialize() methods instead.
    1x in ConnectControllerTest::testRegistration from HWI\Bundle\OAuthBundle\Tests\Functional\Controller

  1x: Implementing the "HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException::unserialize()" method is deprecated since Symfony 4.3, implement the __serialize() and __unserialize() methods instead.
    1x in ConnectControllerTest::testRegistration from HWI\Bundle\OAuthBundle\Tests\Functional\Controller