### PR TITLE
Add test to CI using FOSUserBundle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,3 +141,40 @@ jobs:
         run: vendor/bin/phpunit --version
       - name: Run PHPUnit tests
         run: vendor/bin/phpunit
+
+  phpunit-fosuserbundle:
+    name: PHPUnit (PHP ${{ matrix.php }} FOSUserBundle)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        php:
+          - '7.4'
+      fail-fast: false
+    env:
+      SYMFONY_DEPRECATIONS_HELPER: 'weak'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: pecl, composer
+          extensions: curl, openssl, mbstring
+          ini-values: memory_limit=-1
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Update project dependencies
+        run: composer update --no-interaction --no-progress --ansi --prefer-lowest
+      - name: Install PHPUnit
+        run: vendor/bin/phpunit --version
+      - name: Run PHPUnit tests
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
 
     "require-dev": {
         "doctrine/doctrine-bundle":     "^2.0",
-        "doctrine/orm":                 "^2.6",
+        "doctrine/orm":                 "^2.6.4",
         "symfony/browser-kit":          "^4.4|^5.1",
         "symfony/css-selector":         "^4.4|^5.1",
         "symfony/property-access":      "^4.4|^5.1",


### PR DESCRIPTION
With this, functional tests are executed, it used to failed before #1689, that can be seen in https://github.com/franmomu/HWIOAuthBundle/pull/2, now it should pass.

Replaces https://github.com/hwi/HWIOAuthBundle/pull/1750

This job will be removed in `2.0`, but it is useful to execute our functional tests in CI instead of skipping them.

Needs https://github.com/hwi/HWIOAuthBundle/pull/1752 and https://github.com/hwi/HWIOAuthBundle/pull/1751