### PR TITLE
Set default value for hwi_oauth.connect.confirmation

### DIFF
--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -208,6 +208,7 @@ final class HWIOAuthExtension extends Extension
         } else {
             $container->setParameter('hwi_oauth.fosub_enabled', false);
             $container->setParameter('hwi_oauth.connect', false);
+            $container->setParameter('hwi_oauth.connect.confirmation', false);
         }
     }
 }


### PR DESCRIPTION
... otherwise this is breaking existing setups, there's even a default for the other parameters, so we should do it for that as well 😊