### PR TITLE
Fixed array state for symfony/http-foundation >= 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,7 @@
         "php":                            "^8.1",
         "symfony/deprecation-contracts":  "^3.0",
         "symfony/framework-bundle":       "^5.4 || ^6.3 || ^7.0",
+        "symfony/http-foundation":        "^5.4 || ^6.3 || ^7.0",
         "symfony/security-bundle":        "^5.4 || ^6.3 || ^7.0",
         "symfony/options-resolver":       "^5.4 || ^6.3 || ^7.0",
         "symfony/form":                   "^5.4 || ^6.3 || ^7.0",

--- a/src/Security/OAuthUtils.php
+++ b/src/Security/OAuthUtils.php
@@ -77,7 +77,7 @@ final class OAuthUtils
         }
 
         if ($request->query->has('state')) {
-            $this->addQueryParameterToState($request->query->get('state'), $resourceOwner);
+            $this->addQueryParameterToState($request->query->all()['state'] ?? [], $resourceOwner);
         }
 
         return $resourceOwner->getAuthorizationUrl($redirectUrl, $extraParameters);
@@ -93,7 +93,7 @@ final class OAuthUtils
 
         $request->attributes->set('service', $resourceOwner->getName());
         if ($request->query->has('state')) {
-            $this->addQueryParameterToState($request->query->get('state'), $resourceOwner);
+            $this->addQueryParameterToState($request->query->all()['state'] ?? [], $resourceOwner);
         }
 
         return $this->httpUtils->generateUri($request, 'hwi_oauth_connect_service');


### PR DESCRIPTION
Once upgraded my project to symfony 6.4 (particularly the http-foundation component), I've noticed that OAuthUtils started to throw exception if "state" parameter is passed as an array (this is the way we do it in my project atm). According to the http-foundation changelog:

> Retrieving non-scalar values using InputBag::get() will throw BadRequestException (use InputBad::all() instead to retrieve an array)

This behavior has been deprecated since v5.1 and removed in 6.0.

I've also added symfony/http-foundation as a direct dependency to the composer.json. I was not sure about it, but it's obvious that this bundle relates on the Request class from the http-foundation, but it wasn't present in composer.json for some reason.