### PR TITLE
Add 'prompt' parameter for Azure

### DIFF
--- a/src/OAuth/ResourceOwner/AzureResourceOwner.php
+++ b/src/OAuth/ResourceOwner/AzureResourceOwner.php
@@ -38,8 +38,20 @@ final class AzureResourceOwner extends GenericOAuth2ResourceOwner
      */
     public function configure()
     {
-        $this->options['access_token_url'] = sprintf($this->options['access_token_url'], $this->options['application']);
-        $this->options['authorization_url'] = sprintf($this->options['authorization_url'], $this->options['application']);
+        $this->options['access_token_url'] = \sprintf($this->options['access_token_url'], $this->options['application']);
+        $this->options['authorization_url'] = \sprintf($this->options['authorization_url'], $this->options['application']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAuthorizationUrl($redirectUri, array $extraParameters = [])
+    {
+        $url = parent::getAuthorizationUrl($redirectUri, array_merge([
+            'prompt' => $this->options['prompt'],
+        ], $extraParameters));
+
+        return $url;
     }
 
     /**
@@ -89,6 +101,12 @@ final class AzureResourceOwner extends GenericOAuth2ResourceOwner
             'application' => 'common',
             'api_version' => 'v1.0',
             'csrf' => true,
+            'prompt' => null,
         ]);
+
+        $resolver
+            // @link https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow
+            ->setAllowedValues('prompt', [null, 'login', 'none', 'consent', 'select_account'])
+        ;
     }
 }


### PR DESCRIPTION
The 'prompt' parameter indicates the type of user interaction that is required. Valid values are `login`, `none`, `consent`, and `select_account`.
Without it, the users can't select the account they wish to use, if multiple are logged in.

See here for more info: <https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#request-an-authorization-code>