### PR TITLE
Review: Removed/replaced redundant parameter $firewallNames  in Controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 ## 2.0.0-BETA2 (202x-xx-xx)
+* Enhancement: (@internal) Removed/replaced redundant argument `$firewallNames` from controllers. If controller class was copied and replaced, adapt list of arguments: In controller use `$resourceOwnerMapLocator->getFirewallNames()`.
 * Changed config files from `*.xml` to `*.php` (services and routes). Xml routing configs `connect.xml`, `login.xml` and `redirect.xml` are steel present but deprecated. Please use `*.php` variants in your includes instead.
 
 ## 2.0.0-BETA1 (2021-12-10)

--- a/src/Controller/ConnectController.php
+++ b/src/Controller/ConnectController.php
@@ -67,12 +67,8 @@ final class ConnectController
     private bool $failedUseReferer;
     private string $failedAuthPath;
     private bool $enableConnectConfirmation;
-    private array $firewallNames;
     private string $registrationForm;
 
-    /**
-     * @param string[] $firewallNames
-     */
     public function __construct(
         OAuthUtils $oauthUtils,
         ResourceOwnerMapLocator $resourceOwnerMapLocator,
@@ -88,7 +84,6 @@ final class ConnectController
         bool $failedUseReferer,
         string $failedAuthPath,
         bool $enableConnectConfirmation,
-        array $firewallNames,
         string $registrationForm,
         ?AccountConnectorInterface $accountConnector,
         ?RegistrationFormHandlerInterface $formHandler
@@ -100,7 +95,6 @@ final class ConnectController
         $this->failedUseReferer = $failedUseReferer;
         $this->failedAuthPath = $failedAuthPath;
         $this->enableConnectConfirmation = $enableConnectConfirmation;
-        $this->firewallNames = $firewallNames;
         $this->registrationForm = $registrationForm;
         $this->dispatcher = $dispatcher;
         $this->accountConnector = $accountConnector;
@@ -291,12 +285,7 @@ final class ConnectController
      */
     private function getResourceOwnerByName(string $name): ResourceOwnerInterface
     {
-        foreach ($this->firewallNames as $firewall) {
-            if (!$this->resourceOwnerMapLocator->has($firewall)) {
-                continue;
-            }
-
-            $ownerMap = $this->resourceOwnerMapLocator->get($firewall);
+        foreach ($this->resourceOwnerMapLocator->getResourceOwnerMaps() as $ownerMap) {
             if ($resourceOwner = $ownerMap->getResourceOwnerByName($name)) {
                 return $resourceOwner;
             }
@@ -346,8 +335,8 @@ final class ConnectController
             return null;
         }
 
-        foreach ($this->firewallNames as $providerKey) {
-            $sessionKey = '_security.'.$providerKey.'.target_path';
+        foreach ($this->resourceOwnerMapLocator->getFirewallNames() as $firewallName) {
+            $sessionKey = '_security.'.$firewallName.'.target_path';
             if ($session->has($sessionKey)) {
                 return $session->get($sessionKey);
             }

--- a/src/Controller/RedirectToServiceController.php
+++ b/src/Controller/RedirectToServiceController.php
@@ -11,6 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\Controller;
 
+use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapLocator;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use HWI\Bundle\OAuthBundle\Util\DomainWhitelist;
 use RuntimeException;
@@ -29,7 +30,7 @@ final class RedirectToServiceController
 {
     private OAuthUtils $oauthUtils;
     private DomainWhitelist $domainWhitelist;
-    private array $firewallNames;
+    private ResourceOwnerMapLocator $resourceOwnerMapLocator;
     private ?string $targetPathParameter = null;
     private bool $failedUseReferer;
     private bool $useReferer;
@@ -37,14 +38,14 @@ final class RedirectToServiceController
     public function __construct(
         OAuthUtils $oauthUtils,
         DomainWhitelist $domainWhitelist,
-        array $firewallNames,
+        ResourceOwnerMapLocator $resourceOwnerMapLocator,
         ?string $targetPathParameter,
         bool $failedUseReferer,
         bool $useReferer
     ) {
         $this->oauthUtils = $oauthUtils;
         $this->domainWhitelist = $domainWhitelist;
-        $this->firewallNames = $firewallNames;
+        $this->resourceOwnerMapLocator = $resourceOwnerMapLocator;
         $this->targetPathParameter = $targetPathParameter;
         $this->failedUseReferer = $failedUseReferer;
         $this->useReferer = $useReferer;
@@ -76,9 +77,9 @@ final class RedirectToServiceController
 
         $param = $this->targetPathParameter;
 
-        foreach ($this->firewallNames as $providerKey) {
-            $sessionKey = '_security.'.$providerKey.'.target_path';
-            $sessionKeyFailure = '_security.'.$providerKey.'.failed_target_path';
+        foreach ($this->resourceOwnerMapLocator->getFirewallNames() as $firewallName) {
+            $sessionKey = '_security.'.$firewallName.'.target_path';
+            $sessionKeyFailure = '_security.'.$firewallName.'.failed_target_path';
 
             if (!empty($param) && $targetUrl = $request->get($param)) {
                 if (!$this->domainWhitelist->isValidTargetUrl($targetUrl)) {

--- a/src/DependencyInjection/CompilerPass/ResourceOwnerMapCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/ResourceOwnerMapCompilerPass.php
@@ -28,7 +28,7 @@ final class ResourceOwnerMapCompilerPass implements CompilerPassInterface
         $def = $container->getDefinition('hwi_oauth.resource_ownermap_locator');
 
         foreach ($container->getParameter('hwi_oauth.firewall_names') as $firewallId) {
-            $def->addMethodCall('add', [$firewallId, new Reference('hwi_oauth.resource_ownermap.'.$firewallId)]);
+            $def->addMethodCall('set', [$firewallId, new Reference('hwi_oauth.resource_ownermap.'.$firewallId)]);
         }
     }
 }

--- a/src/Resources/config/controller.php
+++ b/src/Resources/config/controller.php
@@ -36,7 +36,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->arg('$failedUseReferer', '%hwi_oauth.failed_use_referer%')
         ->arg('$failedAuthPath', '%hwi_oauth.failed_auth_path%')
         ->arg('$enableConnectConfirmation', '%hwi_oauth.connect.confirmation%')
-        ->arg('$firewallNames', '%hwi_oauth.firewall_names%')
         ->arg('$registrationForm', '%hwi_oauth.connect.registration_form%')
         ->arg('$accountConnector', service('hwi_oauth.account.connector')->nullOnInvalid())
         ->arg('$formHandler', service('hwi_oauth.registration.form.handler')->nullOnInvalid());
@@ -58,7 +57,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service('hwi_oauth.security.oauth_utils'),
             service('hwi_oauth.util.domain_whitelist'),
-            '%hwi_oauth.firewall_names%',
+            service('hwi_oauth.resource_ownermap_locator'),
             '%hwi_oauth.target_path_parameter%',
             '%hwi_oauth.failed_use_referer%',
             '%hwi_oauth.use_referer%',

--- a/src/Security/Http/ResourceOwnerMapLocator.php
+++ b/src/Security/Http/ResourceOwnerMapLocator.php
@@ -17,22 +17,38 @@ namespace HWI\Bundle\OAuthBundle\Security\Http;
 final class ResourceOwnerMapLocator
 {
     /**
-     * @var array
+     * @var array<string, ResourceOwnerMapInterface>
      */
-    private $resourceOwnerMaps = [];
+    private array $resourceOwnerMaps = [];
 
-    public function add(string $firewallId, ResourceOwnerMapInterface $resourceOwnerMap): void
+    public function set(string $firewallName, ResourceOwnerMapInterface $resourceOwnerMap): void
     {
-        $this->resourceOwnerMaps[$firewallId] = $resourceOwnerMap;
+        $this->resourceOwnerMaps[$firewallName] = $resourceOwnerMap;
     }
 
-    public function has(string $firewallId): bool
+    public function has(string $firewallName): bool
     {
-        return isset($this->resourceOwnerMaps[$firewallId]);
+        return isset($this->resourceOwnerMaps[$firewallName]);
     }
 
-    public function get(string $firewallId): ResourceOwnerMapInterface
+    public function get(string $firewallName): ResourceOwnerMapInterface
     {
-        return $this->resourceOwnerMaps[$firewallId];
+        return $this->resourceOwnerMaps[$firewallName];
+    }
+
+    /**
+     * @return array<string, ResourceOwnerMapInterface>
+     */
+    public function getResourceOwnerMaps(): array
+    {
+        return $this->resourceOwnerMaps;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFirewallNames(): array
+    {
+        return array_keys($this->resourceOwnerMaps);
     }
 }

--- a/tests/Controller/AbstractConnectControllerTest.php
+++ b/tests/Controller/AbstractConnectControllerTest.php
@@ -131,8 +131,9 @@ abstract class AbstractConnectControllerTest extends TestCase
         $this->resourceOwnerMap = $this->createMock(ResourceOwnerMapInterface::class);
         $this->resourceOwnerMap->expects($this->any())
             ->method('getResourceOwnerByName')
-            ->with('facebook')
-            ->willReturn($this->resourceOwner);
+            ->willReturnCallback(function ($owner) {
+                return 'facebook' === $owner ? $this->resourceOwner : null;
+            });
 
         $this->oAuthUtils = new OAuthUtils(
             $this->createMock(HttpUtils::class),
@@ -142,7 +143,7 @@ abstract class AbstractConnectControllerTest extends TestCase
         );
 
         $this->resourceOwnerMapLocator = new ResourceOwnerMapLocator();
-        $this->resourceOwnerMapLocator->add('default', $this->resourceOwnerMap);
+        $this->resourceOwnerMapLocator->set('default', $this->resourceOwnerMap);
 
         $this->formFactory = $this->createMock(FormFactoryInterface::class);
 
@@ -171,8 +172,7 @@ abstract class AbstractConnectControllerTest extends TestCase
 
     protected function createConnectController(
         bool $connectEnabled = true,
-        bool $confirmConnect = true,
-        array $firewallNames = ['default']
+        bool $confirmConnect = true
     ): ConnectController {
         return new ConnectController(
             $this->oAuthUtils,
@@ -189,7 +189,6 @@ abstract class AbstractConnectControllerTest extends TestCase
             true,
             'fake_route',
             $confirmConnect,
-            $firewallNames,
             RegistrationFormType::class,
             $connectEnabled ? $this->accountConnector : null,
             $connectEnabled ? $this->registrationFormHandler : null

--- a/tests/Controller/ConnectControllerConnectServiceActionTest.php
+++ b/tests/Controller/ConnectControllerConnectServiceActionTest.php
@@ -46,7 +46,7 @@ final class ConnectControllerConnectServiceActionTest extends AbstractConnectCon
 
         $this->mockAuthorizationCheck();
 
-        $controller = $this->createConnectController(true, true, []);
+        $controller = $this->createConnectController(true, true);
         $controller->connectServiceAction($this->request, 'unknown');
     }
 

--- a/tests/Controller/RedirectToServiceControllerTest.php
+++ b/tests/Controller/RedirectToServiceControllerTest.php
@@ -16,6 +16,7 @@ namespace HWI\Bundle\OAuthBundle\Tests\Controller;
 use HWI\Bundle\OAuthBundle\Controller\RedirectToServiceController;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapInterface;
+use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapLocator;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use HWI\Bundle\OAuthBundle\Util\DomainWhitelist;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -35,8 +36,6 @@ final class RedirectToServiceControllerTest extends TestCase
     private $session;
 
     private Request $request;
-
-    private array $firewallNames = ['default'];
 
     private string $targetPathParameter = 'target_path';
 
@@ -135,6 +134,9 @@ final class RedirectToServiceControllerTest extends TestCase
             ->withAnyParameters()
             ->willReturn('https://domain.com/oauth/v2/auth');
 
+        $resourceOwnerMapLocator = new ResourceOwnerMapLocator();
+        $resourceOwnerMapLocator->set('default', $ownerMap);
+
         $utils = new OAuthUtils(
             $this->createMock(HttpUtils::class),
             $this->createMock(AuthorizationCheckerInterface::class),
@@ -146,7 +148,7 @@ final class RedirectToServiceControllerTest extends TestCase
         return new RedirectToServiceController(
             $utils,
             new DomainWhitelist(['domain.com']),
-            $this->firewallNames,
+            $resourceOwnerMapLocator,
             $this->targetPathParameter,
             $failedUseReferer,
             $useReferer


### PR DESCRIPTION
Two controllers have this parameter in their constructor, although they can be found in $resourceOwnerMapLocator.
I think rather $resourceOwnerMapLocator is a primary source for this.