### PR TITLE
RFC. Fully customizable oauth token class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 ## 2.0.0-BETA2 (202x-xx-xx)
+* Enhancement: Fully customizable OAuth token class (resource owner's optional option `token_class`). it should only be extended from AbstractOAuthToken. Default is `OAuthToken`.
 * Enhancement: Refresh token listener is disabled by default and will only be enabled if at least one resource owner has option `refresh_on_expure` set to `true`
 * Deprecated: configuration parameter `firewall_names`, firewalls are now computed automatically - all firewalls that have defined `oauth` authenticator/provider will be collected. 
 * Added: Ability to automatically refresh expired access tokens (only for derived from `GenericOAuth2ResourceOwner` resource owners), if option `refresh_on_expire` set to `true`.

--- a/docs/internals/external_resource_owner.md
+++ b/docs/internals/external_resource_owner.md
@@ -55,6 +55,7 @@ resource_owners:
         client_id:      '%oauth.your_provider.client_id%'
         client_secret:  '%oauth.your_provider.client_secret%'
         scope:          '%oauth.your_provider.scope%'
+        token_class:    ~ # default is OAuthToken
 ```
 
 That's all folks!

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\DependencyInjection;
 
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -252,6 +253,18 @@ final class Configuration implements ConfigurationInterface
                                         return empty($v);
                                     })
                                     ->thenUnset()
+                                ->end()
+                            ->end()
+                            ->scalarNode('token_class')
+                                ->validate()
+                                    ->ifNull()
+                                    ->thenUnset()
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(static function ($className) {
+                                        return !is_subclass_of($className, AbstractOAuthToken::class, true);
+                                    })
+                                    ->thenInvalid('Token class should be extended from HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken, %s given.')
                                 ->end()
                             ->end()
                             ->scalarNode('service')

--- a/src/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/src/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -18,6 +18,7 @@ use HWI\Bundle\OAuthBundle\OAuth\Response\PathUserResponse;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use HWI\Bundle\OAuthBundle\OAuth\State\State;
 use HWI\Bundle\OAuthBundle\OAuth\StateInterface;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\OptionsResolver\Exception\AccessException;
@@ -168,6 +169,14 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
         }
 
         $this->storage->save($this, $state, 'state');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTokenClass(): string
+    {
+        return $this->options['token_class'] ?? OAuthToken::class;
     }
 
     /**
@@ -338,6 +347,7 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
             'csrf' => false,
             'user_response_class' => PathUserResponse::class,
             'auth_with_one_url' => false,
+            'token_class' => null,
         ]);
 
         $resolver->setAllowedValues('csrf', [true, false]);

--- a/src/OAuth/ResourceOwner/AppleResourceOwner.php
+++ b/src/OAuth/ResourceOwner/AppleResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\OAuthErrorHandler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -62,7 +61,8 @@ final class AppleResourceOwner extends GenericOAuth2ResourceOwner
         $response = $this->getUserResponse();
         $response->setData(json_encode($data));
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $tokenClass = $this->getTokenClass();
+        $response->setOAuthToken(new $tokenClass($accessToken));
 
         return $response;
     }

--- a/src/OAuth/ResourceOwner/DropboxResourceOwner.php
+++ b/src/OAuth/ResourceOwner/DropboxResourceOwner.php
@@ -13,7 +13,6 @@ namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -63,7 +62,8 @@ final class DropboxResourceOwner extends GenericOAuth2ResourceOwner
             $response = $this->getUserResponse();
             $response->setData($content->toArray(false));
             $response->setResourceOwner($this);
-            $response->setOAuthToken(new OAuthToken($accessToken));
+            $tokenClass = $this->getTokenClass();
+            $response->setOAuthToken(new $tokenClass($accessToken));
 
             return $response;
         } catch (TransportExceptionInterface|JsonException $e) {

--- a/src/OAuth/ResourceOwner/FiwareResourceOwner.php
+++ b/src/OAuth/ResourceOwner/FiwareResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -83,7 +82,8 @@ final class FiwareResourceOwner extends GenericOAuth2ResourceOwner
         $response = $this->getUserResponse();
         $response->setData($content->getContent());
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $tokenClass = $this->getTokenClass();
+        $response->setOAuthToken(new $tokenClass($accessToken));
 
         return $response;
     }

--- a/src/OAuth/ResourceOwner/FlickrResourceOwner.php
+++ b/src/OAuth/ResourceOwner/FlickrResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -50,7 +49,8 @@ final class FlickrResourceOwner extends GenericOAuth1ResourceOwner
         $response = $this->getUserResponse();
         $response->setData($accessToken);
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $tokenClass = $this->getTokenClass();
+        $response->setOAuthToken(new $tokenClass($accessToken));
 
         return $response;
     }

--- a/src/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
+++ b/src/OAuth/ResourceOwner/GenericOAuth1ResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Helper\NonceGenerator;
 use HWI\Bundle\OAuthBundle\Security\OAuthErrorHandler;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
@@ -53,7 +52,8 @@ abstract class GenericOAuth1ResourceOwner extends AbstractResourceOwner
         $response = $this->getUserResponse();
         $response->setData($content->getContent());
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $tokenClass = $this->getTokenClass();
+        $response->setOAuthToken(new $tokenClass($accessToken));
 
         return $response;
     }

--- a/src/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/src/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Helper\NonceGenerator;
 use HWI\Bundle\OAuthBundle\Security\OAuthErrorHandler;
 use Symfony\Component\HttpClient\Exception\JsonException;
@@ -52,7 +51,8 @@ abstract class GenericOAuth2ResourceOwner extends AbstractResourceOwner
             $response = $this->getUserResponse();
             $response->setData($content->toArray(false));
             $response->setResourceOwner($this);
-            $response->setOAuthToken(new OAuthToken($accessToken));
+            $tokenClass = $this->getTokenClass();
+            $response->setOAuthToken(new $tokenClass($accessToken));
 
             return $response;
         } catch (TransportExceptionInterface|JsonException $e) {

--- a/src/OAuth/ResourceOwner/JiraResourceOwner.php
+++ b/src/OAuth/ResourceOwner/JiraResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Helper\NonceGenerator;
 use HWI\Bundle\OAuthBundle\Security\OAuthUtils;
 use Symfony\Component\OptionsResolver\Options;
@@ -78,7 +77,8 @@ final class JiraResourceOwner extends GenericOAuth1ResourceOwner
             $response = $this->getUserResponse();
             $response->setData($content->getContent(false));
             $response->setResourceOwner($this);
-            $response->setOAuthToken(new OAuthToken($accessToken));
+            $tokenClass = $this->getTokenClass();
+            $response->setOAuthToken(new $tokenClass($accessToken));
 
             return $response;
         } catch (TransportExceptionInterface $e) {

--- a/src/OAuth/ResourceOwner/MailRuResourceOwner.php
+++ b/src/OAuth/ResourceOwner/MailRuResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -57,7 +56,8 @@ final class MailRuResourceOwner extends GenericOAuth2ResourceOwner
             $response = $this->getUserResponse();
             $response->setData($content);
             $response->setResourceOwner($this);
-            $response->setOAuthToken(new OAuthToken($accessToken));
+            $tokenClass = $this->getTokenClass();
+            $response->setOAuthToken(new $tokenClass($accessToken));
 
             return $response;
         } catch (TransportExceptionInterface|JsonException $e) {

--- a/src/OAuth/ResourceOwner/OdnoklassnikiResourceOwner.php
+++ b/src/OAuth/ResourceOwner/OdnoklassnikiResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -69,7 +68,8 @@ final class OdnoklassnikiResourceOwner extends GenericOAuth2ResourceOwner
             $response = $this->getUserResponse();
             $response->setData($content);
             $response->setResourceOwner($this);
-            $response->setOAuthToken(new OAuthToken($accessToken));
+            $tokenClass = $this->getTokenClass();
+            $response->setOAuthToken(new $tokenClass($accessToken));
 
             return $response;
         } catch (TransportExceptionInterface|JsonException $e) {

--- a/src/OAuth/ResourceOwner/QQResourceOwner.php
+++ b/src/OAuth/ResourceOwner/QQResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -68,7 +67,8 @@ final class QQResourceOwner extends GenericOAuth2ResourceOwner
         $response = $this->getUserResponse();
         $response->setData($content);
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $tokenClass = $this->getTokenClass();
+        $response->setOAuthToken(new $tokenClass($accessToken));
 
         return $response;
     }

--- a/src/OAuth/ResourceOwner/SensioConnectResourceOwner.php
+++ b/src/OAuth/ResourceOwner/SensioConnectResourceOwner.php
@@ -13,7 +13,6 @@ namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
 use HWI\Bundle\OAuthBundle\OAuth\Response\SensioConnectUserResponse;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -39,7 +38,8 @@ final class SensioConnectResourceOwner extends GenericOAuth2ResourceOwner
             $response = $this->getUserResponse();
             $response->setData($content->getContent(false));
             $response->setResourceOwner($this);
-            $response->setOAuthToken(new OAuthToken($accessToken));
+            $tokenClass = $this->getTokenClass();
+            $response->setOAuthToken(new $tokenClass($accessToken));
 
             return $response;
         } catch (TransportExceptionInterface|JsonException $e) {

--- a/src/OAuth/ResourceOwner/SinaWeiboResourceOwner.php
+++ b/src/OAuth/ResourceOwner/SinaWeiboResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -45,7 +44,8 @@ final class SinaWeiboResourceOwner extends GenericOAuth2ResourceOwner
             $response = $this->getUserResponse();
             $response->setData($content->toArray(false));
             $response->setResourceOwner($this);
-            $response->setOAuthToken(new OAuthToken($accessToken));
+            $tokenClass = $this->getTokenClass();
+            $response->setOAuthToken(new $tokenClass($accessToken));
 
             return $response;
         } catch (TransportExceptionInterface|JsonException $e) {

--- a/src/OAuth/ResourceOwner/SpotifyResourceOwner.php
+++ b/src/OAuth/ResourceOwner/SpotifyResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -48,7 +47,8 @@ final class SpotifyResourceOwner extends GenericOAuth2ResourceOwner
             $response = $this->getUserResponse();
             $response->setData($content->toArray(false));
             $response->setResourceOwner($this);
-            $response->setOAuthToken(new OAuthToken($accessToken));
+            $tokenClass = $this->getTokenClass();
+            $response->setOAuthToken(new $tokenClass($accessToken));
 
             return $response;
         } catch (TransportExceptionInterface|JsonException $e) {

--- a/src/OAuth/ResourceOwner/StackExchangeResourceOwner.php
+++ b/src/OAuth/ResourceOwner/StackExchangeResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -49,7 +48,8 @@ final class StackExchangeResourceOwner extends GenericOAuth2ResourceOwner
             $response = $this->getUserResponse();
             $response->setData($content->toArray(false));
             $response->setResourceOwner($this);
-            $response->setOAuthToken(new OAuthToken($accessToken));
+            $tokenClass = $this->getTokenClass();
+            $response->setOAuthToken(new $tokenClass($accessToken));
 
             return $response;
         } catch (TransportExceptionInterface|JsonException $e) {

--- a/src/OAuth/ResourceOwner/StereomoodResourceOwner.php
+++ b/src/OAuth/ResourceOwner/StereomoodResourceOwner.php
@@ -11,7 +11,6 @@
 
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -32,7 +31,8 @@ final class StereomoodResourceOwner extends GenericOAuth1ResourceOwner
         $response = $this->getUserResponse();
         $response->setData($accessToken);
         $response->setResourceOwner($this);
-        $response->setOAuthToken(new OAuthToken($accessToken));
+        $tokenClass = $this->getTokenClass();
+        $response->setOAuthToken(new $tokenClass($accessToken));
 
         return $response;
     }

--- a/src/OAuth/ResourceOwner/TraktResourceOwner.php
+++ b/src/OAuth/ResourceOwner/TraktResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -48,7 +47,8 @@ final class TraktResourceOwner extends GenericOAuth2ResourceOwner
             $response = $this->getUserResponse();
             $response->setData($content->toArray(false));
             $response->setResourceOwner($this);
-            $response->setOAuthToken(new OAuthToken($accessToken));
+            $tokenClass = $this->getTokenClass();
+            $response->setOAuthToken(new $tokenClass($accessToken));
 
             return $response;
         } catch (TransportExceptionInterface|JsonException $e) {

--- a/src/OAuth/ResourceOwner/VkontakteResourceOwner.php
+++ b/src/OAuth/ResourceOwner/VkontakteResourceOwner.php
@@ -12,7 +12,6 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\ResourceOwner;
 
 use HWI\Bundle\OAuthBundle\OAuth\Exception\HttpTransportException;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -53,7 +52,8 @@ final class VkontakteResourceOwner extends GenericOAuth2ResourceOwner
         try {
             $response = $this->getUserResponse();
             $response->setResourceOwner($this);
-            $response->setOAuthToken(new OAuthToken($accessToken));
+            $tokenClass = $this->getTokenClass();
+            $response->setOAuthToken(new $tokenClass($accessToken));
 
             $content = $this->doGetUserInformationRequest($url)->toArray(false);
             $content['email'] = $accessToken['email'] ?? null;

--- a/src/OAuth/ResourceOwnerInterface.php
+++ b/src/OAuth/ResourceOwnerInterface.php
@@ -47,6 +47,13 @@ interface ResourceOwnerInterface
     public function getAuthorizationUrl($redirectUri, array $extraParameters = []);
 
     /**
+     * Gets oauth token class for this resource owner.
+     *
+     * @return class-string of AbstractOAuthToken
+     */
+    public function getTokenClass(): string;
+
+    /**
      * Retrieve an access token for a given code.
      *
      * @param HttpRequest $request         The request object where is going to extract the code from

--- a/src/OAuth/Response/AbstractUserResponse.php
+++ b/src/OAuth/Response/AbstractUserResponse.php
@@ -12,8 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\Response;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
-use JsonException;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
@@ -32,7 +31,7 @@ abstract class AbstractUserResponse implements UserResponseInterface
     protected $resourceOwner;
 
     /**
-     * @var OAuthToken
+     * @var AbstractOAuthToken
      */
     protected $oAuthToken;
 
@@ -87,7 +86,7 @@ abstract class AbstractUserResponse implements UserResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function setOAuthToken(OAuthToken $token)
+    public function setOAuthToken(AbstractOAuthToken $token)
     {
         $this->oAuthToken = $token;
     }
@@ -127,7 +126,7 @@ abstract class AbstractUserResponse implements UserResponseInterface
 
         try {
             $this->data = json_decode($data, true, 512, \JSON_THROW_ON_ERROR);
-        } catch (JsonException $exception) {
+        } catch (\JsonException $exception) {
             throw new AuthenticationException('Response is not a valid JSON code.');
         }
     }

--- a/src/OAuth/Response/UserResponseInterface.php
+++ b/src/OAuth/Response/UserResponseInterface.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\OAuth\Response;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResponseInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken;
 
 /**
  * @author Alexander <iam.asm89@gmail.com>
@@ -105,12 +105,12 @@ interface UserResponseInterface extends ResponseInterface
     /**
      * Set the raw token data from the request.
      */
-    public function setOAuthToken(OAuthToken $token);
+    public function setOAuthToken(AbstractOAuthToken $token);
 
     /**
      * Get the raw token data from the request.
      *
-     * @return OAuthToken
+     * @return AbstractOAuthToken
      */
     public function getOAuthToken();
 }

--- a/src/Security/Core/Authentication/Provider/OAuthProvider.php
+++ b/src/Security/Core/Authentication/Provider/OAuthProvider.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Security\Core\Authentication\Provider;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAwareExceptionInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthAwareUserProviderInterface;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapInterface;
@@ -51,7 +51,7 @@ final class OAuthProvider implements AuthenticationProviderInterface
      */
     public function supports(TokenInterface $token): bool
     {
-        if (!$token instanceof OAuthToken) {
+        if (!$token instanceof AbstractOAuthToken) {
             return false;
         }
 
@@ -68,7 +68,7 @@ final class OAuthProvider implements AuthenticationProviderInterface
         }
 
         // If token is authenticated, re-create it to reload user details
-        /** @var OAuthToken $token */
+        /** @var AbstractOAuthToken $token */
         if (!$token->isExpired() && null !== $token->getUser()) {
             /** @var UserInterface $user */
             $user = $token->getUser();
@@ -102,9 +102,9 @@ final class OAuthProvider implements AuthenticationProviderInterface
     }
 
     /**
-     * @param OAuthToken $expiredToken
+     * @param AbstractOAuthToken $expiredToken
      */
-    private function refreshToken(TokenInterface $expiredToken, ResourceOwnerInterface $resourceOwner): OAuthToken
+    private function refreshToken(TokenInterface $expiredToken, ResourceOwnerInterface $resourceOwner): AbstractOAuthToken
     {
         if (!$expiredToken->getRefreshToken()) {
             return $expiredToken;
@@ -125,7 +125,7 @@ final class OAuthProvider implements AuthenticationProviderInterface
     }
 
     /**
-     * @template T of OAuthToken
+     * @template T of AbstractOAuthToken
      *
      * @param string|array $data
      * @param T            $oldToken
@@ -134,9 +134,9 @@ final class OAuthProvider implements AuthenticationProviderInterface
      */
     private function createOAuthToken(
         $data,
-        OAuthToken $oldToken,
+        AbstractOAuthToken $oldToken,
         ?UserInterface $user
-    ): OAuthToken {
+    ): AbstractOAuthToken {
         $tokenClass = \get_class($oldToken);
         if (null !== $user) {
             $token = new $tokenClass($data, $user->getRoles());

--- a/src/Security/Http/Authenticator/OAuthAuthenticator.php
+++ b/src/Security/Http/Authenticator/OAuthAuthenticator.php
@@ -13,7 +13,7 @@ namespace HWI\Bundle\OAuthBundle\Security\Http\Authenticator;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\State\State;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAwareExceptionInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthAwareUserProviderInterface;
 use HWI\Bundle\OAuthBundle\Security\Http\Authenticator\Passport\SelfValidatedOAuthPassport;
@@ -136,7 +136,8 @@ final class OAuthAuthenticator implements AuthenticatorInterface, Authentication
             $this->httpUtils->createRequest($request, $checkPath)->getUri()
         );
 
-        $token = new OAuthToken($accessToken);
+        $tokenClass = $resourceOwner->getTokenClass();
+        $token = new $tokenClass($accessToken);
         $token->setResourceOwnerName($resourceOwner->getName());
 
         return new SelfValidatedOAuthPassport($this->refreshToken($token), [new RememberMeBadge()]);
@@ -146,13 +147,13 @@ final class OAuthAuthenticator implements AuthenticatorInterface, Authentication
      * This function can be used for refreshing an expired token
      * or for custom "password grant" authenticator, if site owner also owns oauth instance.
      *
-     * @template T of OAuthToken
+     * @template T of AbstractOAuthToken
      *
      * @param T $token
      *
      * @return T
      */
-    public function refreshToken(OAuthToken $token): OAuthToken
+    public function refreshToken(AbstractOAuthToken $token): AbstractOAuthToken
     {
         $resourceOwner = $this->resourceOwnerMap->getResourceOwnerByName($token->getResourceOwnerName());
         if (!$resourceOwner) {
@@ -197,14 +198,14 @@ final class OAuthAuthenticator implements AuthenticatorInterface, Authentication
     }
 
     /**
-     * @template T of OAuthToken
+     * @template T of AbstractOAuthToken
      *
      * @param T              $token
      * @param ?UserInterface $user
      *
      * @return T
      */
-    public function recreateToken(OAuthToken $token, ?UserInterface $user = null): OAuthToken
+    public function recreateToken(AbstractOAuthToken $token, ?UserInterface $user = null): AbstractOAuthToken
     {
         $user = $user instanceof UserInterface ? $user : $token->getUser();
 

--- a/src/Security/Http/Authenticator/Passport/SelfValidatedOAuthPassport.php
+++ b/src/Security/Http/Authenticator/Passport/SelfValidatedOAuthPassport.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\Security\Http\Authenticator\Passport;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
@@ -21,14 +21,14 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
  */
 final class SelfValidatedOAuthPassport extends SelfValidatingPassport
 {
-    private OAuthToken $token;
+    private AbstractOAuthToken $token;
 
     /**
      * Token already contains authenticated user. No need to create trivial UserBadge outside.
      *
      * @param BadgeInterface[] $badges
      */
-    public function __construct(OAuthToken $token, array $badges = [])
+    public function __construct(AbstractOAuthToken $token, array $badges = [])
     {
         $this->token = $token;
 
@@ -44,7 +44,7 @@ final class SelfValidatedOAuthPassport extends SelfValidatingPassport
         parent::__construct($userBadge, $badges);
     }
 
-    public function getToken(): OAuthToken
+    public function getToken(): AbstractOAuthToken
     {
         return $this->token;
     }

--- a/src/Security/Http/Firewall/AbstractRefreshAccessTokenListener.php
+++ b/src/Security/Http/Firewall/AbstractRefreshAccessTokenListener.php
@@ -12,7 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Security\Http\Firewall;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMap;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -54,7 +54,7 @@ abstract class AbstractRefreshAccessTokenListener extends AbstractListener
             return;
         }
 
-        if (!$token instanceof OAuthToken) {
+        if (!$token instanceof AbstractOAuthToken) {
             return;
         }
 
@@ -90,11 +90,11 @@ abstract class AbstractRefreshAccessTokenListener extends AbstractListener
     }
 
     /**
-     * @template T of OAuthToken
+     * @template T of AbstractOAuthToken
      *
      * @param T $token
      *
      * @return T
      */
-    abstract protected function refreshToken(OAuthToken $token): OAuthToken;
+    abstract protected function refreshToken(AbstractOAuthToken $token): AbstractOAuthToken;
 }

--- a/src/Security/Http/Firewall/OAuthListener.php
+++ b/src/Security/Http/Firewall/OAuthListener.php
@@ -13,7 +13,6 @@ namespace HWI\Bundle\OAuthBundle\Security\Http\Firewall;
 
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\State\State;
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -94,7 +93,8 @@ class OAuthListener extends AbstractAuthenticationListener
             $this->httpUtils->createRequest($request, $checkPath)->getUri()
         );
 
-        $token = new OAuthToken($accessToken);
+        $tokenClass = $resourceOwner->getTokenClass();
+        $token = new $tokenClass($accessToken);
         $token->setResourceOwnerName($resourceOwner->getName());
 
         return $this->authenticationManager->authenticate($token);

--- a/src/Security/Http/Firewall/RefreshAccessTokenListener.php
+++ b/src/Security/Http/Firewall/RefreshAccessTokenListener.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\Security\Http\Firewall;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Http\Authenticator\OAuthAuthenticator;
 
 class RefreshAccessTokenListener extends AbstractRefreshAccessTokenListener
@@ -25,13 +25,13 @@ class RefreshAccessTokenListener extends AbstractRefreshAccessTokenListener
     }
 
     /**
-     * @template T of OAuthToken
+     * @template T of AbstractOAuthToken
      *
      * @param T $token
      *
      * @return T
      */
-    protected function refreshToken(OAuthToken $token): OAuthToken
+    protected function refreshToken(AbstractOAuthToken $token): AbstractOAuthToken
     {
         return $this->oAuthAuthenticator->refreshToken($token);
     }

--- a/src/Security/Http/Firewall/RefreshAccessTokenListenerOld.php
+++ b/src/Security/Http/Firewall/RefreshAccessTokenListenerOld.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\Security\Http\Firewall;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 
 class RefreshAccessTokenListenerOld extends RefreshAccessTokenListener
@@ -25,13 +25,13 @@ class RefreshAccessTokenListenerOld extends RefreshAccessTokenListener
     }
 
     /**
-     * @template T of OAuthToken
+     * @template T of AbstractOAuthToken
      *
      * @param T $token
      *
      * @return T
      */
-    protected function refreshToken(OAuthToken $token): OAuthToken
+    protected function refreshToken(AbstractOAuthToken $token): AbstractOAuthToken
     {
         // @phpstan-ignore-next-line returns TokenInterface instead of OAuthToken
         return $this->oAuthProvider->authenticate($token);

--- a/src/Security/OAuthUtils.php
+++ b/src/Security/OAuthUtils.php
@@ -29,16 +29,15 @@ final class OAuthUtils
     public const SIGNATURE_METHOD_RSA = 'RSA-SHA1';
     public const SIGNATURE_METHOD_PLAINTEXT = 'PLAINTEXT';
 
+    private HttpUtils $httpUtils;
+    private AuthorizationCheckerInterface $authorizationChecker;
     private bool $connect;
     private string $grantRule;
-    private HttpUtils $httpUtils;
 
     /**
      * @var ResourceOwnerMapInterface[]
      */
     private array $ownerMaps = [];
-
-    private AuthorizationCheckerInterface $authorizationChecker;
 
     public function __construct(
         HttpUtils $httpUtils,

--- a/tests/App/config/config.yaml
+++ b/tests/App/config/config.yaml
@@ -54,6 +54,7 @@ hwi_oauth:
             client_id:           'google_client_id'
             client_secret:       'google_client_secret'
             scope:               'https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile'
+            token_class:         'HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken'
         yahoo:
             type:          yahoo
             client_id:     'yahoo_client_id'

--- a/tests/Controller/AbstractConnectControllerTest.php
+++ b/tests/Controller/AbstractConnectControllerTest.php
@@ -17,6 +17,7 @@ use HWI\Bundle\OAuthBundle\Connect\AccountConnectorInterface;
 use HWI\Bundle\OAuthBundle\Controller\ConnectController;
 use HWI\Bundle\OAuthBundle\Form\RegistrationFormHandlerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapInterface;
 use HWI\Bundle\OAuthBundle\Security\Http\ResourceOwnerMapLocator;
@@ -128,6 +129,10 @@ abstract class AbstractConnectControllerTest extends TestCase
             ->method('getUserInformation')
             ->willReturn(new CustomUserResponse())
         ;
+        $this->resourceOwner->expects($this->any())
+            ->method('getTokenClass')
+            ->willReturn(OAuthToken::class)
+        ;
         $this->resourceOwnerMap = $this->createMock(ResourceOwnerMapInterface::class);
         $this->resourceOwnerMap->expects($this->any())
             ->method('getResourceOwnerByName')
@@ -160,7 +165,7 @@ abstract class AbstractConnectControllerTest extends TestCase
     {
         $accountNotLinked = new AccountNotLinkedException();
         $accountNotLinked->setResourceOwnerName('facebook');
-        $accountNotLinked->setToken(new CustomOAuthToken());
+        $accountNotLinked->setToken(CustomOAuthToken::createLoggedIn());
 
         return $accountNotLinked;
     }

--- a/tests/Controller/ConnectControllerConnectServiceActionTest.php
+++ b/tests/Controller/ConnectControllerConnectServiceActionTest.php
@@ -66,7 +66,7 @@ final class ConnectControllerConnectServiceActionTest extends AbstractConnectCon
 
         $this->tokenStorage->expects($this->once())
             ->method('getToken')
-            ->willReturn(new CustomOAuthToken())
+            ->willReturn(CustomOAuthToken::createLoggedIn())
         ;
 
         $form = $this->createMock(FormInterface::class);
@@ -114,7 +114,7 @@ final class ConnectControllerConnectServiceActionTest extends AbstractConnectCon
 
         $this->tokenStorage->expects($this->once())
             ->method('getToken')
-            ->willReturn(new CustomOAuthToken())
+            ->willReturn(CustomOAuthToken::createLoggedIn())
         ;
 
         $this->eventDispatcher->expects($this->exactly(2))
@@ -149,7 +149,7 @@ final class ConnectControllerConnectServiceActionTest extends AbstractConnectCon
 
         $this->tokenStorage->expects($this->once())
             ->method('getToken')
-            ->willReturn(new CustomOAuthToken())
+            ->willReturn(CustomOAuthToken::createLoggedIn())
         ;
 
         $this->eventDispatcher->expects($this->exactly(2))
@@ -188,7 +188,7 @@ final class ConnectControllerConnectServiceActionTest extends AbstractConnectCon
 
         $this->tokenStorage->expects($this->once())
             ->method('getToken')
-            ->willReturn(new CustomOAuthToken())
+            ->willReturn(CustomOAuthToken::createLoggedIn())
         ;
 
         $form = $this->createMock(FormInterface::class);

--- a/tests/DependencyInjection/HWIOAuthExtensionTest.php
+++ b/tests/DependencyInjection/HWIOAuthExtensionTest.php
@@ -12,6 +12,7 @@
 namespace HWI\Bundle\OAuthBundle\Tests\DependencyInjection;
 
 use HWI\Bundle\OAuthBundle\DependencyInjection\HWIOAuthExtension;
+use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\MyCustomProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
@@ -375,6 +376,29 @@ final class HWIOAuthExtensionTest extends TestCase
         $this->assertAlias('security.user_checker', 'hwi_oauth.user_checker');
     }
 
+    public function testCreateResourceOwnerInvalidTokenClass(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid configuration for path "hwi_oauth.resource_owners.any_name.token_class"');
+
+        $config = $this->getEmptyConfig();
+        $config['resource_owners']['any_name']['token_class'] = \stdClass::class;
+
+        $loader = new HWIOAuthExtension();
+        $loader->load([$config], $this->containerBuilder);
+    }
+
+    public function testCreateResourceOwnerValidTokenClass(): void
+    {
+        $config = $this->getEmptyConfig();
+        $config['resource_owners']['any_name']['token_class'] = CustomOAuthToken::class;
+
+        $loader = new HWIOAuthExtension();
+        $loader->load([$config], $this->containerBuilder);
+
+        $this->assertAlias('security.user_checker', 'hwi_oauth.user_checker');
+    }
+
     public function provideInvalidData(): array
     {
         return [
@@ -588,6 +612,7 @@ resource_owners:
         client_id:           client_id
         client_secret:       client_secret
         scope:               ""
+        token_class:         HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
         paths:
             nickname:        [email, id]
 

--- a/tests/Fixtures/CustomOAuthToken.php
+++ b/tests/Fixtures/CustomOAuthToken.php
@@ -16,9 +16,9 @@ use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 
 final class CustomOAuthToken extends OAuthToken
 {
-    public function __construct(array $accessToken = [])
+    public static function createLoggedIn(array $accessToken = []): self
     {
-        parent::__construct(
+        $token = new self(
             $accessToken + [
                 'access_token' => 'access_token_data',
             ],
@@ -27,8 +27,10 @@ final class CustomOAuthToken extends OAuthToken
             ]
         );
 
-        $this->setResourceOwnerName('fake');
-        $this->setUser(new User());
+        $token->setResourceOwnerName('fake');
+        $token->setUser(new User());
+
+        return $token;
     }
 
     public function copyPersistentDataFrom(AbstractOAuthToken $token): void

--- a/tests/Fixtures/MyCustomProvider.php
+++ b/tests/Fixtures/MyCustomProvider.php
@@ -29,6 +29,11 @@ final class MyCustomProvider implements ResourceOwnerInterface
         return '';
     }
 
+    public function getTokenClass(): string
+    {
+        return CustomOAuthToken::class;
+    }
+
     public function getAccessToken(Request $request, $redirectUri, array $extraParameters = []): array
     {
         return [];

--- a/tests/Fixtures/OAuthAwareException.php
+++ b/tests/Fixtures/OAuthAwareException.php
@@ -11,7 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\Tests\Fixtures;
 
-use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\OAuthAwareExceptionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  */
 final class OAuthAwareException extends \Exception implements OAuthAwareExceptionInterface
 {
-    private OAuthToken $token;
+    private AbstractOAuthToken $token;
     private string $resourceOwnerName;
 
     /**
@@ -80,7 +80,7 @@ final class OAuthAwareException extends \Exception implements OAuthAwareExceptio
     }
 
     /**
-     * @param OAuthToken $token
+     * @param AbstractOAuthToken $token
      *
      * {@inheritdoc}
      */

--- a/tests/Functional/AuthenticationHelperTrait.php
+++ b/tests/Functional/AuthenticationHelperTrait.php
@@ -41,7 +41,7 @@ trait AuthenticationHelperTrait
 
     protected function logIn(KernelBrowser $client, SessionInterface $session): void
     {
-        $session->set('_security_hwi_context', serialize(new CustomOAuthToken()));
+        $session->set('_security_hwi_context', serialize(CustomOAuthToken::createLoggedIn()));
 
         $this->saveSession($client, $session);
     }

--- a/tests/Security/Core/Authentication/Token/OAuthTokenTest.php
+++ b/tests/Security/Core/Authentication/Token/OAuthTokenTest.php
@@ -11,6 +11,7 @@
 
 namespace HWI\Bundle\OAuthBundle\Tests\Security\Core\Authentication\Token;
 
+use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\AbstractOAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Core\Exception\AccountNotLinkedException;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\User;
@@ -18,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 
 final class OAuthTokenTest extends TestCase
 {
-    private OAuthToken $token;
+    private AbstractOAuthToken $token;
 
     protected function setUp(): void
     {

--- a/tests/Security/Http/Authenticator/OAuthAuthenticatorTest.php
+++ b/tests/Security/Http/Authenticator/OAuthAuthenticatorTest.php
@@ -129,6 +129,10 @@ final class OAuthAuthenticatorTest extends TestCase
             ->willReturn(Request::create($checkUri));
 
         $resourceOwnerMock->expects($this->once())
+            ->method('getTokenClass')
+            ->willReturn(CustomOAuthToken::class);
+
+        $resourceOwnerMock->expects($this->once())
             ->method('getAccessToken')
             ->with($request, $checkUri)
             ->willReturn($accessToken);
@@ -215,7 +219,7 @@ final class OAuthAuthenticatorTest extends TestCase
             []
         );
 
-        $token = new CustomOAuthToken([
+        $token = CustomOAuthToken::createLoggedIn([
             'refresh_token' => 'refresh token data',
             'expires' => 666,
             'oauth_token_secret' => 'oauth secret',
@@ -266,7 +270,7 @@ final class OAuthAuthenticatorTest extends TestCase
             []
         );
 
-        $token = new CustomOAuthToken([
+        $token = CustomOAuthToken::createLoggedIn([
             'expires' => 666,
         ]);
         $token->setResourceOwnerName($resourceOwnerName);
@@ -313,7 +317,7 @@ final class OAuthAuthenticatorTest extends TestCase
             []
         );
 
-        $token = new CustomOAuthToken([
+        $token = CustomOAuthToken::createLoggedIn([
             'expires' => 666,
             'refresh_token' => 'refresh token data',
         ]);

--- a/tests/Security/Http/RefreshOnExpireTest.php
+++ b/tests/Security/Http/RefreshOnExpireTest.php
@@ -76,7 +76,8 @@ class RefreshOnExpireTest extends WebTestCase
         $this->resourceOwnerMock->expects($this->once())
             ->method('refreshAccessToken')
             ->willReturn([
-               'expires' => 666, // expired
+               'access_token' => 'access_token',
+               'expires' => 666,
                'refresh_token' => 'refresh_token',
            ]);
 
@@ -179,7 +180,7 @@ class RefreshOnExpireTest extends WebTestCase
     {
         $session = $this->getSession($this->client);
 
-        $token = new CustomOAuthToken($tokenData);
+        $token = CustomOAuthToken::createLoggedIn($tokenData);
         $token->setResourceOwnerName('google');
         if (method_exists($token, 'setAuthenticated')) {
             $token->setAuthenticated(true, false);


### PR DESCRIPTION
The code was reviewed, so that `OAuthToken` is fully replaceable by any other AppOAuthToken, that only should be extended from `AbstractOAuthToken`. Use the resource owner's option `token_class`  to change it.