### PR TITLE
Fix code style issue

### DIFF
--- a/HWIOAuthBundle.php
+++ b/HWIOAuthBundle.php
@@ -18,8 +18,8 @@ use HWI\Bundle\OAuthBundle\DependencyInjection\Security\Factory\OAuthFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * @author Geoffrey Bachelet <geoffrey.bachelet@gmail.com>


### PR DESCRIPTION
PHP CS Fixer fails since the use statements are not sorted alphabetically.  

See failing job:
https://github.com/hwi/HWIOAuthBundle/runs/4417396961?check_suite_focus=true