### PR TITLE
make twig extension lazy by using a Runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+## 2.0.0 (2021-xx-xx)
+* BC Break: `OAuthExtension` is now a lazy Twig extension using a Runtime,
+
 ## 1.4.1 (2021-07-28)
 * Bugfix: Define missing `hwi_oauth.connect.confirmation` parameter,
 * Bugfix: Added missing success/failure handlers,

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -6,8 +6,11 @@
 
     <services>
         <service id="hwi_oauth.twig.extension.oauth" class="HWI\Bundle\OAuthBundle\Twig\Extension\OAuthExtension">
-            <argument type="service" id="hwi_oauth.templating.helper.oauth" />
             <tag name="twig.extension" />
+        </service>
+        <service id="hwi_oauth.twig.extension.oauth.runtime" class="HWI\Bundle\OAuthBundle\Twig\Extension\OAuthRuntime">
+            <argument type="service" id="hwi_oauth.templating.helper.oauth" />
+            <tag name="twig.runtime" />
         </service>
     </services>
 </container>

--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -78,9 +78,9 @@ class OAuthUtils
     }
 
     /**
-     * @return array
+     * @return string[]
      */
-    public function getResourceOwners()
+    public function getResourceOwners(): array
     {
         $resourceOwners = [];
 

--- a/Templating/Helper/OAuthHelper.php
+++ b/Templating/Helper/OAuthHelper.php
@@ -40,9 +40,9 @@ class OAuthHelper extends Helper
     }
 
     /**
-     * @return array
+     * @return string[]
      */
-    public function getResourceOwners()
+    public function getResourceOwners(): array
     {
         return $this->oauthUtils->getResourceOwners();
     }

--- a/Twig/Extension/OAuthExtension.php
+++ b/Twig/Extension/OAuthExtension.php
@@ -11,75 +11,27 @@
 
 namespace HWI\Bundle\OAuthBundle\Twig\Extension;
 
-use HWI\Bundle\OAuthBundle\Templating\Helper\OAuthHelper;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 /**
- * OAuthExtension.
- *
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
 final class OAuthExtension extends AbstractExtension
 {
     /**
-     * @var OAuthHelper
-     */
-    private $helper;
-
-    public function __construct(OAuthHelper $helper)
-    {
-        $this->helper = $helper;
-    }
-
-    /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
-            new TwigFunction('hwi_oauth_authorization_url', [$this, 'getAuthorizationUrl']),
-            new TwigFunction('hwi_oauth_login_url', [$this, 'getLoginUrl']),
-            new TwigFunction('hwi_oauth_resource_owners', [$this, 'getResourceOwners']),
+            new TwigFunction('hwi_oauth_authorization_url', [OAuthRuntime::class, 'getAuthorizationUrl']),
+            new TwigFunction('hwi_oauth_login_url', [OAuthRuntime::class, 'getLoginUrl']),
+            new TwigFunction('hwi_oauth_resource_owners', [OAuthRuntime::class, 'getResourceOwners']),
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function getResourceOwners()
-    {
-        return $this->helper->getResourceOwners();
-    }
-
-    /**
-     * @param string $name
-     *
-     * @return string
-     */
-    public function getLoginUrl($name)
-    {
-        return $this->helper->getLoginUrl($name);
-    }
-
-    /**
-     * @param string $name
-     * @param string $redirectUrl     Optional
-     * @param array  $extraParameters Optional
-     *
-     * @return string
-     */
-    public function getAuthorizationUrl($name, $redirectUrl = null, array $extraParameters = [])
-    {
-        return $this->helper->getAuthorizationUrl($name, $redirectUrl, $extraParameters);
-    }
-
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'hwi_oauth';
     }

--- a/Twig/Extension/OAuthRuntime.php
+++ b/Twig/Extension/OAuthRuntime.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Twig\Extension;
+
+use HWI\Bundle\OAuthBundle\Templating\Helper\OAuthHelper;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class OAuthRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var OAuthHelper
+     */
+    private $helper;
+
+    public function __construct(OAuthHelper $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getResourceOwners(): array
+    {
+        return $this->helper->getResourceOwners();
+    }
+
+    public function getLoginUrl(string $name): string
+    {
+        return $this->helper->getLoginUrl($name);
+    }
+
+    public function getAuthorizationUrl(string $name, ?string $redirectUrl = null, array $extraParameters = []): string
+    {
+        return $this->helper->getAuthorizationUrl($name, $redirectUrl, $extraParameters);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -131,7 +131,7 @@
     },
 
     "conflict": {
-        "twig/twig":                    "<1.34"
+        "twig/twig":                    "<1.35|>=2.0,<2.4.4"
     },
 
     "scripts": {


### PR DESCRIPTION
This makes the twig extension lazy. See https://symfony.com/doc/current/templating/twig_extension.html#creating-lazy-loaded-twig-extensions

This has the benefit that not all the services are instantiated already when the twig environment is bootstrapped. Since on my app I rarely use the twig functions provided by this bundle this will speed things up for a lot of requests.

Replaces https://github.com/hwi/HWIOAuthBundle/pull/1719 and targets master without the BC layer.