### PR TITLE
Fix Symfony 5.3 remaining deprecations

### DIFF
--- a/DependencyInjection/Security/Factory/OAuthFactory.php
+++ b/DependencyInjection/Security/Factory/OAuthFactory.php
@@ -11,6 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\DependencyInjection\Security\Factory;
 
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Provider\OAuthProvider;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -98,6 +99,9 @@ class OAuthFactory extends AbstractFactory
         $providerId = 'hwi_oauth.authentication.provider.oauth.'.$id;
 
         $this->createResourceOwnerMap($container, $id, $config);
+
+        $container
+            ->register('hwi_oauth.authentication.provider.oauth', OAuthProvider::class);
 
         $container
             ->setDefinition($providerId, new ChildDefinition('hwi_oauth.authentication.provider.oauth'))

--- a/Resources/config/oauth.xml
+++ b/Resources/config/oauth.xml
@@ -84,7 +84,6 @@
         -->
         <service id="hwi_oauth.authentication.listener.oauth" class="HWI\Bundle\OAuthBundle\Security\Http\Firewall\OAuthListener"
                  parent="security.authentication.listener.abstract" abstract="true" />
-        <service id="hwi_oauth.authentication.provider.oauth" class="HWI\Bundle\OAuthBundle\Security\Core\Authentication\Provider\OAuthProvider" />
         <service id="hwi_oauth.authentication.entry_point.oauth" class="HWI\Bundle\OAuthBundle\Security\Http\EntryPoint\OAuthEntryPoint">
             <argument type="service" id="http_kernel" />
             <argument type="service" id="security.http_utils" />

--- a/Tests/Controller/ConnectControllerRegistrationActionTest.php
+++ b/Tests/Controller/ConnectControllerRegistrationActionTest.php
@@ -69,6 +69,9 @@ class ConnectControllerRegistrationActionTest extends AbstractConnectControllerT
         $controller->registrationAction($this->request, $key);
     }
 
+    /**
+     * @group legacy
+     */
     public function testFailedProcess()
     {
         $key = time();

--- a/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
+++ b/Tests/Security/Core/Authentication/Provider/OAuthProviderTest.php
@@ -26,6 +26,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class OAuthProviderTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testSupportsOAuthToken()
     {
         $resourceOwnerMapMock = $this->getResourceOwnerMapMock();

--- a/Tests/Security/Core/User/OAuthUserProviderTest.php
+++ b/Tests/Security/Core/User/OAuthUserProviderTest.php
@@ -15,6 +15,7 @@ use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser;
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUserProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\User;
 
 class OAuthUserProviderTest extends TestCase
@@ -53,10 +54,15 @@ class OAuthUserProviderTest extends TestCase
 
     public function testRefreshUserUnsupportedClass()
     {
-        $this->expectException(\Symfony\Component\Security\Core\Exception\UnsupportedUserException::class);
-        $this->expectExceptionMessage('Unsupported user class "Symfony\\Component\\Security\\Core\\User\\User"');
+        // BC Layer to be dropped when Symfony >= 5.3 will be required
+        if (class_exists(InMemoryUser::class)) {
+            $user = new InMemoryUser('asm89', 'foo');
+        } else {
+            $user = new User('asm89', 'foo');
+        }
 
-        $user = new User('asm89', 'foo');
+        $this->expectException(\Symfony\Component\Security\Core\Exception\UnsupportedUserException::class);
+        $this->expectExceptionMessage(sprintf('Unsupported user class "%s"', \get_class($user)));
 
         $this->provider->refreshUser($user);
     }

--- a/Tests/Security/Http/Authenticator/OAuthAuthenticatorTest.php
+++ b/Tests/Security/Http/Authenticator/OAuthAuthenticatorTest.php
@@ -86,7 +86,36 @@ class OAuthAuthenticatorTest extends TestCase
             'oauth_token_secret' => 'secret',
         ];
         $userResponseMock = $this->getUserResponseMock();
-        $userMock = $this->getUserMock();
+        $userMock = new class() implements UserInterface {
+            public function getUserIdentifier(): string
+            {
+                return 'username';
+            }
+
+            public function getUsername(): string
+            {
+                return $this->getUserIdentifier();
+            }
+
+            public function getRoles(): array
+            {
+                return ['ROLE_USER'];
+            }
+
+            public function eraseCredentials(): void
+            {
+            }
+
+            public function getPassword(): ?string
+            {
+                return null;
+            }
+
+            public function getSalt(): ?string
+            {
+                return null;
+            }
+        };
         $resourceOwnerName = 'github';
 
         $resourceOwnerMapMock->expects($this->once())
@@ -126,14 +155,6 @@ class OAuthAuthenticatorTest extends TestCase
         $resourceOwnerMock->expects($this->atLeastOnce())
             ->method('getName')
             ->willReturn($resourceOwnerName);
-
-        $userMock
-            ->method('getUsername')
-            ->willReturn('username');
-
-        $userMock->expects($this->once())
-            ->method('getRoles')
-            ->willReturn(['ROLE_USER']);
 
         $authenticator = new OAuthAuthenticator(
             $httpUtilsMock,


### PR DESCRIPTION
Fixes https://github.com/hwi/HWIOAuthBundle/issues/1783

If you could give it a try @garak

There is still a deprecation that we have to break BC or wait for major release.

https://github.com/hwi/HWIOAuthBundle/blob/cd20030f27724524aa39a001eb5b698908a87973/Security/Core/Exception/AccountNotLinkedException.php#L14-L17

`UsernameNotFoundException` is deprecated in favor of `UserNotFoundException`, we could optionally extend from `UserNotFoundException` if the class exists.

