### PR TITLE
Prevent overwriting `failure_path` in `AuthenticationFailureHandler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Changelog
 =========
 ## 2.2.1 (2024-03-xx)
-* Bugfix: Prevent overwriting `failure_path` in `AuthenticationFailureHandler` when connect functionality is not enabled
+* Bugfix: Prevent overwriting `failure_path` in `AuthenticationFailureHandler` when connect functionality is not enabled,
+* Bugfix: Prevent overwriting `failure_handler` in security configuration if set,
 
 ## 2.2.0 (2024-02-28)
 * BC Break: Dropped support for PHP 7.4 & 8.0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+## 2.2.1 (2024-03-xx)
+* Bugfix: Prevent overwriting `failure_path` in `AuthenticationFailureHandler` when connect functionality is not enabled
+
 ## 2.2.0 (2024-02-28)
 * BC Break: Dropped support for PHP 7.4 & 8.0,
 * Added: Telegram resource owner,

--- a/src/DependencyInjection/Security/Factory/OAuthAuthenticatorFactory.php
+++ b/src/DependencyInjection/Security/Factory/OAuthAuthenticatorFactory.php
@@ -138,6 +138,10 @@ final class OAuthAuthenticatorFactory extends AbstractFactory implements Authent
     protected function createAuthenticationFailureHandler(ContainerBuilder $container, string $id, array $config): string
     {
         $id = $this->getFailureHandlerId($id);
+        if ($container->has($id)) {
+            return $id;
+        }
+
         $options = array_intersect_key($config, $this->defaultFailureHandlerOptions);
 
         $failureHandler = $container->setDefinition($id, new ChildDefinition('security.authentication.custom_failure_handler'));

--- a/src/Resources/config/oauth.php
+++ b/src/Resources/config/oauth.php
@@ -69,6 +69,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service('request_stack'),
             service('router'),
+            service('security.http_utils'),
             '%hwi_oauth.connect%',
         ]);
 };

--- a/src/Security/Http/Authenticator/OAuthAuthenticator.php
+++ b/src/Security/Http/Authenticator/OAuthAuthenticator.php
@@ -128,6 +128,7 @@ final class OAuthAuthenticator implements AuthenticatorInterface, Authentication
 
         $userBadge = class_exists(UserBadge::class)
             ? new UserBadge(
+                /* @phpstan-ignore-next-line */
                 $user ? method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername() : null,
                 static function () use ($user) { return $user; }
             )

--- a/tests/Security/Http/Authentication/AuthenticationFailureHandlerTest.php
+++ b/tests/Security/Http/Authentication/AuthenticationFailureHandlerTest.php
@@ -21,8 +21,10 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\HttpUtils;
 
 final class AuthenticationFailureHandlerTest extends TestCase
 {
@@ -35,6 +37,7 @@ final class AuthenticationFailureHandlerTest extends TestCase
         $handler = new AuthenticationFailureHandler(
             $requestStack,
             $router = $this->createMock(RouterInterface::class),
+            new HttpUtils($router, $this->createMock(UrlMatcherInterface::class)),
             false
         );
 
@@ -56,13 +59,14 @@ final class AuthenticationFailureHandlerTest extends TestCase
         $handler = new AuthenticationFailureHandler(
             $requestStack,
             $router = $this->createMock(RouterInterface::class),
+            new HttpUtils($router, $this->createMock(UrlMatcherInterface::class)),
             false,
         );
         $handler->setOptions(['login_path' => 'route_name']);
 
         $router->expects($this->once())
             ->method('generate')
-            ->with('route_name', ['error' => 'An authentication exception occurred.'], 1)
+            ->with('route_name', [], 1)
             ->willReturn('/path');
 
         $this->assertInstanceOf(
@@ -80,6 +84,7 @@ final class AuthenticationFailureHandlerTest extends TestCase
         $handler = new AuthenticationFailureHandler(
             $requestStack,
             $router = $this->createMock(RouterInterface::class),
+            new HttpUtils($router, $this->createMock(UrlMatcherInterface::class)),
             false
         );
 
@@ -101,6 +106,7 @@ final class AuthenticationFailureHandlerTest extends TestCase
         $handler = new AuthenticationFailureHandler(
             $requestStack,
             $router = $this->createMock(RouterInterface::class),
+            new HttpUtils($router, $this->createMock(UrlMatcherInterface::class)),
             true
         );
 
@@ -124,7 +130,9 @@ final class AuthenticationFailureHandlerTest extends TestCase
         $handler = new AuthenticationFailureHandler(
             $requestStack,
             $router = $this->createMock(RouterInterface::class),
-            true
+            new HttpUtils($router, $this->createMock(UrlMatcherInterface::class)),
+            true,
+            ['failure_path' => 'hwi_oauth_connect_registration']
         );
 
         $router->expects($this->once())


### PR DESCRIPTION
Fixes #1989