### PR TITLE
Reviewed authenticator and made refreshToken method public.

### DIFF
--- a/Security/Core/Authentication/Token/AbstractOAuthToken.php
+++ b/Security/Core/Authentication/Token/AbstractOAuthToken.php
@@ -112,6 +112,10 @@ abstract class AbstractOAuthToken extends AbstractToken
         }
     }
 
+    public function copyPersistentDataFrom(self $token): void
+    {
+    }
+
     /**
      * @return mixed|void
      */

--- a/Security/Http/Authenticator/OAuthAuthenticator.php
+++ b/Security/Http/Authenticator/OAuthAuthenticator.php
@@ -16,6 +16,7 @@ use HWI\Bundle\OAuthBundle\OAuth\State\State;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAwareExceptionInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthAwareUserProviderInterface;
+use HWI\Bundle\OAuthBundle\Security\Http\Authenticator\Passport\SelfValidatedOAuthPassport;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,9 +30,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
-use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
-use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 
@@ -52,10 +51,6 @@ final class OAuthAuthenticator implements AuthenticatorInterface, Authentication
      */
     private array $checkPaths;
 
-    private ?array $rawToken = null;
-    private ?string $resourceOwnerName = null;
-    private ?string $refreshToken = null;
-    private ?int $createdAt = null;
     private array $options;
 
     public function __construct(
@@ -144,8 +139,40 @@ final class OAuthAuthenticator implements AuthenticatorInterface, Authentication
         $token = new OAuthToken($accessToken);
         $token->setResourceOwnerName($resourceOwner->getName());
 
+        return new SelfValidatedOAuthPassport($this->refreshToken($token));
+    }
+
+    /**
+     * This function can be used for refreshing an expired token
+     * or for custom "password grant" authenticator, if site owner also owns oauth instance.
+     *
+     * @template T of OAuthToken
+     *
+     * @param T $token
+     *
+     * @return T
+     */
+    public function refreshToken(OAuthToken $token): OAuthToken
+    {
+        $resourceOwner = $this->resourceOwnerMap->getResourceOwnerByName($token->getResourceOwnerName());
+
         if ($token->isExpired()) {
-            $token = $this->refreshToken($token, $resourceOwner);
+            $expiredToken = $token;
+            if ($refreshToken = $expiredToken->getRefreshToken()) {
+                $tokenClass = \get_class($expiredToken);
+                $token = new $tokenClass($resourceOwner->refreshAccessToken($refreshToken));
+                $token->setResourceOwnerName($expiredToken->getResourceOwnerName());
+                if (!$token->getRefreshToken()) {
+                    $token->setRefreshToken($expiredToken->getRefreshToken());
+                }
+                $token->copyPersistentDataFrom($expiredToken);
+            } else {
+                // if you cannot refresh token, you do not need to make user_info request to oauth-resource
+                if (null !== $expiredToken->getUser()) {
+                    return $expiredToken;
+                }
+            }
+            unset($expiredToken);
         }
 
         $userResponse = $resourceOwner->getUserInformation($token->getRawToken());
@@ -163,35 +190,63 @@ final class OAuthAuthenticator implements AuthenticatorInterface, Authentication
             throw new AuthenticationServiceException('loadUserByOAuthUserResponse() must return a UserInterface.');
         }
 
-        $this->rawToken = $token->getRawToken();
-        $this->resourceOwnerName = $resourceOwner->getName();
-        $this->refreshToken = $token->getRefreshToken();
-        $this->createdAt = $token->getCreatedAt();
-
-        return new SelfValidatingPassport(
-            class_exists(UserBadge::class)
-                ? new UserBadge(
-                    // @phpstan-ignore-next-line Symfony <5.4 BC layer
-                    method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername(),
-                    static function () use ($user) { return $user; }
-                )
-                : $user
-        );
+        return $this->recreateToken($token, $user);
     }
 
     /**
-     * @param Passport|SelfValidatingPassport $passport
+     * @template T of OAuthToken
+     *
+     * @param T              $token
+     * @param ?UserInterface $user
+     *
+     * @return T
+     */
+    public function recreateToken(OAuthToken $token, ?UserInterface $user = null): OAuthToken
+    {
+        $user = $user instanceof UserInterface ? $user : $token->getUser();
+
+        $tokenClass = \get_class($token);
+        if ($user) {
+            $newToken = new $tokenClass(
+                $token->getRawToken(),
+                method_exists($user, 'getRoles') ? $user->getRoles() : []
+            );
+            $newToken->setUser($user);
+        } else {
+            $newToken = new $tokenClass($token->getRawToken());
+        }
+
+        $newToken->setResourceOwnerName($token->getResourceOwnerName());
+        $newToken->setRefreshToken($token->getRefreshToken());
+        $newToken->setCreatedAt($token->getCreatedAt());
+        $newToken->setTokenSecret($token->getTokenSecret());
+        $newToken->setAttributes($token->getAttributes());
+
+        // required for compatibility with Symfony 5.4
+        if (method_exists($newToken, 'setAuthenticated')) {
+            $newToken->setAuthenticated((bool) $user, false);
+        }
+
+        $newToken->copyPersistentDataFrom($token);
+
+        return $newToken;
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        return $this->createAuthenticatedToken($passport, $firewallName);
+    }
+
+    /**
+     * @param Passport|SelfValidatedOAuthPassport $passport
      */
     public function createAuthenticatedToken($passport, string $firewallName): TokenInterface
     {
-        $token = $this->createToken($passport, $firewallName);
+        if ($passport instanceof SelfValidatedOAuthPassport) {
+            return $passport->getToken();
+        }
 
-        $this->rawToken = null;
-        $this->resourceOwnerName = null;
-        $this->refreshToken = null;
-        $this->createdAt = null;
-
-        return $token;
+        throw new \LogicException(sprintf('The first argument of "%s" must be instance of "%s", "%s" provided.', __METHOD__, SelfValidatedOAuthPassport::class, \get_class($passport)));
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
@@ -202,34 +257,6 @@ final class OAuthAuthenticator implements AuthenticatorInterface, Authentication
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
         return $this->failureHandler->onAuthenticationFailure($request, $exception);
-    }
-
-    public function createToken(Passport $passport, string $firewallName): TokenInterface
-    {
-        $token = new OAuthToken($this->rawToken, $passport->getUser()->getRoles());
-        $token->setResourceOwnerName($this->resourceOwnerName);
-        $token->setUser($passport->getUser());
-        $token->setRefreshToken($this->refreshToken);
-        $token->setCreatedAt($this->createdAt);
-
-        // required for compatibility with Symfony 5.4
-        if (method_exists($token, 'setAuthenticated')) {
-            $token->setAuthenticated(true, false);
-        }
-
-        return $token;
-    }
-
-    private function refreshToken(OAuthToken $expiredToken, ResourceOwnerInterface $resourceOwner): OAuthToken
-    {
-        if (!$expiredToken->getRefreshToken()) {
-            return $expiredToken;
-        }
-
-        $token = new OAuthToken($resourceOwner->refreshAccessToken($expiredToken->getRefreshToken()));
-        $token->setRefreshToken($expiredToken->getRefreshToken());
-
-        return $token;
     }
 
     private function extractCsrfTokenFromState(?string $stateParameter): ?string

--- a/Security/Http/Authenticator/Passport/SelfValidatedOAuthPassport.php
+++ b/Security/Http/Authenticator/Passport/SelfValidatedOAuthPassport.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Security\Http\Authenticator\Passport;
+
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+/**
+ * SelfValidatingPassport contained OAuthToken.
+ */
+class SelfValidatedOAuthPassport extends SelfValidatingPassport
+{
+    private OAuthToken $token;
+
+    /**
+     * Token already contains authenticated user. No need to create trivial UserBadge outside.
+     *
+     * @param BadgeInterface[] $badges
+     */
+    public function __construct(OAuthToken $token, array $badges = [])
+    {
+        $this->token = $token;
+
+        $user = $token->getUser();
+
+        $userBadge = class_exists(UserBadge::class)
+            ? new UserBadge(
+                method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername(),
+                static function () use ($user) { return $user; }
+            )
+            : $user;
+
+        parent::__construct($userBadge, $badges);
+    }
+
+    public function getToken(): OAuthToken
+    {
+        return $this->token;
+    }
+}

--- a/Tests/Fixtures/CustomOAuthToken.php
+++ b/Tests/Fixtures/CustomOAuthToken.php
@@ -11,14 +11,15 @@
 
 namespace HWI\Bundle\OAuthBundle\Tests\Fixtures;
 
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 
 final class CustomOAuthToken extends OAuthToken
 {
-    public function __construct()
+    public function __construct(array $accessToken = [])
     {
         parent::__construct(
-            [
+            $accessToken + [
                 'access_token' => 'access_token_data',
             ],
             [
@@ -27,5 +28,16 @@ final class CustomOAuthToken extends OAuthToken
         );
 
         $this->setUser(new User());
+    }
+
+    public function copyPersistentDataFrom(AbstractOAuthToken $token): void
+    {
+        if ($token instanceof self) {
+            if ($token->hasAttribute('persistent_key')) {
+                $this->setAttribute('persistent_key', $token->getAttribute('persistent_key'));
+            }
+        }
+
+        parent::copyPersistentDataFrom($token);
     }
 }


### PR DESCRIPTION
With the new authentication manager the access token could not be refreshed by a request listener without copying part of the code from the OAuthAuthenticator. I had reviewed authenticator and:

1. made a public method refreshToken. Using DI I can now pass authenticator in every function/listener, get new token and replace them in token storage.
2. Because we already have in `authenticate()` function a ready to use `OAuthToken`, I have extended SelfValidatedPassport and pass token to them instead of a UserBadge.
3. It is also possible to implement a kind of RememberMe function but with an `OAuthRememberMeToken`. You can store resource owner name and refresh_token with unlimited lifetime (usually you can get it with scope `offline`) in the db and get a new access token every time without asking credentials. `OAuthRememberMeToken` is the same like `OAuthToken` (will expired, refreshed etc), but has an string $series property, which must be always copied from the expired token to a new one, that's why I have permitted myself to add `copyPersistentDataTo(self $token): void` to `OAuthToken`.
<img width="309" alt="rememberme" src="https://user-images.githubusercontent.com/2382015/144720601-c9a6145e-3729-4266-91a3-3225c5a500c5.png">

Feel free to ask or suggest something.