### PR TITLE
Bugfix | Restore wrongly moved `AbstractOAuthToken::getCredentials()`

### DIFF
--- a/Security/Core/Authentication/Token/AbstractOAuthToken.php
+++ b/Security/Core/Authentication/Token/AbstractOAuthToken.php
@@ -116,6 +116,14 @@ abstract class AbstractOAuthToken extends AbstractToken
     }
 
     /**
+     * @return mixed|void
+     */
+    public function getCredentials()
+    {
+        return '';
+    }
+
+    /**
      * @param string $accessToken The OAuth access token
      */
     public function setAccessToken($accessToken)

--- a/Security/Core/Authentication/Token/OAuthToken.php
+++ b/Security/Core/Authentication/Token/OAuthToken.php
@@ -13,10 +13,4 @@ namespace HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token;
 
 class OAuthToken extends AbstractOAuthToken
 {
-    /**
-     * @return mixed|void
-     */
-    public function getCredentials()
-    {
-    }
 }


### PR DESCRIPTION
Closes #1840.