### PR TITLE
Current matched Firewall is respected during generation of check path links.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 * Bugfix: Added `OAuth1ResourceOwner` & `OAuth2ResourceOwner` to cover case of implementing custom oauth resource owners,
 * Bugfix: Fixed Authorization Header in `CleverResourceOwner::doGetRequest`,
 * Bugfix: Catch also the `TransportExceptionInterface` in `AbstractResourceOwner::getResponseContent()` method,
+* Bugfix: Current matched Firewall is respected during generation of resource owner check path links.
 
 ## 2.0.0-BETA2 (2022-01-16)
 * Deprecated: configuration parameter `firewall_names`, firewalls are now computed automatically - all firewalls that have defined `oauth` authenticator/provider will be collected,

--- a/src/DependencyInjection/CompilerPass/ResourceOwnerMapCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/ResourceOwnerMapCompilerPass.php
@@ -42,7 +42,7 @@ final class ResourceOwnerMapCompilerPass implements CompilerPassInterface
             $resourceOwnerMapRef = new Reference($resourceOwnerMapId);
 
             $locatorDef->addMethodCall('set', [$firewallName, $resourceOwnerMapRef]);
-            $oauthUtilsDef->addMethodCall('addResourceOwnerMap', [$resourceOwnerMapRef]);
+            $oauthUtilsDef->addMethodCall('addResourceOwnerMap', [$firewallName, $resourceOwnerMapRef]);
         }
     }
 }

--- a/src/Resources/config/oauth.php
+++ b/src/Resources/config/oauth.php
@@ -58,6 +58,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service('security.http_utils'),
             service('security.authorization_checker'),
+            service('security.firewall.map'),
             '%hwi_oauth.connect%',
             '%hwi_oauth.grant_rule%',
         ]);

--- a/tests/App/config/routing.yaml
+++ b/tests/App/config/routing.yaml
@@ -30,3 +30,18 @@ yahoo_login:
 
 custom_login:
     path: /check-login/custom
+
+app_api_service_redirect:
+  path: /api/connect/{service}
+  defaults:
+    _controller: 'HWI\Bundle\OAuthBundle\Controller\RedirectToServiceController::redirectToServiceAction'
+    methods: GET
+
+api_google_login:
+  path: /api/check-login/google
+
+api_yahoo_login:
+  path: /api/check-login/yahoo
+
+api_custom_login:
+  path: /api/check-login/custom

--- a/tests/App/config/security_v4.yaml
+++ b/tests/App/config/security_v4.yaml
@@ -11,6 +11,23 @@ security:
       pattern: ^/(login$|connect|login_hwi)
       anonymous: lazy
       context: hwi_context
+    api:
+      pattern: ^/api/
+      anonymous: lazy
+      stateless: true
+      oauth:
+        resource_owners:
+          google: '/api/check-login/google'
+          yahoo:  '/api/check-login/yahoo'
+          custom: '/api/check-login/custom'
+        login_path: /api/login
+        check_path: /api/check-login
+        use_forward: false
+        failure_path: /api/login
+        oauth_user_provider:
+          service: HWI\Bundle\OAuthBundle\Tests\App\UserProvider
+        provider: HWI\Bundle\OAuthBundle\Tests\App\UserProvider
+      context: hwi_context
     main:
       pattern: ^/
       anonymous: lazy

--- a/tests/App/config/security_v5.yaml
+++ b/tests/App/config/security_v5.yaml
@@ -9,6 +9,22 @@ security:
   enable_authenticator_manager: true
 
   firewalls:
+    api:
+      pattern: ^/api/
+      stateless: true
+      oauth:
+        resource_owners:
+          google: '/api/check-login/google'
+          yahoo:  '/api/check-login/yahoo'
+          custom: '/api/check-login/custom'
+        login_path: /api/login
+        check_path: /api/check-login
+        use_forward: false
+        failure_path: /api/login
+        oauth_user_provider:
+          service: HWI\Bundle\OAuthBundle\Tests\App\UserProvider
+        provider: HWI\Bundle\OAuthBundle\Tests\App\UserProvider
+      context: hwi_context
     main:
       lazy: true
       pattern: ^/

--- a/tests/App/config/security_v5_bc.yaml
+++ b/tests/App/config/security_v5_bc.yaml
@@ -13,6 +13,23 @@ security:
       pattern: ^/(login$|connect|login_hwi)
       anonymous: lazy
       context: hwi_context
+    api:
+      pattern: ^/api/
+      anonymous: lazy
+      stateless: true
+      oauth:
+        resource_owners:
+          google: '/api/check-login/google'
+          yahoo:  '/api/check-login/yahoo'
+          custom: '/api/check-login/custom'
+        login_path: /api/login
+        check_path: /api/check-login
+        use_forward: false
+        failure_path: /api/login
+        oauth_user_provider:
+          service: HWI\Bundle\OAuthBundle\Tests\App\UserProvider
+        provider: HWI\Bundle\OAuthBundle\Tests\App\UserProvider
+      context: hwi_context
     main:
       pattern: ^/
       anonymous: lazy

--- a/tests/App/config/security_v6.yaml
+++ b/tests/App/config/security_v6.yaml
@@ -9,6 +9,22 @@ security:
   enable_authenticator_manager: true
 
   firewalls:
+    api:
+      pattern: ^/api/
+      stateless: true
+      oauth:
+        resource_owners:
+          google: '/api/check-login/google'
+          yahoo:  '/api/check-login/yahoo'
+          custom: '/api/check-login/custom'
+        login_path: /api/login
+        check_path: /api/check-login
+        use_forward: false
+        failure_path: /api/login
+        oauth_user_provider:
+          service: HWI\Bundle\OAuthBundle\Tests\App\UserProvider
+        provider: HWI\Bundle\OAuthBundle\Tests\App\UserProvider
+      context: hwi_context
     main:
       lazy: true
       pattern: ^/

--- a/tests/App/templates/login.html.twig
+++ b/tests/App/templates/login.html.twig
@@ -1,3 +1,7 @@
 <a href="{{ path('hwi_oauth_service_redirect', {'service': 'google' }) }}">
     <span>Login with Google</span>
 </a>
+
+<a href="{{ path('app_api_service_redirect', {'service': 'google' }) }}">
+  <span>Api Login with Google</span>
+</a>

--- a/tests/Controller/Connect/AbstractConnectControllerTest.php
+++ b/tests/Controller/Connect/AbstractConnectControllerTest.php
@@ -24,6 +24,8 @@ use HWI\Bundle\OAuthBundle\Test\Fixtures\CustomUserResponse;
 use HWI\Bundle\OAuthBundle\Tests\Fixtures\CustomOAuthToken;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -139,6 +141,7 @@ abstract class AbstractConnectControllerTest extends TestCase
         $this->oAuthUtils = new OAuthUtils(
             $httpUtils,
             $this->createMock(AuthorizationCheckerInterface::class),
+            $this->createFirewallMapMock(),
             true,
             'IS_AUTHENTICATED_REMEMBERED'
         );
@@ -169,5 +172,18 @@ abstract class AbstractConnectControllerTest extends TestCase
             ->with('IS_AUTHENTICATED_REMEMBERED')
             ->willReturn($granted)
         ;
+    }
+
+    protected function createFirewallMapMock(): FirewallMap
+    {
+        $firewallMap = $this->createMock(FirewallMap::class);
+
+        $firewallMap
+            ->expects($this->any())
+            ->method('getFirewallConfig')
+            ->willReturn(new FirewallConfig('main', '/path/a'))
+        ;
+
+        return $firewallMap;
     }
 }

--- a/tests/Functional/IntegrationTest.php
+++ b/tests/Functional/IntegrationTest.php
@@ -63,6 +63,41 @@ final class IntegrationTest extends WebTestCase
         $this->assertSame($expectedRedirectUrl, $response->headers->get('Location'));
     }
 
+    public function testRequestRedirectApi(): void
+    {
+        $client = static::createClient();
+        $client->disableReboot();
+        $client->getContainer()->set('hwi_oauth.http_client', new MockHttpClient());
+        $client->request('GET', '/private');
+
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(302, $response->getStatusCode(), $response->getContent());
+        $this->assertSame('http://localhost/login', $response->headers->get('Location'));
+
+        $crawler = $client->request('GET', $response->headers->get('Location'));
+
+        $response = $client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode(), 'No landing, got redirect to '.$response->headers->get('Location'));
+
+        $client->click($crawler->selectLink('Api Login')->link());
+
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(302, $response->getStatusCode(), $response->getContent());
+        $expectedRedirectUrl = 'https://accounts.google.com/o/oauth2/auth?'
+            .http_build_query([
+                'response_type' => 'code',
+                'client_id' => 'google_client_id',
+                'scope' => 'https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile',
+                'redirect_uri' => 'http://localhost/api/check-login/google',
+            ]);
+        $this->assertSame($expectedRedirectUrl, $response->headers->get('Location'));
+    }
+
     public function testRequestCheck(): void
     {
         $redirectLoginFromService = 'http://localhost/check-login/google?'
@@ -96,6 +131,54 @@ final class IntegrationTest extends WebTestCase
         // 'security.event_dispatcher.main' Dispatcher is used for Symfony 5.4 and 6.0 under php ^8.0 and ^8.1
         // and 'event_dispatcher' for all 4.4 and 5.4 under ^7.4
         foreach (['security.event_dispatcher.main', 'event_dispatcher'] as $dispatcherId) {
+            if ($container->has($dispatcherId)) {
+                $container->get($dispatcherId)
+                    ->addListener(SecurityEvents::INTERACTIVE_LOGIN, [$interactiveLoginListener, 'handle']);
+            }
+        }
+
+        $client->request('GET', $redirectLoginFromService);
+
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(302, $response->getStatusCode(), $response->getContent());
+        $this->assertSame('http://localhost/', $response->headers->get('Location'));
+    }
+
+    public function testRequestCheckApi(): void
+    {
+        $redirectLoginFromService = 'http://localhost/api/check-login/google?'
+            .http_build_query([
+                'code' => 'sOmeRand0m-code',
+                'scope' => 'https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile',
+                'authuser' => '0',
+                'session_state' => 'abcde123456789..8787',
+                'prompt' => 'none',
+            ]);
+
+        $httpClient = new MockHttpClient(
+            function ($method, $url, $options) {
+                return new MockResponse(
+                    '{"access_token":"valid-access-token"}',
+                    [
+                        'response_headers' => ['content-type' => 'application/json'],
+                    ]
+                );
+            }
+        );
+
+        $client = static::createClient();
+        $client->disableReboot();
+        $container = $client->getContainer();
+        $container->set('hwi_oauth.http_client', $httpClient);
+
+        $interactiveLoginListener = $this->createMock(CustomEventListener::class);
+        $interactiveLoginListener->expects($this->once())->method('handle');
+        // We attach our custom listener to prove InteractiveLoginEvent fired correctly.
+        // 'security.event_dispatcher.main' Dispatcher is used for Symfony 5.4 and 6.0 under php ^8.0 and ^8.1
+        // and 'event_dispatcher' for all 4.4 and 5.4 under ^7.4
+        foreach (['security.event_dispatcher.api', 'event_dispatcher'] as $dispatcherId) {
             if ($container->has($dispatcherId)) {
                 $container->get($dispatcherId)
                     ->addListener(SecurityEvents::INTERACTIVE_LOGIN, [$interactiveLoginListener, 'handle']);


### PR DESCRIPTION
If matched firewall does not have **oauth** listener/authenticator (aka login_area in old Symfony), the last `potentialResourceOwnerCheckPath` (basically from main firewall) will be taken. 
fixes #1885
