### PR TITLE
Use non-deprecated Extension class

### DIFF
--- a/src/DependencyInjection/HWIOAuthExtension.php
+++ b/src/DependencyInjection/HWIOAuthExtension.php
@@ -23,9 +23,9 @@ use Symfony\Component\DependencyInjection\Exception\BadMethodCallException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * @author Geoffrey Bachelet <geoffrey.bachelet@gmail.com>


### PR DESCRIPTION
Symfony 7.2 triggers a deprecation about the `Symfony\Component\HttpKernel\DependencyInjection\Extension` class. In order to get rid of that, I'm extending `Symfony\Component\DependencyInjection\Extension\Extension` now.

This is technically a BC break because our extension class won't pass an `instanceof` check for the deprecated class anymore, but I believe that this is acceptable.