### PR TITLE
Mark classes as final

### DIFF
--- a/DependencyInjection/Security/Factory/OAuthFactory.php
+++ b/DependencyInjection/Security/Factory/OAuthFactory.php
@@ -19,10 +19,10 @@ use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * OAuthFactory.
- *
  * @author Geoffrey Bachelet <geoffrey.bachelet@gmail.com>
  * @author Alexander <iam.asm89@gmail.com>
+ *
+ * @final since 1.4
  */
 class OAuthFactory extends AbstractFactory
 {

--- a/Event/FilterUserResponseEvent.php
+++ b/Event/FilterUserResponseEvent.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @author Marek Štípek
+ *
+ * @final since 1.4
  */
 class FilterUserResponseEvent extends UserEvent
 {

--- a/Event/FormEvent.php
+++ b/Event/FormEvent.php
@@ -17,6 +17,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author Marek Štípek
+ *
+ * @final since 1.4
  */
 class FormEvent extends AbstractEvent
 {

--- a/Event/GetResponseUserEvent.php
+++ b/Event/GetResponseUserEvent.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author Marek Štípek
+ *
+ * @final since 1.4
  */
 class GetResponseUserEvent extends UserEvent
 {

--- a/Form/FOSUBRegistrationFormHandler.php
+++ b/Form/FOSUBRegistrationFormHandler.php
@@ -22,6 +22,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @author Alexander <iam.asm89@gmail.com>
+ *
+ * @final since 1.4
  */
 class FOSUBRegistrationFormHandler implements RegistrationFormHandlerInterface
 {

--- a/OAuth/Exception/HttpTransportException.php
+++ b/OAuth/Exception/HttpTransportException.php
@@ -13,6 +13,9 @@ namespace HWI\Bundle\OAuthBundle\OAuth\Exception;
 
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
+/**
+ * @final since 1.4
+ */
 class HttpTransportException extends AuthenticationException
 {
     private $ownerName;

--- a/OAuth/Response/LinkedinUserResponse.php
+++ b/OAuth/Response/LinkedinUserResponse.php
@@ -11,6 +11,9 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\Response;
 
+/**
+ * @final since 1.4
+ */
 class LinkedinUserResponse extends PathUserResponse
 {
     /**

--- a/OAuth/Response/SensioConnectUserResponse.php
+++ b/OAuth/Response/SensioConnectUserResponse.php
@@ -16,6 +16,8 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 /**
  * @author Joseph Bielawski <stloyd@gmail.com>
  * @author SensioLabs <contact@sensiolabs.com>
+ *
+ * @final since 1.4
  */
 class SensioConnectUserResponse extends AbstractUserResponse
 {

--- a/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -26,6 +26,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 /**
  * @author Geoffrey Bachelet <geoffrey.bachelet@gmail.com>
  * @author Alexander <iam.asm89@gmail.com>
+ *
+ * @final since 1.4
  */
 class OAuthProvider implements AuthenticationProviderInterface
 {

--- a/Security/Core/Exception/AccountNotLinkedException.php
+++ b/Security/Core/Exception/AccountNotLinkedException.php
@@ -13,6 +13,9 @@ namespace HWI\Bundle\OAuthBundle\Security\Core\Exception;
 
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 
+/**
+ * @final since 1.4
+ */
 class AccountNotLinkedException extends UsernameNotFoundException implements OAuthAwareExceptionInterface
 {
     /**

--- a/Security/Core/User/EntityUserProvider.php
+++ b/Security/Core/User/EntityUserProvider.php
@@ -27,6 +27,8 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  * owner names and the properties of the entities.
  *
  * @author Alexander <iam.asm89@gmail.com>
+ *
+ * @final since 1.4
  */
 class EntityUserProvider implements UserProviderInterface, OAuthAwareUserProviderInterface
 {

--- a/Security/Core/User/FOSUBUserProvider.php
+++ b/Security/Core/User/FOSUBUserProvider.php
@@ -30,6 +30,8 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  * property mapping should be available.
  *
  * @author Alexander <iam.asm89@gmail.com>
+ *
+ * @final since 1.4
  */
 class FOSUBUserProvider implements UserProviderInterface, AccountConnectorInterface, OAuthAwareUserProviderInterface
 {

--- a/Security/Core/User/OAuthUser.php
+++ b/Security/Core/User/OAuthUser.php
@@ -14,9 +14,9 @@ namespace HWI\Bundle\OAuthBundle\Security\Core\User;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
- * OAuthUser.
- *
  * @author Geoffrey Bachelet <geoffrey.bachelet@gmail.com>
+ *
+ * @final since 1.4
  */
 class OAuthUser implements UserInterface
 {

--- a/Security/Core/User/OAuthUserProvider.php
+++ b/Security/Core/User/OAuthUserProvider.php
@@ -17,9 +17,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
- * OAuthUserProvider.
- *
  * @author Geoffrey Bachelet <geoffrey.bachelet@gmail.com>
+ *
+ * @final since 1.4
  */
 class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProviderInterface
 {

--- a/Security/Http/EntryPoint/OAuthEntryPoint.php
+++ b/Security/Http/EntryPoint/OAuthEntryPoint.php
@@ -24,6 +24,8 @@ use Symfony\Component\Security\Http\HttpUtils;
  *
  * @author Geoffrey Bachelet <geoffrey.bachelet@gmail.com>
  * @author Alexander <iam.asm89@gmail.com>
+ *
+ * @final since 1.4
  */
 class OAuthEntryPoint implements AuthenticationEntryPointInterface
 {

--- a/Security/Http/Firewall/OAuthListener.php
+++ b/Security/Http/Firewall/OAuthListener.php
@@ -21,10 +21,10 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Firewall\AbstractAuthenticationListener;
 
 /**
- * OAuthListener.
- *
  * @author Geoffrey Bachelet <geoffrey.bachelet@gmail.com>
  * @author Alexander <iam.asm89@gmail.com>
+ *
+ * @final since 1.4
  */
 class OAuthListener extends AbstractAuthenticationListener
 {

--- a/Security/Http/ResourceOwnerMap.php
+++ b/Security/Http/ResourceOwnerMap.php
@@ -23,6 +23,8 @@ use Symfony\Component\Security\Http\HttpUtils;
  * loads the appropriate resource owner when requested.
  *
  * @author Alexander <iam.asm89@gmail.com>
+ *
+ * @final since 1.4
  */
 class ResourceOwnerMap implements ContainerAwareInterface, ResourceOwnerMapInterface
 {

--- a/Security/OAuthUtils.php
+++ b/Security/OAuthUtils.php
@@ -22,6 +22,8 @@ use Symfony\Component\Security\Http\HttpUtils;
  * @author Alexander <iam.asm89@gmail.com>
  * @author Joseph Bielawski <stloyd@gmail.com>
  * @author Francisco Facioni <fran6co@gmail.com>
+ *
+ * @final since 1.4
  */
 class OAuthUtils
 {

--- a/Templating/Helper/OAuthHelper.php
+++ b/Templating/Helper/OAuthHelper.php
@@ -18,6 +18,8 @@ use Symfony\Component\Templating\Helper\Helper;
 /**
  * @author Alexander <iam.asm89@gmail.com>
  * @author Joseph Bielawski <stloyd@gmail.com>
+ *
+ * @final since 1.4
  */
 class OAuthHelper extends Helper
 {


### PR DESCRIPTION
Related to: #1743

To be easier to review I list the ones I left without annotation (I'm not listing the already `final` ones and `abstract`):
- https://github.com/hwi/HWIOAuthBundle/blob/master/Event/UserEvent.php (there are other events extending it).
- https://github.com/hwi/HWIOAuthBundle/blob/master/OAuth/Response/PathUserResponse.php (some extends from this).
- https://github.com/hwi/HWIOAuthBundle/blob/master/Security/Core/Authentication/Token/OAuthToken.php (in tests there is a [CustomOAuthToken](https://github.com/hwi/HWIOAuthBundle/blob/master/Tests/Fixtures/CustomOAuthToken.php) extending)

And [ResourceOwners](https://github.com/hwi/HWIOAuthBundle/tree/master/OAuth/ResourceOwner) that I wasn't sure what to do, maybe they could be marked as internal
