### PR TITLE
Define `hwi_oauth.connect.confirmation` parameter

### DIFF
--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -175,6 +175,8 @@ final class HWIOAuthExtension extends Extension
      */
     private function createConnectIntegration(ContainerBuilder $container, array $config)
     {
+        $container->setParameter('hwi_oauth.connect.confirmation', false);
+
         if (isset($config['connect'])) {
             $container->setParameter('hwi_oauth.connect', true);
 

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -383,6 +383,7 @@ class HWIOAuthExtensionTest extends TestCase
         $this->assertNotHasDefinition('hwi_oauth.user.provider.fosub_bridge');
 
         $this->assertParameter(false, 'hwi_oauth.connect');
+        $this->assertParameter(false, 'hwi_oauth.connect.confirmation');
 
         $this->assertAlias('security.user_checker', 'hwi_oauth.user_checker');
     }


### PR DESCRIPTION
When using the last version (`1.4` is already in packagist 👍 ), this error appears:

```
 You have requested a non-existent parameter "hwi_oauth.connect.confirmation".
```

That's because it is used in:

https://github.com/hwi/HWIOAuthBundle/blob/d4986a7280beaccb336535e6abbcf7a85004517c/Resources/config/controller.xml#L16

But it is only defined in:

https://github.com/hwi/HWIOAuthBundle/blob/d4986a7280beaccb336535e6abbcf7a85004517c/DependencyInjection/HWIOAuthExtension.php#L201

The proper way to fix this I guess is to check if `connect` is enabled and then load the `ConnectController`, but that would be BC break since the controller service won't be available.

I tried to make the argument optional, but I couldn't, I'm not sure if that's possible with a parameter from the container.