### PR TITLE
Fix parsing OAuth1.0a responses for Twitter

### DIFF
--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -290,17 +290,12 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
 
     protected function getResponseContent(ResponseInterface $rawResponse): array
     {
-        $contentTypes = $rawResponse->getHeaders(false)['content-type'] ?? [];
-        if (\in_array('text/plain', $contentTypes, true)) {
-            parse_str($rawResponse->getContent(false), $response);
-
-            return $response;
-        }
-
         try {
             return $rawResponse->toArray(false);
         } catch (JsonException $e) {
-            return [];
+            parse_str($rawResponse->getContent(false), $response);
+
+            return $response;
         }
     }
 

--- a/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth1ResourceOwnerTest.php
@@ -210,6 +210,52 @@ class GenericOAuth1ResourceOwnerTest extends ResourceOwnerTestCase
         );
     }
 
+    public function testGetAccessTokenHtmlResponse(): void
+    {
+        $request = new Request(['oauth_verifier' => 'code', 'oauth_token' => 'token']);
+
+        $resourceOwner = $this->createResourceOwner(
+            [],
+            [],
+            [
+                $this->createMockResponse('oauth_token=token&oauth_token_secret=secret', 'text/html;charset=utf-8'),
+            ]
+        );
+
+        $this->storage->expects($this->once())
+            ->method('fetch')
+            ->with($resourceOwner, 'token')
+            ->willReturn(['oauth_token' => 'token2', 'oauth_token_secret' => 'secret2']);
+
+        $this->assertEquals(
+            ['oauth_token' => 'token', 'oauth_token_secret' => 'secret'],
+            $resourceOwner->getAccessToken($request, 'http://redirect.to/')
+        );
+    }
+
+    public function testGetAccessTokenUrlEncodedResponse(): void
+    {
+        $request = new Request(['oauth_verifier' => 'code', 'oauth_token' => 'token']);
+
+        $resourceOwner = $this->createResourceOwner(
+            [],
+            [],
+            [
+                $this->createMockResponse('oauth_token=token&oauth_token_secret=secret', 'application/x-www-form-urlencoded'),
+            ]
+        );
+
+        $this->storage->expects($this->once())
+            ->method('fetch')
+            ->with($resourceOwner, 'token')
+            ->willReturn(['oauth_token' => 'token2', 'oauth_token_secret' => 'secret2']);
+
+        $this->assertEquals(
+            ['oauth_token' => 'token', 'oauth_token_secret' => 'secret'],
+            $resourceOwner->getAccessToken($request, 'http://redirect.to/')
+        );
+    }
+
     public function testGetAccessTokenJsonResponse(): void
     {
         $resourceOwner = $this->createResourceOwner(

--- a/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
+++ b/Tests/OAuth/ResourceOwner/GenericOAuth2ResourceOwnerTest.php
@@ -232,6 +232,11 @@ json;
             'text/plain',
         ];
 
+        yield 'html text with charset' => [
+            'access_token=code',
+            'text/html;charset=utf-8',
+        ];
+
         yield 'json' => [
             '{"access_token": "code"}',
             'application/json',


### PR DESCRIPTION
Fixes #1820

Parses text/html;charset=utf-8 response as string instead of json. This is necessary for OAuth1.0a responses from Twitter.