### PR TITLE
[2.x] Fix HTTP client definition

### DIFF
--- a/Resources/config/util.xml
+++ b/Resources/config/util.xml
@@ -9,6 +9,8 @@
             <argument>%hwi_oauth.target_path_domains_whitelist%</argument>
         </service>
 
-        <service id="hwi_oauth.http_client" class="Symfony\Contracts\HttpClient\HttpClientInterface" />
+        <service id="hwi_oauth.http_client" class="Symfony\Contracts\HttpClient\HttpClientInterface">
+            <factory class="Symfony\Component\HttpClient\HttpClient" method="create" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
The Symfony HTTP client service definition introduced in #1681 was incomplete, and unusable in such state. I copied how it's built from the main framework.

[EDIT] IMHO we should still go forward with #1787, and use the Symfony client as default.