### PR TITLE
Add handling for an expired token on Bitbucket while fetching user information

### DIFF
--- a/OAuth/ResourceOwner/Bitbucket2ResourceOwner.php
+++ b/OAuth/ResourceOwner/Bitbucket2ResourceOwner.php
@@ -40,6 +40,10 @@ final class Bitbucket2ResourceOwner extends GenericOAuth2ResourceOwner
         // fetch the email addresses linked to the account
         if (empty($responseData['email'])) {
             $content = $this->httpRequest($this->normalizeUrl($this->options['emails_url']), null, ['Authorization' => 'Bearer '.$accessToken['access_token']]);
+            if (isset($accessToken['refresh_token']) && !isset($this->getResponseContent($content)['values'])) {
+                $refreshTokenResponse = $this->refreshAccessToken($accessToken['refresh_token']);
+                $content = $this->httpRequest($this->normalizeUrl($this->options['emails_url']), null, ['Authorization' => 'Bearer '.$refreshTokenResponse['access_token']]);
+            }
             foreach ($this->getResponseContent($content)['values'] as $email) {
                 // we only need the primary email address
                 if (true === $email['is_primary']) {


### PR DESCRIPTION
In case there is an empty email with Bitbucket and there is an attempt to fetch the linked emails. There is a second request to `emails_url` that could fail in case the token is expired. This results into an undefined index warning while accessing `values` and the user information missing the email.

I've added a refresh for the token and attempting to fetch emails again.