### PR TITLE
[bug] fix missing success/failure handler

### DIFF
--- a/DependencyInjection/Security/Factory/OAuthAuthenticatorFactory.php
+++ b/DependencyInjection/Security/Factory/OAuthAuthenticatorFactory.php
@@ -42,16 +42,9 @@ final class OAuthAuthenticatorFactory extends OAuthFactory implements Authentica
             )
             ->addArgument($this->getResourceOwnerMapReference($firewallName))
             ->addArgument($config['resource_owners'])
-            ->addArgument(
-                isset($config['success_handler'])
-                    ? new Reference($this->createAuthenticationSuccessHandler($container, $firewallName, $config))
-                    : null
-            )
-            ->addArgument(
-                isset($config['failure_handler'])
-                    ? new Reference($this->createAuthenticationFailureHandler($container, $firewallName, $config))
-                    : null
-            );
+            ->addArgument(new Reference($this->createAuthenticationSuccessHandler($container, $firewallName, $config)))
+            ->addArgument(new Reference($this->createAuthenticationFailureHandler($container, $firewallName, $config)))
+        ;
 
         return $authenticatorId;
     }

--- a/Security/Http/Authenticator/OAuthAuthenticator.php
+++ b/Security/Http/Authenticator/OAuthAuthenticator.php
@@ -59,12 +59,12 @@ final class OAuthAuthenticator implements AuthenticatorInterface
     private $checkPaths;
 
     /**
-     * @var AuthenticationSuccessHandlerInterface|null
+     * @var AuthenticationSuccessHandlerInterface
      */
     private $successHandler;
 
     /**
-     * @var AuthenticationFailureHandlerInterface|null
+     * @var AuthenticationFailureHandlerInterface
      */
     private $failureHandler;
 
@@ -93,8 +93,8 @@ final class OAuthAuthenticator implements AuthenticatorInterface
         OAuthAwareUserProviderInterface $userProvider,
         ResourceOwnerMapInterface $resourceOwnerMap,
         array $checkPaths,
-        ?AuthenticationSuccessHandlerInterface $successHandler = null,
-        ?AuthenticationFailureHandlerInterface $failureHandler = null
+        AuthenticationSuccessHandlerInterface $successHandler,
+        AuthenticationFailureHandlerInterface $failureHandler
     ) {
         $this->failureHandler = $failureHandler;
         $this->successHandler = $successHandler;
@@ -203,12 +203,12 @@ final class OAuthAuthenticator implements AuthenticatorInterface
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        return $this->successHandler ? $this->successHandler->onAuthenticationSuccess($request, $token) : null;
+        return $this->successHandler->onAuthenticationSuccess($request, $token);
     }
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
-        return $this->failureHandler ? $this->failureHandler->onAuthenticationFailure($request, $exception) : null;
+        return $this->failureHandler->onAuthenticationFailure($request, $exception);
     }
 
     private function refreshToken(OAuthToken $expiredToken, ResourceOwnerInterface $resourceOwner): OAuthToken

--- a/Tests/Security/Http/Authenticator/OAuthAuthenticatorTest.php
+++ b/Tests/Security/Http/Authenticator/OAuthAuthenticatorTest.php
@@ -175,7 +175,7 @@ class OAuthAuthenticatorTest extends TestCase
             $this->getResourceOwnerMapMock(),
             [],
             $successHandlerMock,
-            null
+            $this->getAuthenticationFailureHandlerMock()
         );
 
         $this->assertSame($response, $authenticator->onAuthenticationSuccess($request, $token, 'main'));
@@ -199,7 +199,7 @@ class OAuthAuthenticatorTest extends TestCase
             $this->getOAuthAwareUserProviderMock(),
             $this->getResourceOwnerMapMock(),
             [],
-            null,
+            $this->getAuthenticationSuccessHandlerMock(),
             $failureHandlerMock
         );
 


### PR DESCRIPTION
The success and failure handlers should always be present in the Authenticator. It is resolved by `AbstractFactory:: createAuthenticationSuccessHandler()`:
https://github.com/symfony/symfony/blob/5.1/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php#L165-L174
where default handler is resolved if none is set for the current firewall.

This issue makes it impossible to log in unless someone provides a custom success handler. I discovered this bug after upgrading to 1.4 and switching to new authentication system.