### PR TITLE
Fixed a double credentials error

### DIFF
--- a/src/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
+++ b/src/OAuth/ResourceOwner/GenericOAuth2ResourceOwner.php
@@ -189,10 +189,12 @@ abstract class GenericOAuth2ResourceOwner extends AbstractResourceOwner
         if ($this->options['use_authorization_to_get_token']) {
             if ($this->options['client_secret']) {
                 $headers['Authorization'] = 'Basic '.base64_encode($this->options['client_id'].':'.$this->options['client_secret']);
+
+                unset($parameters['client_id'], $parameters['client_secret']);
             }
         } else {
-            $parameters['client_id'] = $this->options['client_id'];
-            $parameters['client_secret'] = $this->options['client_secret'];
+            $parameters['client_id'] = $parameters['client_id'] ?? $this->options['client_id'];
+            $parameters['client_secret'] = $parameters['client_secret'] ?? $this->options['client_secret'];
         }
 
         return $this->httpRequest($url, http_build_query($parameters, '', '&'), $headers);


### PR DESCRIPTION
When the "use_authorization_to_get_token" option is on (which it by default is), credentials are sent twice if they are also present in the parameters.

In my case (HelloID), it results in a server error about sending credentials twice.

Additionally, client ID and secret are always overwritten in the parameters if this option is turned off, even in cases where the secret is generated and already added to the parameters (for example in `AppleResourceOwner` and `InstagramResourceOwner`).