### PR TITLE
Define hwi_oauth.connect.confirmation parameter

### DIFF
--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -175,6 +175,8 @@ final class HWIOAuthExtension extends Extension
      */
     private function createConnectIntegration(ContainerBuilder $container, array $config)
     {
+        $container->setParameter('hwi_oauth.connect.confirmation', false);
+
         if (isset($config['connect'])) {
             $container->setParameter('hwi_oauth.connect', true);
 

--- a/Tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/Tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -382,6 +382,7 @@ class HWIOAuthExtensionTest extends TestCase
         $this->assertNotHasDefinition('hwi_oauth.user.provider.fosub_bridge');
 
         $this->assertParameter(false, 'hwi_oauth.connect');
+        $this->assertParameter(false, 'hwi_oauth.connect.confirmation');
 
         $this->assertAlias('security.user_checker', 'hwi_oauth.user_checker');
     }


### PR DESCRIPTION
Based on https://github.com/hwi/HWIOAuthBundle/pull/1756#issuecomment-887939798, I didn't realised that there was a new `1.4` branch.

This is a cherry-pick of the commit in `master`.