### PR TITLE
getMasterRequest is deprecated since Symfony 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+## 1.4.3
+* Fix: getMasterRequest is deprecated since Symfony 5.3, use getMainRequest if exists
+
 ## 1.4.2 (2021-08-09)
 * Bugfix: remove `@final` declaration from `OAuthFactory` & `FOSUBUserProvider`,
 * Maintain: added `.gitattributes` to reduce amount of code in archives,

--- a/Templating/Helper/OAuthHelper.php
+++ b/Templating/Helper/OAuthHelper.php
@@ -87,7 +87,7 @@ class OAuthHelper extends Helper
      */
     private function getMainRequest()
     {
-        if (\is_callable([$this->requestStack, 'getMainRequest'])) {
+        if (method_exists($this->requestStack, 'getMainRequest')) {
             return $this->requestStack->getMainRequest(); // Symfony 5.3+
         }
 

--- a/Templating/Helper/OAuthHelper.php
+++ b/Templating/Helper/OAuthHelper.php
@@ -12,8 +12,8 @@
 namespace HWI\Bundle\OAuthBundle\Templating\Helper;
 
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Templating\Helper\Helper;
 
 /**

--- a/Templating/Helper/OAuthHelper.php
+++ b/Templating/Helper/OAuthHelper.php
@@ -87,7 +87,7 @@ class OAuthHelper extends Helper
      */
     private function getMainRequest()
     {
-        if (method_exists($this->requestStack, 'getMainRequest')) {
+        if (\method_exists($this->requestStack, 'getMainRequest')) {
             return $this->requestStack->getMainRequest(); // Symfony 5.3+
         }
 

--- a/Templating/Helper/OAuthHelper.php
+++ b/Templating/Helper/OAuthHelper.php
@@ -87,7 +87,7 @@ class OAuthHelper extends Helper
      */
     private function getMainRequest()
     {
-        if (\method_exists($this->requestStack, 'getMainRequest')) {
+        if (method_exists($this->requestStack, 'getMainRequest')) {
             return $this->requestStack->getMainRequest(); // Symfony 5.3+
         }
 

--- a/Templating/Helper/OAuthHelper.php
+++ b/Templating/Helper/OAuthHelper.php
@@ -13,6 +13,7 @@ namespace HWI\Bundle\OAuthBundle\Templating\Helper;
 
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Templating\Helper\Helper;
 
 /**
@@ -56,7 +57,7 @@ class OAuthHelper extends Helper
      */
     public function getLoginUrl($name)
     {
-        return $this->oauthUtils->getLoginUrl($this->requestStack->getMasterRequest(), $name);
+        return $this->oauthUtils->getLoginUrl($this->getMainRequest(), $name);
     }
 
     /**
@@ -68,7 +69,7 @@ class OAuthHelper extends Helper
      */
     public function getAuthorizationUrl($name, $redirectUrl = null, array $extraParameters = [])
     {
-        return $this->oauthUtils->getAuthorizationUrl($this->requestStack->getMasterRequest(), $name, $redirectUrl, $extraParameters);
+        return $this->oauthUtils->getAuthorizationUrl($this->getMainRequest(), $name, $redirectUrl, $extraParameters);
     }
 
     /**
@@ -79,5 +80,17 @@ class OAuthHelper extends Helper
     public function getName()
     {
         return 'hwi_oauth';
+    }
+
+    /**
+     * @return Request|null
+     */
+    private function getMainRequest()
+    {
+        if (\is_callable([$this->requestStack, 'getMainRequest'])) {
+            return $this->requestStack->getMainRequest(); // Symfony 5.3+
+        }
+
+        return $this->requestStack->getMasterRequest();
     }
 }


### PR DESCRIPTION
I'm targeting this branche because it's BC.

Added function to check if "getMainRequest" exists, otherwise use the current "getMasterRequest":

From Symfony 5.3 notes:

 * Deprecate the `RequestStack::getMasterRequest()` method and add `getMainRequest()` as replacement
