### PR TITLE
Corrected old path for editing routing

### DIFF
--- a/docs/3-configuring_the_security_layer.md
+++ b/docs/3-configuring_the_security_layer.md
@@ -91,7 +91,7 @@ security:
 The paths configured at the `resource_owners` section should be defined in your routing.
 
 ```yaml
-# app/config/routing.yml
+# config/routes/hwi_oauth_routing.yaml
 facebook_login:
     path: /login/check-facebook
 


### PR DESCRIPTION
The path given here in the docs seems to refer to the old location for editing routing (Symfony 2 and 3). It will direct you to a nonexistent file on Symfony 4+. So I substituted it for the more up-to-date location to add these routes.