### PR TITLE
Use CSPRNG for generating nonce

### DIFF
--- a/src/Security/Helper/NonceGenerator.php
+++ b/src/Security/Helper/NonceGenerator.php
@@ -19,6 +19,6 @@ final class NonceGenerator
 
     public static function generate(): string
     {
-        return md5(microtime(true).uniqid('', true));
+        return bin2hex(random_bytes(16));
     }
 }


### PR DESCRIPTION
The current nonce generator is time based and predictable, use the PHP builtin cryptographically secure random byte generator instead.