### PR TITLE
Allow null User for refreshing oauth token

### DIFF
--- a/src/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/src/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -135,12 +135,16 @@ final class OAuthProvider implements AuthenticationProviderInterface
     private function createOAuthToken(
         $data,
         OAuthToken $oldToken,
-        UserInterface $user
+        ?UserInterface $user
     ): OAuthToken {
         $tokenClass = \get_class($oldToken);
-        $token = new $tokenClass($data, $user->getRoles());
+        if (null !== $user) {
+            $token = new $tokenClass($data, $user->getRoles());
+            $token->setUser($user);
+        } else {
+            $token = new $tokenClass($data);
+        }
         $token->setResourceOwnerName($oldToken->getResourceOwnerName());
-        $token->setUser($user);
         $token->setCreatedAt($oldToken->isExpired() ? time() : $oldToken->getCreatedAt());
 
         // required for compatibility with Symfony 5.4


### PR DESCRIPTION
It should be possible to refresh access token using only a valid refresh token without infos about owner.
I need it for my "OAuthRememberMeToken". Probably it is needed also for #1825

P.S. I have used it for couple of month in my own OAuthProvirder (I had to replace the default one for this small changes hier and in merged #1849)