### PR TITLE
Don't re-use creation date from previous token if was already expired  in `OAuthProvider`

### DIFF
--- a/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -149,7 +149,7 @@ class OAuthProvider implements AuthenticationProviderInterface
         $token->setResourceOwnerName($oldToken->getResourceOwnerName());
         $token->setUser($user);
         $token->setAuthenticated(true);
-        $token->setCreatedAt($oldToken->getCreatedAt());
+        $token->setCreatedAt($oldToken->isExpired() ? time() : $oldToken->getCreatedAt());
 
         // Don't use old data if newer was already set
         if (!$token->getRefreshToken()) {

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -148,7 +148,7 @@ class OAuthProviderTest extends TestCase
         try {
             $oauthProvider->authenticate($oauthToken);
 
-            $this->assertTrue(false, 'Exception was not thrown.');
+            $this->fail('Exception was not thrown.');
         } catch (OAuthAwareException $e) {
             $this->assertTrue(true, 'Exception was thrown.');
             $this->assertInstanceOf(OAuthAwareExceptionInterface::class, $e);
@@ -176,7 +176,7 @@ class OAuthProviderTest extends TestCase
         $refreshedToken = [
             'access_token' => 'access_token_new',
             'refresh_token' => 'refresh_token',
-            'expires_in' => '666_new',
+            'expires_in' => '777',
             'oauth_token_secret' => 'secret_new',
         ];
 


### PR DESCRIPTION
Fixes #1767.