### PR TITLE
Fix PHP 8.2 deprecation for partially supported callable

### DIFF
--- a/src/Security/Core/Authentication/Token/AbstractOAuthToken.php
+++ b/src/Security/Core/Authentication/Token/AbstractOAuthToken.php
@@ -55,7 +55,7 @@ abstract class AbstractOAuthToken extends AbstractToken
             $this->expiresIn,
             $this->createdAt,
             $this->resourceOwnerName,
-            \is_callable('parent::__serialize') ? parent::__serialize() : unserialize(parent::serialize()),
+            \is_callable(parent::class.'::__serialize') ? parent::__serialize() : unserialize(parent::serialize()),
         ];
     }
 
@@ -78,7 +78,7 @@ abstract class AbstractOAuthToken extends AbstractToken
             $this->tokenSecret = $this->rawToken['oauth_token_secret'];
         }
 
-        if (\is_callable('parent::__serialize')) {
+        if (\is_callable(parent::class.'::__serialize')) {
             parent::__unserialize($parent);
         } else {
             parent::unserialize(serialize($parent));


### PR DESCRIPTION
https://php.watch/versions/8.2/partially-supported-callable-deprecation
> The easiest way to avoid the deprecation notice is to convert all `self`, `parent`, and `static` keywords in the callable construction to their corresponding class names. This can be easily done with the `::class` magic method, which resolves to the fully-qualified class name.