### PR TITLE
Prevent fatal error when token doesn't have resource owner name set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 ## 2.0.0 (2023-xx-xx)
 * Bugfix: Prevent refreshing non-expired tokens
 * Bugfix: Remove deprecations reported by Symfony 6.x
+* Bugfix: Prevent fatal error when token doesn't have resource owner name set
 
 ## 2.0.0-BETA3 (2023-08-20)
 * BC Break: Dropped support for Symfony: 6.0.*,

--- a/src/Security/Core/Authentication/Token/AbstractOAuthToken.php
+++ b/src/Security/Core/Authentication/Token/AbstractOAuthToken.php
@@ -26,7 +26,7 @@ abstract class AbstractOAuthToken extends AbstractToken
     private array $rawToken;
     private ?int $expiresIn = null;
     private ?int $createdAt = null;
-    private string $resourceOwnerName;
+    private ?string $resourceOwnerName = null;
     private ?string $tokenSecret = null;
     private ?string $refreshToken = null;
 
@@ -251,7 +251,7 @@ abstract class AbstractOAuthToken extends AbstractToken
     /**
      * Get the resource owner name.
      *
-     * @return string
+     * @return string|null
      */
     public function getResourceOwnerName()
     {


### PR DESCRIPTION
Fixes #1921