### PR TITLE
Fixed wrong HTTP status code in `RegisterController`

### DIFF
--- a/src/Controller/Connect/RegisterController.php
+++ b/src/Controller/Connect/RegisterController.php
@@ -169,10 +169,13 @@ final class RegisterController extends AbstractController
             return $response;
         }
 
-        return new Response($this->twig->render('@HWIOAuth/Connect/registration.html.twig', [
-            'key' => $key,
-            'form' => $form->createView(),
-            'userInformation' => $userInformation,
-        ]));
+        return new Response(
+            $this->twig->render('@HWIOAuth/Connect/registration.html.twig', [
+                'key' => $key,
+                'form' => $form->createView(),
+                'userInformation' => $userInformation,
+            ]),
+            $form->isSubmitted() ? 422 : 200
+        );
     }
 }


### PR DESCRIPTION
When using i.e., Turbo, it will cache the response when returning `200`; here, the form can be invalid, and we should return that as a proper HTTP status code in the response.

Ref: https://symfony.com/bundles/ux-turbo/current/index.html#3-form-response-code-changes