### PR TITLE
Fix compatibility with symfony 4.4

### DIFF
--- a/Controller/ConnectController.php
+++ b/Controller/ConnectController.php
@@ -21,6 +21,7 @@ use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapLocator;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\EventDispatcher\Event as DeprecatedEvent;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -380,7 +381,10 @@ final class ConnectController extends AbstractController
         return $response;
     }
 
-    private function dispatch(Event $event, string $eventName = null): void
+    /**
+     * @param Event|DeprecatedEvent $event
+     */
+    private function dispatch($event, string $eventName = null): void
     {
         $this->get('event_dispatcher')->dispatch($event, $eventName);
     }


### PR DESCRIPTION
When calling:

https://github.com/hwi/HWIOAuthBundle/blob/e76e83035dfb09f74391897377b4a9ef37f75d88/Controller/ConnectController.php#L309-L312

[`InteractiveLoginEvent` in 4.4 does not implement `Event` from `Contracts`](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Security/Http/Event/InteractiveLoginEvent.php#L14), so dispatch method throws a TypeError.