### PR TITLE
Fix RefreshAccessTokenListener after Symfony 7.2 decoration

### DIFF
--- a/src/Security/Http/Firewall/RefreshAccessTokenListener.php
+++ b/src/Security/Http/Firewall/RefreshAccessTokenListener.php
@@ -47,6 +47,6 @@ class RefreshAccessTokenListener extends AbstractRefreshAccessTokenListener
             }
         }
 
-        throw new \RuntimeException('Unsupported authenticator, expecting OAuthAuthenticator, got ' . get_debug_type($this->authenticator));
+        throw new \RuntimeException('Unsupported authenticator, expecting OAuthAuthenticator, got ' . get_class($this->authenticator));
     }
 }

--- a/src/Security/Http/Firewall/RefreshAccessTokenListener.php
+++ b/src/Security/Http/Firewall/RefreshAccessTokenListener.php
@@ -13,15 +13,17 @@ namespace HWI\Bundle\OAuthBundle\Security\Http\Firewall;
 
 use HWI\Bundle\OAuthBundle\Security\Core\Authentication\Token\OAuthToken;
 use HWI\Bundle\OAuthBundle\Security\Http\Authenticator\OAuthAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
 
 class RefreshAccessTokenListener extends AbstractRefreshAccessTokenListener
 {
-    private OAuthAuthenticator $oAuthAuthenticator;
+    private AuthenticatorInterface $authenticator;
 
     public function __construct(
-        OAuthAuthenticator $oAuthAuthenticator
+        AuthenticatorInterface $authenticator
     ) {
-        $this->oAuthAuthenticator = $oAuthAuthenticator;
+        $this->authenticator = $authenticator;
     }
 
     /**
@@ -33,6 +35,18 @@ class RefreshAccessTokenListener extends AbstractRefreshAccessTokenListener
      */
     protected function refreshToken(OAuthToken $token): OAuthToken
     {
-        return $this->oAuthAuthenticator->refreshToken($token);
+        if ($this->authenticator instanceof OAuthAuthenticator) {
+            return $this->authenticator->refreshToken($token);
+        }
+        
+        if ($this->authenticator instanceof TraceableAuthenticator) {
+            $authenticator = $this->authenticator->getAuthenticator();
+            
+            if ($authenticator instanceof OAuthAuthenticator) {
+                return $authenticator->refreshToken($token);
+            }
+        }
+
+        throw new \RuntimeException('Unsupported authenticator, expecting OAuthAuthenticator, got ' . get_debug_type($this->authenticator));
     }
 }


### PR DESCRIPTION
This is a re-do of #2020, with a workaround to avoid PHPStan errors, which was in fast highlighting a possible failure case.