### PR TITLE
Fix missing `hwi_oauth.connect.confirmation` parameter

### DIFF
--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -208,6 +208,7 @@ final class HWIOAuthExtension extends Extension
         } else {
             $container->setParameter('hwi_oauth.fosub_enabled', false);
             $container->setParameter('hwi_oauth.connect', false);
+            $container->setParameter('hwi_oauth.connect.confirmation', false);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/hwi/HWIOAuthBundle/issues/1757