### PR TITLE
Pass content in HTTP POST request on OAuth server

### DIFF
--- a/DependencyInjection/HWIOAuthExtension.php
+++ b/DependencyInjection/HWIOAuthExtension.php
@@ -148,7 +148,7 @@ final class HWIOAuthExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'hwi_oauth';
     }

--- a/HWIOAuthBundle.php
+++ b/HWIOAuthBundle.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\Authentic
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 /**
  * @author Geoffrey Bachelet <geoffrey.bachelet@gmail.com>
@@ -50,7 +51,7 @@ class HWIOAuthBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         // return the right extension instead of "auto-registering" it. Now the
         // alias can be hwi_oauth instead of hwi_o_auth.

--- a/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -273,9 +273,8 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
             if (!isset($options['headers']['Content-Length'])) {
                 $options['headers'] += ['Content-Length' => (string) \strlen($content)];
             }
-        } elseif (\is_array($content)) {
-            $options['body'] = $content;
         }
+        $options['body'] = $content;
 
         try {
             return $this->httpClient->request(


### PR DESCRIPTION
Performs an HTTP request.
HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\AbstractResourceOwner::httpRequest

If the $content is string, then the $content was lost. $content passed to $this->httpClient->request for array only, not string. 
I was getting an 400 response from the Auth0 server on /oauth/token instead of access token.

This is fixed. Tested on Auth0.