### PR TITLE
Implement UserProviderInterface::loadUserByIdentifier

### DIFF
--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -66,9 +66,17 @@ class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterf
     /**
      * {@inheritdoc}
      */
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        return $this->userManager->findUserByUsername($identifier);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function loadUserByUsername($username)
     {
-        return $this->userManager->findUserByUsername($username);
+        return $this->loadUserByIdentifier($username);
     }
 
     /**

--- a/Security/Core/User/OAuthUserProvider.php
+++ b/Security/Core/User/OAuthUserProvider.php
@@ -26,9 +26,17 @@ class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProvider
     /**
      * {@inheritdoc}
      */
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        return new OAuthUser($identifier);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function loadUserByUsername($username)
     {
-        return new OAuthUser($username);
+        return $this->loadUserByIdentifier($username);
     }
 
     /**

--- a/Tests/Security/Core/User/EntityUserProviderTest.php
+++ b/Tests/Security/Core/User/EntityUserProviderTest.php
@@ -20,6 +20,7 @@ use HWI\Bundle\OAuthBundle\Security\Core\User\EntityUserProvider;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\User;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 
 class EntityUserProviderTest extends TestCase
 {
@@ -31,6 +32,20 @@ class EntityUserProviderTest extends TestCase
         if (!class_exists('Doctrine\Persistence\ManagerRegistry')) {
             $this->markTestSkipped('The Doctrine ORM is too old');
         }
+    }
+
+    public function testLoadUserByIdentifierThrowsExceptionWhenUserIsNotFound()
+    {
+        if (!class_exists(UserNotFoundException::class)) {
+            $this->markTestSkipped('This test only runs on Symfony >= 5.3');
+        }
+
+        $provider = $this->createEntityUserProvider();
+
+        $this->expectException(UserNotFoundException::class);
+        $this->expectDeprecationMessage('User \'asm89\' not found.');
+
+        $provider->loadUserByIdentifier('asm89');
     }
 
     public function testLoadUserByUsernameThrowsExceptionWhenUserIsNull()

--- a/Tests/Security/Core/User/OAuthUserProviderTest.php
+++ b/Tests/Security/Core/User/OAuthUserProviderTest.php
@@ -36,6 +36,13 @@ class OAuthUserProviderTest extends TestCase
         $this->assertEquals('asm89', $user->getUsername());
     }
 
+    public function testLoadUserByIdentifier()
+    {
+        $user = $this->provider->loadUserByIdentifier('asm89');
+        $this->assertInstanceOf(OAuthUser::class, $user);
+        $this->assertEquals('asm89', $user->getUserIdentifier());
+    }
+
     public function testRefreshUser()
     {
         $user = new OAuthUser('asm89');


### PR DESCRIPTION
This method was added in Symfony 5.3: https://github.com/symfony/symfony/blob/19b96f89a07b290181eeca49d9b98d968865d4c9/src/Symfony/Component/Security/Core/User/UserProviderInterface.php#L32

[As a replacement of `UserProviderInterface::loadUserByUsername`](https://github.com/symfony/symfony/blob/5.4/UPGRADE-5.3.md#security).

In `EntityUserProvider` I was going to call `loadUserByIdentifier` from `loadUserByUsername`, but since `loadUserByIdentifier` should throw the new `UserNotFoundException`, the code was a bit messy, I think this is cleaner.