### PR TITLE
Allow "use_authorization_to_get_token" to be configured to false for generic OAuth2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -297,6 +297,9 @@ final class Configuration implements ConfigurationInterface
                             ->scalarNode('use_authorization_to_get_token')
                                 ->validate()
                                     ->ifTrue(function ($v) {
+                                        if (false === $v) {
+                                            return false;
+                                        }
                                         return empty($v);
                                     })
                                     ->thenUnset()


### PR DESCRIPTION
This PR allows to set a false value for use_authorization_to_get_token in the config.
Useful to configure the generic OAuth2 resource owner, as the default value is true.
Previously, setting a false value was considered empty, then unset.