### PR TITLE
auto refresh oauth2 token on expire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 ## 2.0.0-BETA2 (202x-xx-xx)
+* Added: Ability to automatically refresh expired access tokens (only for derived from `GenericOAuth2ResourceOwner` resource owners), if option `refresh_on_expire` set to `true`.
 * Enhancement: (@internal) Removed/replaced redundant argument `$firewallNames` from controllers. If controller class was copied and replaced, adapt list of arguments: In controller use `$resourceOwnerMapLocator->getFirewallNames()`.
 * Changed config files from `*.xml` to `*.php` (services and routes). Xml routing configs `connect.xml`, `login.xml` and `redirect.xml` are steel present but deprecated. Please use `*.php` variants in your includes instead.
 

--- a/docs/2-configuring_resource_owners.md
+++ b/docs/2-configuring_resource_owners.md
@@ -95,6 +95,10 @@ This will be round-tripped to your application in the `state` parameter.
 Other types of state can be configured under the `state` key, either as a single string or key/value pairs. State can
 also be passed directly in the `state` query parameter of your request, provided they don't override the configured keys
 and are json and base64 encoded, as can be seen in `OAuth/State/State`.
+
+### Auto refreshing of expired access tokens
+This option is experimental and can be enabled for `GenericOAuth2ResourceOwner` with option `refresh_on_expire: true`
+
 ```yaml
 # config/package/hwi_oauth.yaml
 hwi_oauth:
@@ -105,6 +109,7 @@ hwi_oauth:
             client_secret:       <client_secret>
             options:
                 csrf: true
+                refresh_on_expire: true
                 state: 
                   some: parameter
                   some-other: parameter

--- a/src/DependencyInjection/CompilerPass/RefreshOAuthTokenCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/RefreshOAuthTokenCompilerPass.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * For Symfony 4.4 only
+ * Adds already registered by OAuthFactory RefreshAccessTokenListenerOld to security.firewall.map.context.
+ * It's taking control immediately after token was passed from session to token storage.
+ */
+class RefreshOAuthTokenCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getDefinitions() as $listenerId => $listenerDef) {
+            if (0 === strpos($listenerId, 'hwi_oauth.context_listener.token_refresher.')) {
+                $firewallName = substr($listenerId, 43);
+                $firewallMapContextId = 'security.firewall.map.context.'.$firewallName;
+
+                if ($container->has($firewallMapContextId)) {
+                    $firewallMapContextDef = $container->getDefinition($firewallMapContextId);
+                    /* @var IteratorArgument $listenersIter */
+                    $listenerIter = $firewallMapContextDef->getArgument(0);
+
+                    $listenerRefs = $listenerIter->getValues();
+                    // add listener after security.context_listener.X
+                    for ($pos = 0; $pos < \count($listenerRefs); ++$pos) {
+                        if (0 === strpos($listenerRefs[$pos], 'security.context_listener.')) {
+                            array_splice($listenerRefs, $pos + 1, 0, [new Reference($listenerId)]);
+                            break;
+                        }
+                    }
+                    $listenerIter->setValues($listenerRefs);
+                }
+            }
+        }
+    }
+}

--- a/src/HWIOAuthBundle.php
+++ b/src/HWIOAuthBundle.php
@@ -11,6 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle;
 
+use HWI\Bundle\OAuthBundle\DependencyInjection\CompilerPass\RefreshOAuthTokenCompilerPass;
 use HWI\Bundle\OAuthBundle\DependencyInjection\CompilerPass\ResourceOwnerMapCompilerPass;
 use HWI\Bundle\OAuthBundle\DependencyInjection\HWIOAuthExtension;
 use HWI\Bundle\OAuthBundle\DependencyInjection\Security\Factory\OAuthAuthenticatorFactory;
@@ -42,6 +43,7 @@ class HWIOAuthBundle extends Bundle
         } elseif (interface_exists(AuthenticationProviderInterface::class)) {
             // @phpstan-ignore-next-line Symfony 4.4 BC layer
             $extension->addSecurityListenerFactory(new OAuthFactory());
+            $container->addCompilerPass(new RefreshOAuthTokenCompilerPass());
         } else {
             // @phpstan-ignore-next-line Symfony < 5.4 BC layer
             $extension->addSecurityListenerFactory(new OAuthAuthenticatorFactory());

--- a/src/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/src/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -170,6 +170,14 @@ abstract class GenericOAuth2ResourceOwner extends AbstractResourceOwner
     /**
      * {@inheritdoc}
      */
+    public function shouldRefreshOnExpire()
+    {
+        return $this->options['refresh_on_expire'] ?? false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function doGetTokenRequest($url, array $parameters = [])
     {
         $headers = [];
@@ -225,9 +233,11 @@ abstract class GenericOAuth2ResourceOwner extends AbstractResourceOwner
             'use_commas_in_scope' => false,
             'use_bearer_authorization' => true,
             'use_authorization_to_get_token' => true,
+            'refresh_on_expire' => false,
         ]);
 
         $resolver->setDefined('revoke_token_url');
+        $resolver->setAllowedValues('refresh_on_expire', [true, false]);
 
         // Unfortunately some resource owners break the spec by using commas instead
         // of spaces to separate scopes (Disqus, Facebook, Github, Vkontante)

--- a/src/Resources/config/oauth.php
+++ b/src/Resources/config/oauth.php
@@ -18,6 +18,7 @@ use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Provider\OAuthProvider;
 use HWI\Bundle\OAuthBundle\Security\Core\User\EntityUserProvider;
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUserProvider;
 use HWI\Bundle\OAuthBundle\Security\Http\EntryPoint\OAuthEntryPoint;
+use HWI\Bundle\OAuthBundle\Security\Http\Firewall\AbstractRefreshAccessTokenListener;
 use HWI\Bundle\OAuthBundle\Security\Http\Firewall\OAuthListener;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 
@@ -40,6 +41,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set('hwi_oauth.user.provider.entity', EntityUserProvider::class)
         ->args([service('doctrine')]);
+
+    $services->set('hwi_oauth.context_listener.abstract_token_refresher', AbstractRefreshAccessTokenListener::class)
+        ->abstract()
+        ->arg(0, \function_exists(__NAMESPACE__.'\abstract_arg')
+            ? abstract_arg('OAuthAuthenticator or AuthenticationProviderInterface')
+            : null // Symfony 4.4
+        )
+        ->call('setTokenStorage', [service('security.token_storage')]);
 
     // Session storage
     $services->set('hwi_oauth.storage.session', SessionStorage::class)

--- a/src/Security/Http/Firewall/AbstractRefreshAccessTokenListener.php
+++ b/src/Security/Http/Firewall/AbstractRefreshAccessTokenListener.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Security\Http\Firewall;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Firewall\AbstractListener;
+
+abstract class AbstractRefreshAccessTokenListener extends AbstractListener
+{
+    protected TokenStorageInterface $tokenStorage;
+
+    protected ResourceOwnerMap $resourceOwnerMap;
+
+    public function setTokenStorage(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    public function setResourceOwnerMap(ResourceOwnerMap $resourceOwnerMap)
+    {
+        $this->resourceOwnerMap = $resourceOwnerMap;
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        return null;
+    }
+
+    public function authenticate(RequestEvent $event)
+    {
+        if (null === $token = $this->tokenStorage->getToken()) {
+            return;
+        }
+
+        if (!$token instanceof OAuthToken) {
+            return;
+        }
+
+        if (false === $token->isExpired()) {
+            return;
+        }
+
+        $resourceOwner = $this->resourceOwnerMap->getResourceOwnerByName($token->getResourceOwnerName());
+
+        if (!$resourceOwner instanceof GenericOAuth2ResourceOwner) {
+            return;
+        }
+
+        if (!$resourceOwner->shouldRefreshOnExpire()) {
+            return;
+        }
+
+        // here not clear what were better,
+        // * silent stop or
+        // * a logger with a notice or
+        // * force user to logout
+        if (!$token->getRefreshToken()) {
+            return;
+        }
+
+        try {
+            $newToken = $this->refreshToken($token);
+        } catch (AuthenticationException $e) {
+            $newToken = null;
+        }
+
+        $this->tokenStorage->setToken($newToken);
+    }
+
+    /**
+     * @template T of OAuthToken
+     *
+     * @param T $token
+     *
+     * @return T
+     */
+    abstract protected function refreshToken(OAuthToken $token): OAuthToken;
+}

--- a/src/Security/Http/Firewall/RefreshAccessTokenListener.php
+++ b/src/Security/Http/Firewall/RefreshAccessTokenListener.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Security\Http\Firewall;
+
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Http\Authenticator\OAuthAuthenticator;
+
+class RefreshAccessTokenListener extends AbstractRefreshAccessTokenListener
+{
+    private OAuthAuthenticator $oAuthAuthenticator;
+
+    public function __construct(
+        OAuthAuthenticator $oAuthAuthenticator
+    ) {
+        $this->oAuthAuthenticator = $oAuthAuthenticator;
+    }
+
+    /**
+     * @template T of OAuthToken
+     *
+     * @param T $token
+     *
+     * @return T
+     */
+    protected function refreshToken(OAuthToken $token): OAuthToken
+    {
+        return $this->oAuthAuthenticator->refreshToken($token);
+    }
+}

--- a/src/Security/Http/Firewall/RefreshAccessTokenListenerOld.php
+++ b/src/Security/Http/Firewall/RefreshAccessTokenListenerOld.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Security\Http\Firewall;
+
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
+
+class RefreshAccessTokenListenerOld extends RefreshAccessTokenListener
+{
+    private AuthenticationProviderInterface $oAuthProvider;
+
+    public function __construct(
+        AuthenticationProviderInterface $oAuthProvider
+    ) {
+        $this->oAuthProvider = $oAuthProvider;
+    }
+
+    /**
+     * @template T of OAuthToken
+     *
+     * @param T $token
+     *
+     * @return T
+     */
+    protected function refreshToken(OAuthToken $token): OAuthToken
+    {
+        // @phpstan-ignore-next-line returns TokenInterface instead of OAuthToken
+        return $this->oAuthProvider->authenticate($token);
+    }
+}

--- a/tests/App/Controller/HomeController.php
+++ b/tests/App/Controller/HomeController.php
@@ -32,4 +32,9 @@ final class HomeController
     {
         return new Response('Hello, this is the homepage');
     }
+
+    public function privatePage(): Response
+    {
+        return new Response('Hello, this is some private homepage');
+    }
 }

--- a/tests/App/config/routing.yaml
+++ b/tests/App/config/routing.yaml
@@ -14,6 +14,10 @@ home:
     path:  /
     defaults: { _controller: 'HWI\Bundle\OAuthBundle\Tests\App\Controller\HomeController::index' }
 
+private_page:
+    path:  /private
+    defaults: { _controller: 'HWI\Bundle\OAuthBundle\Tests\App\Controller\HomeController::privatePage' }
+
 login_landing:
     path:  /login
     defaults: { _controller: 'HWI\Bundle\OAuthBundle\Tests\App\Controller\HomeController::login' }

--- a/tests/App/config/security_v4.yaml
+++ b/tests/App/config/security_v4.yaml
@@ -13,6 +13,7 @@ security:
       context: hwi_context
     main:
       pattern: ^/
+      anonymous: true
       oauth:
         resource_owners:
           google: "/check-login/google"
@@ -25,4 +26,4 @@ security:
       context: hwi_context
 
   access_control:
-    - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/private, roles: ROLE_USER }

--- a/tests/App/config/security_v5.yaml
+++ b/tests/App/config/security_v5.yaml
@@ -24,4 +24,5 @@ security:
 
   access_control:
     - { path: '^/(login$|connect|login_hwi)', roles: PUBLIC_ACCESS }
-    - { path: ^/, roles: ROLE_USER }
+    - { path: ^/private, roles: ROLE_USER }
+    - { path: ^/, roles: PUBLIC_ACCESS }

--- a/tests/App/config/security_v5_bc.yaml
+++ b/tests/App/config/security_v5_bc.yaml
@@ -15,6 +15,7 @@ security:
       context: hwi_context
     main:
       pattern: ^/
+      anonymous: true
       oauth:
         resource_owners:
           google: "/check-login/google"
@@ -27,4 +28,4 @@ security:
       context: hwi_context
 
   access_control:
-    - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/private, roles: ROLE_USER }

--- a/tests/App/config/security_v6.yaml
+++ b/tests/App/config/security_v6.yaml
@@ -24,4 +24,5 @@ security:
 
   access_control:
     - { path: '^/(login$|connect|login_hwi)', roles: PUBLIC_ACCESS }
-    - { path: ^/, roles: ROLE_USER }
+    - { path: ^/private, roles: ROLE_USER }
+    - { path: ^/, roles: PUBLIC_ACCESS }

--- a/tests/Functional/IntegrationTest.php
+++ b/tests/Functional/IntegrationTest.php
@@ -31,7 +31,7 @@ final class IntegrationTest extends WebTestCase
         $client = static::createClient();
         $client->disableReboot();
         $client->getContainer()->set('hwi_oauth.http_client', new MockHttpClient());
-        $client->request('GET', '/');
+        $client->request('GET', '/private');
 
         $response = $client->getResponse();
 

--- a/tests/Security/Http/RefreshOnExpireTest.php
+++ b/tests/Security/Http/RefreshOnExpireTest.php
@@ -1,0 +1,216 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\Security\Http;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner;
+use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
+use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
+use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
+use HWI\Bundle\OAuthBundle\Tests\Functional\AuthenticationHelperTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\HttpUtils;
+
+/**
+ * @group legacy
+ */
+class RefreshOnExpireTest extends WebTestCase
+{
+    use AuthenticationHelperTrait;
+
+    private KernelBrowser $client;
+
+    private MockObject $resourceOwnerMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = static::createClient();
+
+        $container = $this->client->getContainer();
+
+        $this->createResourceOwnerMock($container);
+    }
+
+    public function testTokenIsValid()
+    {
+        $token = $this->loginUserWithToken([
+            'expires' => 666,
+            'refresh_token' => 'refresh_token',
+        ]);
+
+        $this->resourceOwnerMock->expects($this->never())->method('refreshAccessToken');
+
+        $this->client->request('GET', '/');
+
+        $this->assertResponseIsSuccessful();
+        /** @var CustomOAuthToken $newToken */
+        $newToken = $this->getCurrentToken();
+        $this->assertInstanceOf(CustomOAuthToken::class, $newToken);
+        $this->assertEquals($token->getCreatedAt(), $newToken->getCreatedAt());
+    }
+
+    public function testTokenIsExpiredSuccessfulRefresh()
+    {
+        $token = $this->loginUserWithToken([
+            'expires' => 20,
+            'refresh_token' => 'refresh_token',
+        ]);
+
+        $this->resourceOwnerMock->expects($this->once())
+            ->method('refreshAccessToken')
+            ->willReturn([
+               'expires' => 666, // expired
+               'refresh_token' => 'refresh_token',
+           ]);
+
+        $this->resourceOwnerMock->expects($this->once())
+            ->method('getUserInformation')
+            ->willReturn(new PathUserResponse());
+
+        $this->client->request('GET', '/');
+
+        $this->assertResponseIsSuccessful();
+        /** @var CustomOAuthToken $newToken */
+        $newToken = $this->getCurrentToken();
+        $this->assertInstanceOf(CustomOAuthToken::class, $newToken);
+        $this->assertNotEquals($token->getCreatedAt(), $newToken->getCreatedAt()); // token refreshed
+    }
+
+    public function testTokenIsExpiredForwardToLogin()
+    {
+        $this->loginUserWithToken([
+            'expires' => 20, // expired
+            'refresh_token' => 'refresh_token',
+        ]);
+
+        $this->resourceOwnerMock->expects($this->once())
+            ->method('refreshAccessToken')
+            ->willThrowException(new AuthenticationException());
+
+        $this->resourceOwnerMock->expects($this->never())
+            ->method('getUserInformation');
+
+        $this->client->request('GET', '/private');
+
+        $this->assertResponseRedirects('http://localhost/login');
+        $newToken = $this->getCurrentToken();
+        $this->assertUserNotLogged($newToken);
+    }
+
+    public function testTokenIsExpiredSeamlessLogout()
+    {
+        $this->loginUserWithToken([
+            'expires' => 20, // expired
+            'refresh_token' => 'refresh_token',
+        ]);
+
+        $this->resourceOwnerMock->expects($this->once())
+            ->method('refreshAccessToken')
+            ->willThrowException(new AuthenticationException());
+
+        $this->resourceOwnerMock->expects($this->never())
+            ->method('getUserInformation');
+
+        $this->client->request('GET', '/');
+
+        $this->assertResponseIsSuccessful();
+        $newToken = $this->getCurrentToken();
+        $this->assertUserNotLogged($newToken);
+    }
+
+    public function testDoNotTryRefreshIfTokenDoesNotContainsIt()
+    {
+        $token = $this->loginUserWithToken([
+            'expires' => 20, // expired
+            'refresh_token' => null,
+        ]);
+
+        $this->resourceOwnerMock->expects($this->never())
+            ->method('refreshAccessToken');
+
+        $this->resourceOwnerMock->expects($this->never())
+            ->method('getUserInformation');
+
+        $this->client->request('GET', '/');
+
+        $this->assertResponseIsSuccessful();
+        /** @var CustomOAuthToken $newToken */
+        $newToken = $this->getCurrentToken();
+        $this->assertInstanceOf(CustomOAuthToken::class, $newToken);
+        $this->assertEquals($token->getCreatedAt(), $newToken->getCreatedAt());
+    }
+
+    private function createResourceOwnerMock(ContainerInterface $container)
+    {
+        $this->resourceOwnerMock = $this->createMock(GenericOAuth2ResourceOwner::class);
+        $this->resourceOwnerMock->method('shouldRefreshOnExpire')->willReturn(true);
+
+        $serviceLocatorMock = $this->createMock(ServiceLocator::class);
+        $serviceLocatorMock->method('get')->willReturn($this->resourceOwnerMock);
+
+        $resourceOwnerMap = new ResourceOwnerMap(
+            $this->getHttpUtilsMock(),
+            ['google' => '/fake'],
+            ['google' => '/fake'],
+            $serviceLocatorMock
+        );
+
+        $container->set('hwi_oauth.resource_ownermap.main', $resourceOwnerMap);
+    }
+
+    private function loginUserWithToken(array $tokenData): CustomOAuthToken
+    {
+        $session = $this->getSession($this->client);
+
+        $token = new CustomOAuthToken($tokenData);
+        $token->setResourceOwnerName('google');
+        if (method_exists($token, 'setAuthenticated')) {
+            $token->setAuthenticated(true, false);
+        }
+        // if createdAt of 2 tokens is the same, the token was not refreshed either
+        $token->setCreatedAt(time() - 1);
+
+        $session->set('_security_hwi_context', serialize($token));
+        $this->saveSession($this->client, $session);
+
+        return $token;
+    }
+
+    private function getHttpUtilsMock(): HttpUtils
+    {
+        return $this->createMock(HttpUtils::class);
+    }
+
+    /**
+     * @return TokenInterface|CustomOAuthToken|null
+     */
+    private function getCurrentToken(): ?TokenInterface
+    {
+        return $this->client->getContainer()->get('security.token_storage')->getToken();
+    }
+
+    private function assertUserNotLogged(?TokenInterface $newToken, string $message = ''): void
+    {
+        $this->assertTrue(
+            null === $newToken || class_exists(AnonymousToken::class) && $newToken instanceof AnonymousToken,
+            $message
+        );
+    }
+}


### PR DESCRIPTION
Please take a look to my implementation of auto-refresh-expired-token functionality.

During creating of Authenticator/Provider will also created a listener that fires after OAuthToken was set from session to token storage. This is the best moment to refresh or invalidate the token, because it fires before the symfony's access control listener.
If the old token could not be refreshed user will be seamless logged out, on a private page the user is redirected to login page.

If PR accepted I will also add listener to symfony 4.4 and write some tests.