### PR TITLE
Fix access control suggestions

### DIFF
--- a/docs/3-configuring_the_security_layer.md
+++ b/docs/3-configuring_the_security_layer.md
@@ -59,6 +59,7 @@ security:
 
     access_control:
         - { path: ^/login, roles: PUBLIC_ACCESS }
+        - { path: ^/connect, roles: PUBLIC_ACCESS }
         - { path: ^/, roles: ROLE_USER } // force login
 ```
 


### PR DESCRIPTION
I am trying to reconfigure an app during a Symfony 5.4 -> 6.4 upgrade. During this, I took the time to realign my use of this bundle to the standard and the recipe.

I'm not using the connect feature, and I was unable to make it work until I added the suggested line to my access control, because without that the redirect route (`/connect/{service}`) is hidden behind the default rule (`^/ roles: ROLE_USER`) and hence triggering a loop that pushes me back to the login page.