### PR TITLE
set resourceOwner services directly without using tag

### DIFF
--- a/src/DependencyInjection/CompilerPass/ResourceOwnerMapCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/ResourceOwnerMapCompilerPass.php
@@ -34,7 +34,12 @@ final class ResourceOwnerMapCompilerPass implements CompilerPassInterface
         $oauthUtilsDef = $container->getDefinition('hwi_oauth.security.oauth_utils');
 
         foreach ($firewallNames as $firewallName => $_) {
-            $resourceOwnerMapRef = new Reference('hwi_oauth.resource_ownermap.'.$firewallName);
+            $resourceOwnerMapId = 'hwi_oauth.resource_ownermap.'.$firewallName;
+
+            $container->getDefinition($resourceOwnerMapId)
+                ->setArgument('$locator', new Reference('hwi_oauth.resource_owners.locator'));
+
+            $resourceOwnerMapRef = new Reference($resourceOwnerMapId);
 
             $locatorDef->addMethodCall('set', [$firewallName, $resourceOwnerMapRef]);
             $oauthUtilsDef->addMethodCall('addResourceOwnerMap', [$resourceOwnerMapRef]);

--- a/src/Resources/config/resource_owners.php
+++ b/src/Resources/config/resource_owners.php
@@ -92,8 +92,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->abstract()
         ->arg('$httpUtils', service('security.http_utils'))
         ->arg('$possibleResourceOwners', '%hwi_oauth.resource_owners%')
-        ->arg('$resourceOwners', [])
-        ->arg('$locator', tagged_locator('hwi_oauth.resource_owner', 'resource-name', 'getDefaultResourceNameName', 'getDefaultResourceNamePriority'));
+        ->arg('$resourceOwners', []);
 
     $services->set('hwi_oauth.resource_ownermap_locator', ResourceOwnerMapLocator::class);
 };

--- a/tests/App/ResourceOwner/CustomResourceOwner.php
+++ b/tests/App/ResourceOwner/CustomResourceOwner.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\App\ResourceOwner;
+
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwner\GenericOAuth2ResourceOwner;
+
+class CustomResourceOwner extends GenericOAuth2ResourceOwner
+{
+}

--- a/tests/App/config/config.yaml
+++ b/tests/App/config/config.yaml
@@ -34,6 +34,19 @@ services:
         class: Symfony\Contracts\HttpClient\HttpClientInterface
         public: true
 
+    app.custom_resource_owner:
+        class: HWI\Bundle\OAuthBundle\Tests\App\ResourceOwner\CustomResourceOwner
+        arguments:
+            $options: {
+                access_token_url: 'http://custom/token',
+                authorization_url: 'http://custom/auth',
+                infos_url: 'http://custom/info',
+                client_id: 'client_id',
+                client_secret: 'client_secret',
+            }
+            $name: 'custom'
+            $storage: '@hwi_oauth.storage.session'
+
 doctrine:
     dbal:
         driver: pdo_sqlite
@@ -61,6 +74,8 @@ hwi_oauth:
             scope:         'scope=mail-r sdct-r'
             options:
                 refresh_on_expire: true
+        custom:
+            service: 'app.custom_resource_owner'
 
 twig:
     strict_variables: '%kernel.debug%'

--- a/tests/App/config/routing.yaml
+++ b/tests/App/config/routing.yaml
@@ -27,3 +27,6 @@ google_login:
 
 yahoo_login:
     path: /check-login/yahoo
+
+custom_login:
+    path: /check-login/custom

--- a/tests/App/config/security_v4.yaml
+++ b/tests/App/config/security_v4.yaml
@@ -18,6 +18,7 @@ security:
         resource_owners:
           google: '/check-login/google'
           yahoo:  '/check-login/yahoo'
+          custom:  '/check-login/custom'
         login_path: /login
         use_forward: false
         failure_path: /login

--- a/tests/App/config/security_v5.yaml
+++ b/tests/App/config/security_v5.yaml
@@ -16,6 +16,7 @@ security:
         resource_owners:
           google: '/check-login/google'
           yahoo:  '/check-login/yahoo'
+          custom:  '/check-login/custom'
         login_path:  /login
         use_forward: false
         failure_path: /login

--- a/tests/App/config/security_v5_bc.yaml
+++ b/tests/App/config/security_v5_bc.yaml
@@ -20,6 +20,7 @@ security:
         resource_owners:
           google: '/check-login/google'
           yahoo:  '/check-login/yahoo'
+          custom:  '/check-login/custom'
         login_path: /login
         use_forward: false
         failure_path: /login

--- a/tests/App/config/security_v6.yaml
+++ b/tests/App/config/security_v6.yaml
@@ -16,6 +16,7 @@ security:
         resource_owners:
           google: '/check-login/google'
           yahoo:  '/check-login/yahoo'
+          custom:  '/check-login/custom'
         login_path: /login
         use_forward: false
         failure_path: /login

--- a/tests/Functional/Controller/LoginControllerTest.php
+++ b/tests/Functional/Controller/LoginControllerTest.php
@@ -36,7 +36,9 @@ final class LoginControllerTest extends WebTestCase
         $response = $client->getResponse();
 
         $this->assertSame(200, $response->getStatusCode(), $response->getContent());
-        $this->assertSame('google', $crawler->filter('a')->text(), $response->getContent());
+        $this->assertSame('google', $crawler->filter('a:nth-child(1)')->text(), $response->getContent());
+        $this->assertSame('yahoo', $crawler->filter('a:nth-child(3)')->text(), $response->getContent());
+        $this->assertSame('custom', $crawler->filter('a:nth-child(5)')->text(), $response->getContent());
     }
 
     public function testRedirectingToRegistrationFormWithError(): void


### PR DESCRIPTION
I don't think we need the tag `hwi_oauth.resource_owner`. Registering the service locator ourselves seems straightforward and fixes https://github.com/hwi/HWIOAuthBundle/issues/1873