### PR TITLE
Fix issue if user ID is a Ulid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+## 2.5.1
+* Bugfix: Prevent error in `EntityUserProvider::refreshUser` when `$userId` is a `Ulid`
+
 ## 2.5.0 (2026-02-19)
 * Added: PHP 8.5 test coverage,
 * Added: Support for Symfony 8.0,

--- a/src/Security/Core/User/EntityUserProvider.php
+++ b/src/Security/Core/User/EntityUserProvider.php
@@ -94,7 +94,7 @@ final class EntityUserProvider implements UserProviderInterface, OAuthAwareUserP
         $username = $user->getUserIdentifier();
 
         if (null === $user = $this->findUser([$identifier => $userId])) {
-            throw $this->createUserNotFoundException($username, \sprintf('User with ID "%d" could not be reloaded.', $userId));
+            throw $this->createUserNotFoundException($username, \sprintf('User with ID "%s" could not be reloaded.', $userId));
         }
 
         return $user;

--- a/tests/Fixtures/StringIDUser.php
+++ b/tests/Fixtures/StringIDUser.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the HWIOAuthBundle package.
+ *
+ * (c) Hardware Info <opensource@hardware.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HWI\Bundle\OAuthBundle\Tests\Fixtures;
+
+use Deprecated;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class StringIDUser implements UserInterface
+{
+    public function getId(): string
+    {
+        return '6f5f78b2-005d-4eea-96c4-79044aaebb34';
+    }
+
+    public function getRoles(): array
+    {
+        return [];
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return 'abc';
+    }
+
+    #[Deprecated]
+    public function eraseCredentials(): void
+    {
+    }
+}


### PR DESCRIPTION
I've noticed an issue in my application, where upon failing to refresh the user an error is thrown. Digging into it it appears to be the combination of `framework.php_errors.throw: true` (treat warnings as errors) and the conversion of a `Ulid` to `int`.

This simply changes the format string to allow `Ulid::__toString`  to be used.