### PR TITLE
Prevent fatal error in `loadUserByOAuthUserResponse()` when `nickname` is not available in OAuth response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Changelog
 * Bugfix: Added `OAuth1ResourceOwner` & `OAuth2ResourceOwner` to cover case of implementing custom oauth resource owners,
 * Bugfix: Fixed Authorization Header in `CleverResourceOwner::doGetRequest`,
 * Bugfix: Catch also the `TransportExceptionInterface` in `AbstractResourceOwner::getResponseContent()` method,
-* Bugfix: Current matched Firewall is respected during generation of resource owner check path links.
+* Bugfix: Current matched Firewall is respected during generation of resource owner check path links,
+* Bugfix: Prevent fatal error in `OAuthUserProvider::loadUserByOAuthUserResponse()` when `nickname` is not available in OAuth response.
 
 ## 2.0.0-BETA2 (2022-01-16)
 * Deprecated: configuration parameter `firewall_names`, firewalls are now computed automatically - all firewalls that have defined `oauth` authenticator/provider will be collected,

--- a/src/Security/Core/User/OAuthUserProvider.php
+++ b/src/Security/Core/User/OAuthUserProvider.php
@@ -40,7 +40,7 @@ final class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserPr
 
     public function loadUserByOAuthUserResponse(UserResponseInterface $response): UserInterface
     {
-        return $this->loadUserByIdentifier($response->getNickname());
+        return $this->loadUserByIdentifier($response->getNickname() ?: $response->getUserIdentifier());
     }
 
     public function refreshUser(UserInterface $user): UserInterface


### PR DESCRIPTION
Fixes #1901