### PR TITLE
Fix typo in configuration comment

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -218,7 +218,7 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('type')
                                 // will be validated in ResourceOwnerCompilerPass, other apps can register own resource
-                                // owner maps later with tag hei_oauth.resource_owner
+                                // owner maps later with tag hwi_oauth.resource_owner
                                 ->validate()
                                     ->ifEmpty()
                                     ->thenUnset()


### PR DESCRIPTION
Fix typo in comment on how to register own resource owners