### PR TITLE
Added support for optional audience and organization options for Auth0.

### DIFF
--- a/docs/resource_owners/auth0.md
+++ b/docs/resource_owners/auth0.md
@@ -11,11 +11,28 @@ Next configure a resource owner of type `auth0` with appropriate `client_id`,
 hwi_oauth:
     resource_owners:
         any_name:
-            type:           auth0
-            client_id:      <client_id>
-            client_secret:  <client_secret>
-            base_url:       https://<domain>
-            scope:          <scope>
+            type:             auth0
+            client_id:        <client_id>
+            client_secret:    <client_secret>
+            base_url:         https://<domain>
+            scope:            <scope>
+```
+
+Optionally, you can configure the `organization` and `audience` options when the login flow for the application requires this:
+```yaml
+# config/packages/hwi_oauth.yaml
+
+hwi_oauth:
+    resource_owners:
+        any_name:
+            type:             auth0
+            client_id:        <client_id>
+            client_secret:    <client_secret>
+            base_url:         https://<domain>
+            scope:            <scope>
+            options:
+                organization: <organization>
+                audience:     <audience>
 ```
 
 When you're done. Continue by configuring the security layer or go back to

--- a/src/OAuth/ResourceOwner/Auth0ResourceOwner.php
+++ b/src/OAuth/ResourceOwner/Auth0ResourceOwner.php
@@ -55,6 +55,11 @@ final class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
             'auth0_client' => $auth0Client,
         ]);
 
+        $resolver->setDefined([
+            'organization',
+            'audience',
+        ]);
+
         $resolver->setRequired([
             'base_url',
         ]);
@@ -78,5 +83,21 @@ final class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
         }
 
         return parent::httpRequest($url, $content, $headers, $method);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAuthorizationUrl($redirectUri, array $extraParameters = []): string
+    {
+        if (!empty($this->options['organization'])) {
+            $extraParameters['organization'] = $this->options['organization'];
+        }
+
+        if (!empty($this->options['audience'])) {
+            $extraParameters['audience'] = $this->options['audience'];
+        }
+
+        return parent::getAuthorizationUrl($redirectUri, $extraParameters);
     }
 }

--- a/src/OAuth/ResourceOwner/Auth0ResourceOwner.php
+++ b/src/OAuth/ResourceOwner/Auth0ResourceOwner.php
@@ -33,6 +33,22 @@ final class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
     ];
 
     /**
+     * {@inheritDoc}
+     */
+    public function getAuthorizationUrl($redirectUri, array $extraParameters = []): string
+    {
+        if (!empty($this->options['organization'])) {
+            $extraParameters['organization'] = $this->options['organization'];
+        }
+
+        if (!empty($this->options['audience'])) {
+            $extraParameters['audience'] = $this->options['audience'];
+        }
+
+        return parent::getAuthorizationUrl($redirectUri, $extraParameters);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function configureOptions(OptionsResolver $resolver)
@@ -83,21 +99,5 @@ final class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
         }
 
         return parent::httpRequest($url, $content, $headers, $method);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getAuthorizationUrl($redirectUri, array $extraParameters = []): string
-    {
-        if (!empty($this->options['organization'])) {
-            $extraParameters['organization'] = $this->options['organization'];
-        }
-
-        if (!empty($this->options['audience'])) {
-            $extraParameters['audience'] = $this->options['audience'];
-        }
-
-        return parent::getAuthorizationUrl($redirectUri, $extraParameters);
     }
 }

--- a/src/OAuth/ResourceOwner/KeycloakResourceOwner.php
+++ b/src/OAuth/ResourceOwner/KeycloakResourceOwner.php
@@ -34,8 +34,8 @@ final class KeycloakResourceOwner extends GenericOAuth2ResourceOwner
     public function getAuthorizationUrl($redirectUri, array $extraParameters = [])
     {
         return parent::getAuthorizationUrl($redirectUri, array_merge([
-          'approval_prompt' => $this->getOption('approval_prompt'),
-          'kc_idp_hint' => $this->getOption('idp_hint'),
+            'approval_prompt' => $this->getOption('approval_prompt'),
+            'kc_idp_hint' => $this->getOption('idp_hint'),
         ], $extraParameters));
     }
 
@@ -44,19 +44,19 @@ final class KeycloakResourceOwner extends GenericOAuth2ResourceOwner
         parent::configureOptions($resolver);
 
         $resolver->setDefaults([
-          'protocol' => 'openid-connect',
-          'scope' => 'openid email',
-          'response_type' => 'code',
-          'approval_prompt' => 'auto',
-          'authorization_url' => '{keycloak_url}/auth',
-          'access_token_url' => '{keycloak_url}/token',
-          'infos_url' => '{keycloak_url}/userinfo',
-          'idp_hint' => null,
+            'protocol' => 'openid-connect',
+            'scope' => 'openid email',
+            'response_type' => 'code',
+            'approval_prompt' => 'auto',
+            'authorization_url' => '{keycloak_url}/auth',
+            'access_token_url' => '{keycloak_url}/token',
+            'infos_url' => '{keycloak_url}/userinfo',
+            'idp_hint' => null,
         ]);
 
         $resolver->setRequired([
-          'realm',
-          'base_url',
+            'realm',
+            'base_url',
         ]);
 
         $normalizer = function (Options $options, $value) {

--- a/tests/App/Form/RegistrationFormType.php
+++ b/tests/App/Form/RegistrationFormType.php
@@ -53,8 +53,8 @@ final class RegistrationFormType extends AbstractType
     {
         $resolver->setDefaults(
             [
-               'data_class' => User::class,
-               'csrf_token_id' => 'registration',
+                'data_class' => User::class,
+                'csrf_token_id' => 'registration',
             ]
         );
     }

--- a/tests/App/ResourceOwner/CustomResourceOwner.php
+++ b/tests/App/ResourceOwner/CustomResourceOwner.php
@@ -36,10 +36,10 @@ final class CustomResourceOwner extends GenericOAuth2ResourceOwner
 
         $resolver->setDefaults(
             [
-               'authorization_url' => '{base_url}/authorize',
-               'access_token_url' => '{base_url}/oauth/token',
-               'infos_url' => '{base_url}/userinfo',
-           ]
+                'authorization_url' => '{base_url}/authorize',
+                'access_token_url' => '{base_url}/oauth/token',
+                'infos_url' => '{base_url}/userinfo',
+            ]
         );
 
         $resolver->setRequired(['base_url']);

--- a/tests/OAuth/ResourceOwner/KeycloakResourceOwnerTest.php
+++ b/tests/OAuth/ResourceOwner/KeycloakResourceOwnerTest.php
@@ -17,16 +17,16 @@ use HWI\Bundle\OAuthBundle\Test\OAuth\ResourceOwner\GenericOAuth2ResourceOwnerTe
 final class KeycloakResourceOwnerTest extends GenericOAuth2ResourceOwnerTestCase
 {
     protected array $options = [
-      'base_url' => 'http://keycloak.example.com/auth',
-      'realm' => 'example',
-      'client_id' => 'clientid',
-      'client_secret' => 'clientsecret',
+        'base_url' => 'http://keycloak.example.com/auth',
+        'realm' => 'example',
+        'client_id' => 'clientid',
+        'client_secret' => 'clientsecret',
 
-      'authorization_url' => 'http://keycloak.example.com/auth/realms/example/protocol/openid-connect/auth',
-      'access_token_url' => 'http://keycloak.example.com/auth/realms/example/protocol/openid-connect/token',
-      'infos_url' => 'http://keycloak.example.com/auth/realms/example/protocol/openid-connect/userinfo',
+        'authorization_url' => 'http://keycloak.example.com/auth/realms/example/protocol/openid-connect/auth',
+        'access_token_url' => 'http://keycloak.example.com/auth/realms/example/protocol/openid-connect/token',
+        'infos_url' => 'http://keycloak.example.com/auth/realms/example/protocol/openid-connect/userinfo',
 
-      'attr_name' => 'access_token',
+        'attr_name' => 'access_token',
     ];
 
     protected string $authorizationUrlBasePart = 'http://keycloak.example.com/auth/realms/example/protocol/openid-connect/auth?response_type=code&client_id=clientid&scope=openid+email';

--- a/tests/Security/Http/RefreshOnExpireTest.php
+++ b/tests/Security/Http/RefreshOnExpireTest.php
@@ -76,9 +76,9 @@ class RefreshOnExpireTest extends WebTestCase
         $this->resourceOwnerMock->expects($this->once())
             ->method('refreshAccessToken')
             ->willReturn([
-               'expires' => 666, // expired
-               'refresh_token' => 'refresh_token',
-           ]);
+                'expires' => 666, // expired
+                'refresh_token' => 'refresh_token',
+            ]);
 
         $this->resourceOwnerMock->expects($this->once())
             ->method('getUserInformation')


### PR DESCRIPTION
Adds (optional) support for `organization` and `audience` options in the `Auth0ResourceOwner`. 

These parameters are required when an application is set up with a no-prompt business-user login flow:
![afbeelding](https://github.com/hwi/HWIOAuthBundle/assets/34477826/400c0ee0-956f-497c-8a6b-a4971f1ee634)


This fixes https://github.com/hwi/HWIOAuthBundle/issues/1697.