### PR TITLE
Bugfix | Remove usage of `$this->prophesize()` in favour of mocking & use internal Symfony container

### DIFF
--- a/Tests/Controller/ConnectControllerRegistrationActionTest.php
+++ b/Tests/Controller/ConnectControllerRegistrationActionTest.php
@@ -159,12 +159,13 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
             ->method('getData')
             ->willReturn(new User());
 
-        if (!class_exists(FactoryInterface::class)) {
+        if (!class_exists(\FOS\UserBundle\Model\User::class)) {
             $this->markTestSkipped('FOSUserBundle not installed.');
         }
 
         $this->container->setParameter('hwi_oauth.fosub_enabled', true);
 
+        // @phpstan-ignore-next-line
         $registrationFormFactory = $this->createMock(FactoryInterface::class);
         $registrationFormFactory->expects($this->any())
             ->method('createForm')


### PR DESCRIPTION
This removes deprecation warning in PHPUnit:
```
PHPUnit\Framework\TestCase::prophesize() is deprecated and will be removed in PHPUnit 10. Please use the trait provided by phpspec/prophecy-phpunit
```