### PR TITLE
Fix PHP 8.2 compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,8 @@ jobs:
             symfony-version: ^5.4
           - php: '8.1'
             symfony-version: ^6.1
+          - php: '8.2'
+            symfony-version: ^6.1
       fail-fast: false
 
     steps:

--- a/src/OAuth/ResourceOwner/AbstractResourceOwner.php
+++ b/src/OAuth/ResourceOwner/AbstractResourceOwner.php
@@ -177,12 +177,12 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      * @param mixed       $redirectUri     The uri to redirect the client back to
      * @param array       $extraParameters An array of parameters to add to the url
      *
-     * @throws AuthenticationException If an OAuth error occurred or no access token is found
-     * @throws HttpTransportException
-     *
      * @return array array containing the access token and it's 'expires_in' value,
      *               along with any other parameters returned from the authentication
      *               provider
+     *
+     * @throws AuthenticationException If an OAuth error occurred or no access token is found
+     * @throws HttpTransportException
      */
     abstract public function getAccessToken(HttpRequest $request, $redirectUri, array $extraParameters = []);
 
@@ -192,12 +192,12 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      * @param string $refreshToken    Refresh token
      * @param array  $extraParameters An array of parameters to add to the url
      *
-     * @throws AuthenticationException If an OAuth error occurred or no access token is found
-     * @throws HttpTransportException
-     *
      * @return array array containing the access token and it's 'expires_in' value,
      *               along with any other parameters returned from the authentication
      *               provider
+     *
+     * @throws AuthenticationException If an OAuth error occurred or no access token is found
+     * @throws HttpTransportException
      */
     public function refreshAccessToken($refreshToken, array $extraParameters = [])
     {
@@ -209,10 +209,10 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      *
      * @param string $token the token (access token or a refresh token) that should be revoked
      *
+     * @return bool returns True if the revocation was successful, otherwise False
+     *
      * @throws AuthenticationException If an OAuth error occurred
      * @throws HttpTransportException
-     *
-     * @return bool returns True if the revocation was successful, otherwise False
      */
     public function revokeToken($token)
     {
@@ -257,9 +257,9 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
      * @param array        $headers The headers of the request
      * @param string       $method  The HTTP method to use
      *
-     * @throws HttpTransportException
-     *
      * @return ResponseInterface The response content
+     *
+     * @throws HttpTransportException
      */
     protected function httpRequest($url, $content = null, array $headers = [], $method = null)
     {
@@ -303,18 +303,18 @@ abstract class AbstractResourceOwner implements ResourceOwnerInterface
     /**
      * @param string $url
      *
-     * @throws HttpTransportException
-     *
      * @return ResponseInterface
+     *
+     * @throws HttpTransportException
      */
     abstract protected function doGetTokenRequest($url, array $parameters = []);
 
     /**
      * @param string $url
      *
-     * @throws HttpTransportException
-     *
      * @return ResponseInterface
+     *
+     * @throws HttpTransportException
      */
     abstract protected function doGetUserInformationRequest($url, array $parameters = []);
 

--- a/src/OAuth/ResourceOwner/DropboxResourceOwner.php
+++ b/src/OAuth/ResourceOwner/DropboxResourceOwner.php
@@ -48,7 +48,7 @@ final class DropboxResourceOwner extends GenericOAuth2ResourceOwner
                 $this->normalizeUrl($this->options['infos_url'], $extraParameters),
                 'null',
                 [
-                    'Authorization' => 'Bearer'.' '.$accessToken['access_token'],
+                    'Authorization' => 'Bearer '.$accessToken['access_token'],
                     'Accept' => 'application/json',
                     'Content-Type' => 'application/json; charset=utf-8',
                 ], 'POST');

--- a/src/OAuth/ResourceOwnerInterface.php
+++ b/src/OAuth/ResourceOwnerInterface.php
@@ -30,9 +30,9 @@ interface ResourceOwnerInterface
      * @param array $accessToken     The access token
      * @param array $extraParameters An array of parameters to add to the url
      *
-     * @throws HttpTransportException
-     *
      * @return UserResponseInterface the wrapped response interface
+     *
+     * @throws HttpTransportException
      */
     public function getUserInformation(array $accessToken, array $extraParameters = []);
 
@@ -53,9 +53,9 @@ interface ResourceOwnerInterface
      * @param string      $redirectUri     The uri to redirect the client back to
      * @param array       $extraParameters An array of parameters to add to the url
      *
-     * @throws HttpTransportException
-     *
      * @return array The access token
+     *
+     * @throws HttpTransportException
      */
     public function getAccessToken(HttpRequest $request, $redirectUri, array $extraParameters = []);
 

--- a/src/Security/Core/Authentication/Token/AbstractOAuthToken.php
+++ b/src/Security/Core/Authentication/Token/AbstractOAuthToken.php
@@ -55,7 +55,7 @@ abstract class AbstractOAuthToken extends AbstractToken
             $this->expiresIn,
             $this->createdAt,
             $this->resourceOwnerName,
-            \is_callable('parent::__serialize') ? parent::__serialize() : unserialize(parent::serialize()),
+            parent::__serialize(),
         ];
     }
 
@@ -78,11 +78,7 @@ abstract class AbstractOAuthToken extends AbstractToken
             $this->tokenSecret = $this->rawToken['oauth_token_secret'];
         }
 
-        if (\is_callable('parent::__serialize')) {
-            parent::__unserialize($parent);
-        } else {
-            parent::unserialize(serialize($parent));
-        }
+        parent::__unserialize($parent);
     }
 
     public function copyPersistentDataFrom(self $token): void


### PR DESCRIPTION
Fixes deprecation notice when running on PHP 8.2: `Deprecated: Use of "parent" in callables is deprecated`

Since we are requiring Symfony ^4.4, `__serialize()` is already there (since v4.3) so we don't need to check if it exists:
https://github.com/symfony/symfony/blob/c52b0edeb04feab571e2514ac8d613aed186d5ed/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php#L160-L182

Added PHP 8.2 to the build matrix too.

Failing style check is not related.