### PR TITLE
Bugfix | Prevent issue with missing parameter when `connect` option is not enabled

### DIFF
--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -182,6 +182,7 @@ final class HWIOAuthExtension extends Extension
     private function createConnectIntegration(ContainerBuilder $container, array $config): void
     {
         $container->setParameter('hwi_oauth.connect.confirmation', false);
+        $container->setParameter('hwi_oauth.connect.registration_form', null);
 
         if (!isset($config['connect'])) {
             $container->setParameter('hwi_oauth.connect', false);


### PR DESCRIPTION
Fixes #1781.