### PR TITLE
Add option "show_dialog" for Spotify resource owner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: phpunit-logs-php${{ matrix.php }}
           path: build/logs/phpunit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,11 +87,15 @@ jobs:
           - php: '8.2'
             symfony-version: '^6.4'
           - php: '8.2'
-            symfony-version: '^7.1'
+            symfony-version: '^7.2'
           - php: '8.3'
             symfony-version: '^6.4'
           - php: '8.3'
-            symfony-version: '^7.1'
+            symfony-version: '^7.2'
+          - php: '8.4'
+            symfony-version: '^6.4'
+          - php: '8.4'
+            symfony-version: '^7.2'
       fail-fast: false
 
     steps:

--- a/docs/resource_owners/spotify.md
+++ b/docs/resource_owners/spotify.md
@@ -17,6 +17,21 @@ hwi_oauth:
             client_secret:       <client_secret>
 ```
 
+Optionally you can force the user to approve the app again if they've already done so with the [`show_dialog`](https://developer.spotify.com/documentation/web-api/tutorials/code-flow) option:
+
+```yaml
+# config/packages/hwi_oauth.yaml
+
+hwi_oauth:
+    resource_owners:
+        any_name:
+            type:                spotify
+            client_id:           <client_id>
+            client_secret:       <client_secret>
+            options:
+                show_dialog:     true # Can be false or true
+```
+
 When you're done. Continue by configuring the security layer or go back to
 setup more resource owners.
 

--- a/src/OAuth/ResourceOwner/SpotifyResourceOwner.php
+++ b/src/OAuth/ResourceOwner/SpotifyResourceOwner.php
@@ -35,6 +35,11 @@ final class SpotifyResourceOwner extends GenericOAuth2ResourceOwner
         'profilepicture' => 'images.0.url',
     ];
 
+    public function getAuthorizationUrl($redirectUri, array $extraParameters = [])
+    {
+        return parent::getAuthorizationUrl($redirectUri, array_merge(['show_dialog' => $this->options['show_dialog']], $extraParameters));
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -69,6 +74,10 @@ final class SpotifyResourceOwner extends GenericOAuth2ResourceOwner
             'authorization_url' => 'https://accounts.spotify.com/authorize',
             'access_token_url' => 'https://accounts.spotify.com/api/token',
             'infos_url' => 'https://api.spotify.com/v1/me',
+            'show_dialog' => null,
         ]);
+
+        // @link https://developer.spotify.com/documentation/web-api/tutorials/code-flow
+        $resolver->setAllowedValues('show_dialog', ['true', 'false', null]);
     }
 }

--- a/tests/OAuth/ResourceOwner/SpotifyResourceOwnerTest.php
+++ b/tests/OAuth/ResourceOwner/SpotifyResourceOwnerTest.php
@@ -105,4 +105,34 @@ json;
         $this->assertNull($userResponse->getRefreshToken());
         $this->assertNull($userResponse->getExpiresIn());
     }
+
+    public function testGetAuthorizationUrl(): void
+    {
+        $resourceOwner = $this->createResourceOwner();
+
+        $this->assertEquals(
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F',
+            $resourceOwner->getAuthorizationUrl('http://redirect.to/')
+        );
+    }
+
+    public function testGetAuthorizationUrlWithDialog(): void
+    {
+        $resourceOwner = $this->createResourceOwner(['show_dialog' => 'true']);
+
+        $this->assertEquals(
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&show_dialog=true',
+            $resourceOwner->getAuthorizationUrl('http://redirect.to/')
+        );
+    }
+
+    public function testGetAuthorizationUrlWithoutDialog(): void
+    {
+        $resourceOwner = $this->createResourceOwner(['show_dialog' => 'false']);
+
+        $this->assertEquals(
+            $this->options['authorization_url'].'&response_type=code&client_id=clientid&state=eyJzdGF0ZSI6InJhbmRvbSJ9&redirect_uri=http%3A%2F%2Fredirect.to%2F&show_dialog=false',
+            $resourceOwner->getAuthorizationUrl('http://redirect.to/')
+        );
+    }
 }


### PR DESCRIPTION
Allow to set the optional "show_dialog" option for the Spotify resource owner: https://developer.spotify.com/documentation/web-api/tutorials/code-flow.

```
Whether or not to force the user to approve the app again if they’ve already done so. If false (default), a user who has already approved the application may be automatically redirected to the URI specified by redirect_uri. If true, the user will not be automatically redirected and will have to approve the app again.
```