### PR TITLE
Bugfix: Fixed `VkontakteResourceOwner` option: `api_version` to not point to deprecated one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+## 1.4.3 (2021-xx-xx)
+* Bugfix: Fixed `VkontakteResourceOwner` option: `api_version` to not point to deprecated one,
+
 ## 1.4.2 (2021-08-09)
 * Bugfix: remove `@final` declaration from `OAuthFactory` & `FOSUBUserProvider`,
 * Maintain: added `.gitattributes` to reduce amount of code in archives,

--- a/OAuth/ResourceOwner/VkontakteResourceOwner.php
+++ b/OAuth/ResourceOwner/VkontakteResourceOwner.php
@@ -86,7 +86,8 @@ class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
             'infos_url' => 'https://api.vk.com/method/users.get',
             'use_authorization_to_get_token' => false,
 
-            'api_version' => '5.73',
+            // Based on: https://vk.com/dev/constant_version_updates
+            'api_version' => '5.131',
 
             'scope' => 'email',
 


### PR DESCRIPTION
Fixed #1803.